### PR TITLE
[NSDB-1] Separation of concerns

### DIFF
--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
@@ -58,8 +58,8 @@ class MetricsDataActorSpec()
     import scala.concurrent.duration._
     implicit val timeout: Timeout = 10 second
 
-    Await.result(metricsDataActor ? DeleteNamespace(db, namespace), 3 seconds)
-    Await.result(metricsDataActor ? DeleteNamespace(db, namespace1), 3 seconds)
+    Await.result(metricsDataActor ? DeleteNamespace(db, namespace), 10 seconds)
+    Await.result(metricsDataActor ? DeleteNamespace(db, namespace1), 10 seconds)
   }
 
   "metricsDataActor" should "write and delete properly" in within(5.seconds) {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
@@ -33,7 +33,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class MetricsDataActorSpec()
-    extends TestKit(ActorSystem("namespaceActorSpec"))
+    extends TestKit(ActorSystem("metricsDataActorSpec"))
     with ImplicitSender
     with FlatSpecLike
     with Matchers
@@ -41,13 +41,13 @@ class MetricsDataActorSpec()
 
   val probe            = TestProbe()
   val probeActor       = probe.ref
-  val basePath         = "target/test_index/NamespaceActorSpec"
+  val basePath         = "target/test_index/metricsDataActorSpec"
   val db               = "db"
   val namespace        = "namespace"
   val namespace1       = "namespace1"
   val metricsDataActor = system.actorOf(MetricsDataActor.props(basePath))
 
-  private val metric = "namespaceActorMetric"
+  private val metric = "metricsDataActorMetric"
 
   val location = Location(_: String, "testNode", 0, 0)
 
@@ -68,40 +68,35 @@ class MetricsDataActorSpec()
 
     probe.send(metricsDataActor, AddRecordToLocation(db, namespace, record, location(metric)))
 
-    awaitAssert {
-      val expectedAdd = probe.expectMsgType[RecordAdded]
-      expectedAdd.metric shouldBe metric
-      expectedAdd.record shouldBe record
+    val expectedAdd = awaitAssert {
+      probe.expectMsgType[RecordAdded]
     }
+    expectedAdd.metric shouldBe metric
+    expectedAdd.record shouldBe record
 
     expectNoMessage(interval)
 
     probe.send(metricsDataActor, GetCount(db, namespace, metric))
 
-    awaitAssert {
-      val expectedCount = probe.expectMsgType[CountGot]
-      expectedCount.metric shouldBe metric
-      expectedCount.count shouldBe 1
+    val expectedCount = awaitAssert {
+      probe.expectMsgType[CountGot]
     }
+    expectedCount.metric shouldBe metric
+    expectedCount.count shouldBe 1
 
     probe.send(metricsDataActor, DeleteRecordFromLocation(db, namespace, record, location(metric)))
 
-    awaitAssert {
-      val expectedDelete = probe.expectMsgType[RecordDeleted]
-      expectedDelete.metric shouldBe metric
-      expectedDelete.record shouldBe record
-    }
+    val expectedDelete = awaitAssert { probe.expectMsgType[RecordDeleted] }
+    expectedDelete.metric shouldBe metric
+    expectedDelete.record shouldBe record
 
     expectNoMessage(interval)
 
     probe.send(metricsDataActor, GetCount(db, namespace, metric))
 
-    awaitAssert {
-      val expectedCountDeleted = probe.expectMsgType[CountGot]
-      expectedCountDeleted.metric shouldBe metric
-      expectedCountDeleted.count shouldBe 0
-    }
-
+    val expectedCountDeleted = awaitAssert { probe.expectMsgType[CountGot] }
+    expectedCountDeleted.metric shouldBe metric
+    expectedCountDeleted.count shouldBe 0
   }
 
   "metricsDataActor" should "write and delete properly in multiple namespaces" in within(5.seconds) {
@@ -109,25 +104,28 @@ class MetricsDataActorSpec()
     val record = Bit(System.currentTimeMillis, 24, Map("content" -> s"content"))
 
     probe.send(metricsDataActor, AddRecordToLocation(db, namespace1, record, location(metric + "2")))
-    probe.expectMsgType[RecordAdded]
+
+    awaitAssert {
+      probe.expectMsgType[RecordAdded]
+    }
 
     expectNoMessage(interval)
 
     probe.send(metricsDataActor, GetCount(db, namespace, metric))
 
-    awaitAssert {
-      val expectedCount = probe.expectMsgType[CountGot]
-      expectedCount.metric shouldBe metric
-      expectedCount.count shouldBe 0
+    val expectedCount = awaitAssert {
+      probe.expectMsgType[CountGot]
     }
+    expectedCount.metric shouldBe metric
+    expectedCount.count shouldBe 0
 
     probe.send(metricsDataActor, GetCount(db, namespace1, metric + "2"))
 
-    awaitAssert {
-      val expectedCount2 = probe.expectMsgType[CountGot]
-      expectedCount2.metric shouldBe metric + "2"
-      expectedCount2.count shouldBe 1
+    val expectedCount2 = awaitAssert {
+      probe.expectMsgType[CountGot]
     }
+    expectedCount2.metric shouldBe metric + "2"
+    expectedCount2.count shouldBe 1
 
   }
 
@@ -136,16 +134,20 @@ class MetricsDataActorSpec()
     val record = Bit(System.currentTimeMillis, 23, Map("content" -> s"content"))
 
     probe.send(metricsDataActor, AddRecordToLocation(db, namespace1, record, location(metric + "2")))
-    probe.expectMsgType[RecordAdded]
+
+    awaitAssert {
+      probe.expectMsgType[RecordAdded]
+    }
 
     expectNoMessage(interval)
 
     probe.send(metricsDataActor, GetCount(db, namespace1, metric + "2"))
-    awaitAssert {
-      val expectedCount2 = probe.expectMsgType[CountGot]
-      expectedCount2.metric shouldBe metric + "2"
-      expectedCount2.count shouldBe 1
+
+    val expectedCount2 = awaitAssert {
+      probe.expectMsgType[CountGot]
     }
+    expectedCount2.metric shouldBe metric + "2"
+    expectedCount2.count shouldBe 1
 
     probe.send(metricsDataActor, DeleteNamespace(db, namespace1))
     awaitAssert {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
@@ -62,7 +62,7 @@ class MetricsDataActorSpec()
     Await.result(metricsDataActor ? DeleteNamespace(db, namespace1), 3 seconds)
   }
 
-  "namespaceActor" should "write and delete properly" in within(5.seconds) {
+  "metricsDataActor" should "write and delete properly" in within(5.seconds) {
 
     val record = Bit(System.currentTimeMillis, 0.5, Map("content" -> s"content"))
 
@@ -104,7 +104,7 @@ class MetricsDataActorSpec()
 
   }
 
-  "namespaceActor" should "write and delete properly in multiple namespaces" in within(5.seconds) {
+  "metricsDataActor" should "write and delete properly in multiple namespaces" in within(5.seconds) {
 
     val record = Bit(System.currentTimeMillis, 24, Map("content" -> s"content"))
 
@@ -131,7 +131,7 @@ class MetricsDataActorSpec()
 
   }
 
-  "namespaceActor" should "delete a namespace" in within(5.seconds) {
+  "metricsDataActor" should "delete a namespace" in within(5.seconds) {
 
     val record = Bit(System.currentTimeMillis, 23, Map("content" -> s"content"))
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/NamespaceSchemaActorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/NamespaceSchemaActorSpec.scala
@@ -50,11 +50,11 @@ class NamespaceSchemaActorSpec
   val surnameRecord = Bit(0, 1, Map("surname" -> "surname"))
 
   before {
-    implicit val timeout = Timeout(3 seconds)
-    Await.result(namespaceSchemaActor ? DeleteNamespace(db, namespace), 3 seconds)
-    Await.result(namespaceSchemaActor ? DeleteNamespace(db, namespace1), 3 seconds)
-    Await.result(namespaceSchemaActor ? UpdateSchemaFromRecord(db, namespace, "people", nameRecord), 3 seconds)
-    Await.result(namespaceSchemaActor ? UpdateSchemaFromRecord(db, namespace1, "people", surnameRecord), 3 seconds)
+    implicit val timeout = Timeout(10 seconds)
+    Await.result(namespaceSchemaActor ? DeleteNamespace(db, namespace), 10 seconds)
+    Await.result(namespaceSchemaActor ? DeleteNamespace(db, namespace1), 10 seconds)
+    Await.result(namespaceSchemaActor ? UpdateSchemaFromRecord(db, namespace, "people", nameRecord), 10 seconds)
+    Await.result(namespaceSchemaActor ? UpdateSchemaFromRecord(db, namespace1, "people", surnameRecord), 10 seconds)
   }
 
   "SchemaActor" should "get schemas from different namespaces" in {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorBehaviour.scala
@@ -100,10 +100,8 @@ trait ReadCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers =
         "return it properly" in within(5.seconds) {
           probe.send(readCoordinatorActor, GetDbs)
 
-          awaitAssert {
-            val expected = probe.expectMsgType[DbsGot]
-            expected.dbs shouldBe Set(db)
-          }
+          val expected = probe.expectMsgType[DbsGot]
+          expected.dbs shouldBe Set(db)
 
         }
       }
@@ -112,10 +110,8 @@ trait ReadCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers =
         "return it properly" in within(5.seconds) {
           probe.send(readCoordinatorActor, GetNamespaces(db))
 
-          awaitAssert {
-            val expected = probe.expectMsgType[NamespacesGot]
-            expected.namespaces shouldBe Set(namespace)
-          }
+          val expected = probe.expectMsgType[NamespacesGot]
+          expected.namespaces shouldBe Set(namespace)
 
         }
       }
@@ -124,11 +120,11 @@ trait ReadCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers =
         "return it properly" in within(5.seconds) {
           probe.send(readCoordinatorActor, GetMetrics(db, namespace))
 
-          awaitAssert {
-            val expected = probe.expectMsgType[MetricsGot]
-            expected.namespace shouldBe namespace
-            expected.metrics shouldBe Set(LongMetric.name, DoubleMetric.name, AggregationMetric.name)
-          }
+          val expected = probe.expectMsgType[MetricsGot]
+
+          expected.namespace shouldBe namespace
+          expected.metrics shouldBe Set(LongMetric.name, DoubleMetric.name, AggregationMetric.name)
+
         }
       }
 
@@ -185,15 +181,15 @@ trait ReadCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers =
               )
             )
           )
-          awaitAssert {
-            val expected = probe.expectMsgType[SelectStatementExecuted]
-            val names    = expected.values.flatMap(_.dimensions.values.map(_.asInstanceOf[String]))
-            names.contains("Bill") shouldBe true
-            names.contains("Frank") shouldBe true
-            names.contains("Frankie") shouldBe true
-            names.contains("John") shouldBe true
-            names.size shouldBe 4
+          val expected = awaitAssert {
+            probe.expectMsgType[SelectStatementExecuted]
           }
+          val names = expected.values.flatMap(_.dimensions.values.map(_.asInstanceOf[String]))
+          names.contains("Bill") shouldBe true
+          names.contains("Frank") shouldBe true
+          names.contains("Frankie") shouldBe true
+          names.contains("John") shouldBe true
+          names.size shouldBe 4
         }
         "execute successfully with limit over distinct values" in within(5.seconds) {
           probe.send(
@@ -209,11 +205,11 @@ trait ReadCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers =
               )
             )
           )
-          awaitAssert {
-            val expected = probe.expectMsgType[SelectStatementExecuted]
-            val names    = expected.values.flatMap(_.dimensions.values.map(_.asInstanceOf[String]))
-            names.size shouldBe 2
+          val expected = awaitAssert {
+            probe.expectMsgType[SelectStatementExecuted]
           }
+          val names = expected.values.flatMap(_.dimensions.values.map(_.asInstanceOf[String]))
+          names.size shouldBe 2
         }
 
         "execute successfully with ascending order" in within(5.seconds) {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorShardSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorShardSpec.scala
@@ -61,49 +61,50 @@ class ReadCoordinatorShardSpec
     import scala.concurrent.duration._
     implicit val timeout = Timeout(5 second)
 
-    Await.result(readCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "node1"), 3 seconds)
+    Await.result(readCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "node1"), 10 seconds)
 
     val location1 = Location(_: String, "node1", 0, 5)
     val location2 = Location(_: String, "node1", 6, 10)
 
     //long metric
-    Await.result(metricsDataActor ? DropMetric(db, namespace, LongMetric.name), 3 seconds)
+    Await.result(metricsDataActor ? DropMetric(db, namespace, LongMetric.name), 10 seconds)
 
     Await.result(schemaActor ? UpdateSchemaFromRecord(db, namespace, LongMetric.name, LongMetric.testRecords.head),
-                 3 seconds)
+                 10 seconds)
 
     LongMetric.recordsShard1.foreach(r =>
-      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location1(LongMetric.name)), 3 seconds))
+      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location1(LongMetric.name)), 10 seconds))
     LongMetric.recordsShard2.foreach(r =>
-      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location2(LongMetric.name)), 3 seconds))
+      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location2(LongMetric.name)), 10 seconds))
 
     //double metric
-    Await.result(metricsDataActor ? DropMetric(db, namespace, DoubleMetric.name), 3 seconds)
+    Await.result(metricsDataActor ? DropMetric(db, namespace, DoubleMetric.name), 10 seconds)
 
     Await.result(schemaActor ? UpdateSchemaFromRecord(db, namespace, DoubleMetric.name, DoubleMetric.testRecords.head),
-                 3 seconds)
+                 10 seconds)
 
     DoubleMetric.recordsShard1.foreach(r =>
-      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location1(DoubleMetric.name)), 3 seconds))
+      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location1(DoubleMetric.name)), 10 seconds))
     DoubleMetric.recordsShard2.foreach(r =>
-      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location2(DoubleMetric.name)), 3 seconds))
+      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location2(DoubleMetric.name)), 10 seconds))
 
     //aggregation metric
-    Await.result(metricsDataActor ? DropMetric(db, namespace, AggregationMetric.name), 3 seconds)
+    Await.result(metricsDataActor ? DropMetric(db, namespace, AggregationMetric.name), 10 seconds)
 
     Await.result(
       schemaActor ? UpdateSchemaFromRecord(db, namespace, AggregationMetric.name, AggregationMetric.testRecords.head),
-      3 seconds)
+      10 seconds)
 
     AggregationMetric.recordsShard1.foreach(
       r =>
         Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location1(AggregationMetric.name)),
-                     3 seconds))
+                     10 seconds))
     AggregationMetric.recordsShard2.foreach(
       r =>
         Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location2(AggregationMetric.name)),
-                     3 seconds))
+                     10 seconds))
 
+    expectNoMessage(interval)
     expectNoMessage(interval)
   }
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSpec.scala
@@ -53,36 +53,37 @@ class ReadCoordinatorSpec
 
     val location = Location(_: String, "testNode", 0, 0)
 
-    Await.result(readCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "testNode"), 3 seconds)
+    Await.result(readCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "testNode"), 10 seconds)
 
     //long metric
-    Await.result(metricsDataActor ? DropMetric(db, namespace, LongMetric.name), 3 seconds)
+    Await.result(metricsDataActor ? DropMetric(db, namespace, LongMetric.name), 10 seconds)
     Await.result(schemaActor ? UpdateSchemaFromRecord(db, namespace, LongMetric.name, LongMetric.testRecords.head),
-                 3 seconds)
+                 10 seconds)
 
     LongMetric.testRecords.foreach { record =>
-      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, record, location(LongMetric.name)), 3 seconds)
+      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, record, location(LongMetric.name)),
+                   10 seconds)
     }
 
     //double metric
-    Await.result(metricsDataActor ? DropMetric(db, namespace, DoubleMetric.name), 3 seconds)
+    Await.result(metricsDataActor ? DropMetric(db, namespace, DoubleMetric.name), 10 seconds)
     Await.result(schemaActor ? UpdateSchemaFromRecord(db, namespace, DoubleMetric.name, DoubleMetric.testRecords.head),
-                 3 seconds)
+                 10 seconds)
 
     DoubleMetric.testRecords.foreach { record =>
       Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, record, location(DoubleMetric.name)),
-                   3 seconds)
+                   10 seconds)
     }
 
     //aggregation metric
-    Await.result(metricsDataActor ? DropMetric(db, namespace, AggregationMetric.name), 3 seconds)
+    Await.result(metricsDataActor ? DropMetric(db, namespace, AggregationMetric.name), 10 seconds)
     Await.result(
       schemaActor ? UpdateSchemaFromRecord(db, namespace, AggregationMetric.name, AggregationMetric.testRecords.head),
-      3 seconds)
+      10 seconds)
 
     AggregationMetric.testRecords.foreach { record =>
       Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, record, location(AggregationMetric.name)),
-                   3 seconds)
+                   10 seconds)
     }
 
     expectNoMessage(interval)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -113,20 +113,26 @@ trait WriteCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers 
 
       probe.send(writeCoordinatorActor, MapInput(System.currentTimeMillis, db, namespace, "testMetric", record1))
 
-      val expectedAdd = probe.expectMsgType[InputMapped]
+      val expectedAdd = awaitAssert {
+        probe.expectMsgType[InputMapped]
+      }
       expectedAdd.metric shouldBe "testMetric"
       expectedAdd.record shouldBe record1
 
       probe.send(writeCoordinatorActor, MapInput(System.currentTimeMillis, db, namespace, "testMetric", record2))
 
-      val expectedAdd2 = probe.expectMsgType[InputMapped]
+      val expectedAdd2 = awaitAssert {
+        probe.expectMsgType[InputMapped]
+      }
       expectedAdd2.metric shouldBe "testMetric"
       expectedAdd2.record shouldBe record2
 
       probe.send(writeCoordinatorActor,
                  MapInput(System.currentTimeMillis, db, namespace, "testMetric", incompatibleRecord))
 
-      probe.expectMsgType[RecordRejected]
+      awaitAssert {
+        probe.expectMsgType[RecordRejected]
+      }
 
     }
 
@@ -153,13 +159,14 @@ trait WriteCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers 
       probe.send(writeCoordinatorActor,
                  MapInput(System.currentTimeMillis, db, namespace, "testMetric", testRecordSatisfy))
 
-      awaitAssert {
-        val expectedAdd = probe.expectMsgType[InputMapped]
-        expectedAdd.metric shouldBe "testMetric"
-        expectedAdd.record shouldBe testRecordSatisfy
-
-        subscriber.underlyingActor.receivedMessages shouldBe 1
+      val expectedAdd = awaitAssert {
+        probe.expectMsgType[InputMapped]
       }
+      expectedAdd.metric shouldBe "testMetric"
+      expectedAdd.record shouldBe testRecordSatisfy
+
+      subscriber.underlyingActor.receivedMessages shouldBe 1
+
       expectNoMessage(interval)
     }
 
@@ -168,10 +175,20 @@ trait WriteCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers 
 
       awaitAssert {
         probe.expectMsgType[NamespaceDeleted]
-
-        namespaceSchemaActor.underlyingActor.schemaActors.keys.size shouldBe 0
-        metricsDataActor.underlyingActor.context.children.size shouldBe 0
       }
+
+      Thread.sleep(2000)
+
+      namespaceSchemaActor.underlyingActor.schemaActors.keys.size shouldBe 0
+      metricsDataActor.underlyingActor.context.children.size shouldBe 0
+
+      probe.send(metricsDataActor, GetNamespaces(db))
+
+      val result = awaitAssert {
+        probe.expectMsgType[NamespacesGot]
+      }
+
+      result.namespaces.size shouldBe 0
     }
 
     "delete entries" in within(5.seconds) {
@@ -225,9 +242,8 @@ trait WriteCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers 
       probe.expectMsgType[SchemaGot].schema.isDefined shouldBe true
 
       probe.send(metricsDataActor, GetCount(db, namespace, "testMetric"))
-      awaitAssert {
-        probe.expectMsgType[CountGot].count shouldBe 2
-      }
+
+      probe.expectMsgType[CountGot].count shouldBe 2
 
       probe.send(writeCoordinatorActor, DropMetric(db, namespace, "testMetric"))
       awaitAssert {
@@ -237,9 +253,10 @@ trait WriteCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers 
       expectNoMessage(interval)
 
       probe.send(metricsDataActor, GetCount(db, namespace, "testMetric"))
-      awaitAssert {
-        probe.expectMsgType[CountGot].count shouldBe 0
+      val result = awaitAssert {
+        probe.expectMsgType[CountGot]
       }
+      result.count shouldBe 0
 
       probe.send(namespaceSchemaActor, GetSchema(db, namespace, "testMetric"))
       probe.expectMsgType[SchemaGot].schema.isDefined shouldBe false

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -170,7 +170,7 @@ trait WriteCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers 
         probe.expectMsgType[NamespaceDeleted]
 
         namespaceSchemaActor.underlyingActor.schemaActors.keys.size shouldBe 0
-        metricsDataActor.underlyingActor.childActors.keys.size shouldBe 0
+        metricsDataActor.underlyingActor.context.children.size shouldBe 0
       }
     }
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorShardSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorShardSpec.scala
@@ -48,12 +48,12 @@ class WriteCoordinatorShardSpec
   val db        = "writeCoordinatorSpecShardDB"
   val namespace = "namespace"
 
-  implicit val timeout = Timeout(3 seconds)
+  implicit val timeout = Timeout(10 seconds)
 
   override def beforeAll: Unit = {
-    Await.result(writeCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "node1"), 3 seconds)
-    Await.result(writeCoordinatorActor ? DeleteNamespace(db, namespace), 3 seconds)
-    Await.result(namespaceSchemaActor ? UpdateSchemaFromRecord(db, namespace, "testMetric", record1), 3 seconds)
+    Await.result(writeCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "node1"), 10 seconds)
+    Await.result(writeCoordinatorActor ? DeleteNamespace(db, namespace), 10 seconds)
+    Await.result(namespaceSchemaActor ? UpdateSchemaFromRecord(db, namespace, "testMetric", record1), 10 seconds)
   }
 
   "WriteCoordinator in shard mode" should behave.like(defaultBehaviour)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
@@ -53,12 +53,12 @@ class WriteCoordinatorSpec
   import akka.pattern.ask
 
   import scala.concurrent.duration._
-  implicit val timeout = Timeout(3 seconds)
+  implicit val timeout = Timeout(10 seconds)
 
   override def beforeAll {
-    Await.result(writeCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "node1"), 3 seconds)
-    Await.result(writeCoordinatorActor ? DeleteNamespace(db, namespace), 3 seconds)
-    Await.result(namespaceSchemaActor ? UpdateSchemaFromRecord(db, namespace, "testMetric", record1), 3 seconds)
+    Await.result(writeCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "node1"), 10 seconds)
+    Await.result(writeCoordinatorActor ? DeleteNamespace(db, namespace), 10 seconds)
+//    Await.result(namespaceSchemaActor ? UpdateSchemaFromRecord(db, namespace, "testMetric", record1), 10 seconds)
   }
 
   "WriteCoordinator" should behave.like(defaultBehaviour)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardAccumulatorActor.scala
@@ -52,11 +52,6 @@ class ShardAccumulatorActor(val basePath: String, val db: String, val namespace:
 
   private val statementParser = new StatementParser()
 
-//  /**
-//    * Materialized configuration key. true if sharding is enabled.
-//    */
-//  lazy val sharding: Boolean = context.system.settings.config.getBoolean("nsdb.sharding.enabled")
-
   implicit val dispatcher: ExecutionContextExecutor = context.system.dispatcher
 
   /**
@@ -84,12 +79,6 @@ class ShardAccumulatorActor(val basePath: String, val db: String, val namespace:
     */
   private var performingOps: Map[String, ShardOperation] = Map.empty
 
-//  private def handleQueryResults(metric: String, out: Try[Seq[Bit]]) = {
-//    out.recoverWith {
-//      case _: IndexNotFoundException => Success(Seq.empty)
-//    }
-//  }
-
   private def deleteMetricData(metric: String): Unit = {
     val folders = Option(Paths.get(basePath, db, namespace, "shards").toFile.list())
       .map(_.toSeq)
@@ -101,50 +90,10 @@ class ShardAccumulatorActor(val basePath: String, val db: String, val namespace:
     )
   }
 
-//  /**
-//    * Applies, if needed, ordering and limiting to results from multiple shards.
-//    * @param shardResult sequence of shard results.
-//    * @param statement the initial sql statement.
-//    * @param schema metric's schema.
-//    * @return a single result obtained from the manipulation of multiple results from different shards.
-//    */
-//  private def applyOrderingWithLimit(shardResult: Try[Seq[Bit]], statement: SelectSQLStatement, schema: Schema) = {
-//    Try(shardResult.get).map(s => {
-//      val maybeSorted = if (statement.order.isDefined) {
-//        val o = schema.fields.find(_.name == statement.order.get.dimension).get.indexType.ord
-//        implicit val ord: Ordering[JSerializable] =
-//          if (statement.order.get.isInstanceOf[DescOrderOperator]) o.reverse
-//          else o
-//        s.sortBy(_.fields(statement.order.get.dimension))
-//      } else s
-//
-//      if (statement.limit.isDefined) maybeSorted.take(statement.limit.get.value) else maybeSorted
-//    })
-//  }
-
   /**
     * Any existing shard is retrieved, the [[ShardPerformerActor]] is initialized and actual writes are scheduled.
     */
   override def preStart: Unit = {
-//    Option(Paths.get(basePath, db, namespace, "shards").toFile.list())
-//      .map(_.toSet)
-//      .getOrElse(Set.empty)
-//      .filter(_.split("_").length == 3)
-//      .map(_.split("_"))
-//      .foreach {
-//        case Array(metric, from, to) =>
-//          val directory =
-//            new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${metric}_${from}_$to"))
-//          val newIndex = new TimeSeriesIndex(directory)
-//          shards += (ShardKey(metric, from.toLong, to.toLong) -> newIndex)
-//          val directoryFacets =
-//            new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${metric}_${from}_$to", "facet"))
-//          val taxoDirectoryFacets =
-//            new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${metric}_${from}_$to", "facet", "taxo"))
-//          val newFacetIndex = new FacetIndex(directoryFacets, taxoDirectoryFacets)
-//          facetIndexShards += (ShardKey(metric, from.toLong, to.toLong) -> newFacetIndex)
-//      }
-
     performerActor =
       context.actorOf(ShardPerformerActor.props(basePath, db, namespace), s"shard-performer-service-$db-$namespace")
 
@@ -207,192 +156,6 @@ class ShardAccumulatorActor(val basePath: String, val db: String, val namespace:
       readerActor ! msg
       sender() ! MetricDropped(db, namespace, metric)
   }
-
-//  private def filterShardsThroughTime[T](expression: Option[Expression], indexes: mutable.Map[ShardKey, T]) = {
-//    val intervals = TimeRangeExtractor.extractTimeRange(expression)
-//    indexes.filter {
-//      case (key, _) if intervals.nonEmpty =>
-//        intervals
-//          .map(i => Interval.closed(key.from, key.to).intersect(i) != Interval.empty[Long])
-//          .foldLeft(false)((x, y) => x || y)
-//      case _ => true
-//    }.toSeq
-//  }
-
-//  /**
-//    * Groups results coming from different shards according to the group by clause provided in the query.
-//    * @param shardResults results coming from different shards.
-//    * @param dimension the group by clause dimension
-//    * @param aggregationFunction the aggregate function corresponding to the aggregation operator (sum, count ecc.) contained in the query.
-//    * @return the grouped results.
-//    */
-//  private def groupShardResults[W](shardResults: Seq[Try[Seq[Bit]]], dimension: String)(
-//      aggregationFunction: Seq[Bit] => W): Try[Seq[W]] = {
-//    Try(
-//      shardResults
-//        .flatMap(_.get)
-//        .groupBy(_.dimensions(dimension))
-//        .mapValues(aggregationFunction)
-//        .values
-//        .toSeq)
-//  }
-
-//  /**
-//    * Retrieves and order results from different shards in case the statement does not contains aggregations
-//    * and a where condition involving timestamp has been provided.
-//    * @param statement raw statement.
-//    * @param parsedStatement parsed statement.
-//    * @param indexes shard indexes to retrieve data from.
-//    * @param schema metric's schema.
-//    * @return a single sequence of results obtained from different shards.
-//    */
-//  private def retrieveAndorderPlainResults(statement: SelectSQLStatement,
-//                                           parsedStatement: ParsedSimpleQuery,
-//                                           indexes: Seq[(ShardKey, TimeSeriesIndex)],
-//                                           schema: Schema): Try[Seq[Bit]] = {
-//    val (_, metric, q, _, limit, fields, sort) = ParsedSimpleQuery.unapply(parsedStatement).get
-//    if (statement.getTimeOrdering.isDefined || statement.order.isEmpty) {
-//      val result: ListBuffer[Try[Seq[Bit]]] = ListBuffer.empty
-//
-//      val eventuallyOrdered =
-//        statement.getTimeOrdering.map(indexes.sortBy(_._1.from)(_)).getOrElse(indexes)
-//
-//      eventuallyOrdered.takeWhile {
-//        case (_, index) =>
-//          val partials = handleQueryResults(metric, Try(index.query(q, fields, limit, sort)(identity)))
-//          result += partials
-//
-//          val combined = Try(result.flatMap(_.get))
-//
-//          combined.isSuccess && combined.get.lengthCompare(statement.limit.map(_.value).getOrElse(Int.MaxValue)) < 0
-//      }
-//
-//      Try(result.flatMap(_.get))
-//
-//    } else {
-//
-//      val shardResults = indexes.map {
-//        case (_, index) =>
-//          handleQueryResults(metric, Try(index.query(q, fields, limit, sort)(identity)))
-//      }
-//
-//      Try(shardResults.flatMap(_.get)).map(s => {
-//        val o = schema.fields.find(_.name == statement.order.get.dimension).get.indexType.ord
-//        implicit val ord: Ordering[JSerializable] =
-//          if (statement.order.get.isInstanceOf[DescOrderOperator]) o.reverse else o
-//        val sorted = s.sortBy(_.dimensions(statement.order.get.dimension))
-//        sorted.take(statement.limit.get.value)
-//      })
-//
-//    }
-//  }
-
-//  /**
-//    * behaviour for read operations.
-//    *
-//    * - [[GetMetrics]] retrieve and return all the metrics.
-//    *
-//    * - [[ExecuteSelectStatement]] execute a given sql statement.
-//    */
-//  def readOps: Receive = {
-//    case GetMetrics(_, _) =>
-//      sender() ! MetricsGot(db, namespace, shards.keys.map(_.metric).toSet)
-//    case GetCount(_, ns, metric) =>
-//      val hits = shardsForMetric(metric).map {
-//        case (_, index) =>
-//          index.query(new MatchAllDocsQuery(), Seq.empty, Int.MaxValue, None)(identity).size
-//      }.sum
-//      sender ! CountGot(db, ns, metric, hits)
-//    case ExecuteSelectStatement(statement, schema) =>
-//      val postProcessedResult: Try[Seq[Bit]] =
-//        statementParser.parseStatement(statement, schema) match {
-//          case Success(parsedStatement @ ParsedSimpleQuery(_, metric, _, false, limit, fields, _)) =>
-//            val indexes =
-//              if (sharding)
-//                filterShardsThroughTime(statement.condition.map(_.expression), shardsForMetric(statement.metric))
-//              else Seq((ShardKey(metric, 0, 0), getIndex(ShardKey(metric, 0, 0))))
-//
-//            val orderedResults = retrieveAndorderPlainResults(statement, parsedStatement, indexes, schema)
-//
-//            if (fields.lengthCompare(1) == 0 && fields.head.count) {
-//              orderedResults.map(seq => {
-//                val recordCount = seq.map(_.value.asInstanceOf[Int]).sum
-//                val count       = if (recordCount <= limit) recordCount else limit
-//                Seq(Bit(0, count, Map(seq.head.dimensions.head._1 -> count)))
-//              })
-//            } else
-//              orderedResults.map(
-//                s =>
-//                  s.map(
-//                    b =>
-//                      if (b.dimensions.contains("count(*)")) b.copy(dimensions = b.dimensions + ("count(*)" -> s.size))
-//                      else b)
-//              )
-//
-//          case Success(ParsedSimpleQuery(_, metric, q, true, limit, fields, sort)) if fields.lengthCompare(1) == 0 =>
-//            val distinctField = fields.head.name
-//
-//            val filteredIndexes =
-//              filterShardsThroughTime(statement.condition.map(_.expression), facetsShardsFromMetric(statement.metric))
-//
-//            val results = filteredIndexes.map {
-//              case (_, index) =>
-//                handleQueryResults(metric, Try(index.getDistinctField(q, fields.map(_.name).head, sort, limit)))
-//            }
-//
-//            val shardResults = groupShardResults(results, distinctField) { values =>
-//              Bit(0, 0, Map[String, JSerializable]((distinctField, values.head.dimensions(distinctField))))
-//            }
-//
-//            applyOrderingWithLimit(shardResults, statement, schema)
-//
-//          case Success(ParsedAggregatedQuery(_, metric, q, collector: CountAllGroupsCollector[_], sort, limit)) =>
-//            val result = filterShardsThroughTime(statement.condition.map(_.expression),
-//                                                 facetsShardsFromMetric(statement.metric)).map {
-//              case (_, index) =>
-//                handleQueryResults(
-//                  metric,
-//                  Try(index
-//                    .getCount(q, collector.groupField, sort, limit, schema.fieldsMap(collector.groupField).indexType)))
-//            }
-//
-//            val shardResults = groupShardResults(result, statement.groupBy.get) { values =>
-//              Bit(0, values.map(_.value.asInstanceOf[Long]).sum, values.head.dimensions)
-//            }
-//
-//            applyOrderingWithLimit(shardResults, statement, schema)
-//
-//          case Success(ParsedAggregatedQuery(_, metric, q, collector, sort, limit)) =>
-//            val shardResults = shardsForMetric(statement.metric).toSeq.map {
-//              case (_, index) =>
-//                handleQueryResults(metric, Try(index.query(q, collector.clear, limit, sort)))
-//            }
-//            val rawResult =
-//              groupShardResults(shardResults, statement.groupBy.get) { values =>
-//                val v                                        = schema.fields.find(_.name == "value").get.indexType.asInstanceOf[NumericType[_, _]]
-//                implicit val numeric: Numeric[JSerializable] = v.numeric
-//                collector match {
-//                  case _: MaxAllGroupsCollector[_, _] =>
-//                    Bit(0, values.map(_.value).max, values.head.dimensions)
-//                  case _: MinAllGroupsCollector[_, _] =>
-//                    Bit(0, values.map(_.value).min, values.head.dimensions)
-//                  case _: SumAllGroupsCollector[_, _] =>
-//                    Bit(0, values.map(_.value).sum, values.head.dimensions)
-//                }
-//              }
-//
-//            applyOrderingWithLimit(rawResult, statement, schema)
-//
-//          case Failure(ex) => Failure(ex)
-//          case _           => Failure(new InvalidStatementException("Not a select statement."))
-//        }
-//
-//      postProcessedResult match {
-//        case Success(bits)                          => sender() ! SelectStatementExecuted(db, namespace, statement.metric, bits)
-//        case Failure(ex: InvalidStatementException) => sender() ! SelectStatementFailed(ex.message)
-//        case Failure(ex)                            => sender() ! SelectStatementFailed(ex.getMessage)
-//      }
-//  }
 
   /**
     * behaviour for accumulate operations.

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardAccumulatorActor.scala
@@ -184,7 +184,7 @@ class ShardAccumulatorActor(val basePath: String, val db: String, val namespace:
       FileUtils.deleteDirectory(Paths.get(basePath, db, namespace).toFile)
 
       sender ! AllMetricsDeleted(db, ns)
-    case DropMetric(_, _, metric) =>
+    case msg @ DropMetric(_, _, metric) =>
       shardsForMetric(metric).foreach {
         case (key, index) =>
           implicit val writer: IndexWriter = index.getWriter
@@ -204,6 +204,7 @@ class ShardAccumulatorActor(val basePath: String, val db: String, val namespace:
 
       deleteMetricData(metric)
 
+      readerActor ! msg
       sender() ! MetricDropped(db, namespace, metric)
   }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardAccumulatorActor.scala
@@ -16,7 +16,6 @@
 
 package io.radicalbit.nsdb.actors
 
-import java.io.File
 import java.nio.file.Paths
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -25,41 +24,27 @@ import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import akka.util.Timeout
 import io.radicalbit.nsdb.actors.ShardAccumulatorActor.Refresh
 import io.radicalbit.nsdb.actors.ShardPerformerActor.PerformShardWrites
-import io.radicalbit.nsdb.common.JSerializable
-import io.radicalbit.nsdb.common.exception.InvalidStatementException
-import io.radicalbit.nsdb.common.protocol.Bit
-import io.radicalbit.nsdb.common.statement.{DescOrderOperator, Expression, SelectSQLStatement}
-import io.radicalbit.nsdb.index.lucene._
-import io.radicalbit.nsdb.index.{FacetIndex, NumericType, TimeSeriesIndex}
-import io.radicalbit.nsdb.model.Schema
+import io.radicalbit.nsdb.index.{FacetIndex, TimeSeriesIndex}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
+import io.radicalbit.nsdb.statement.StatementParser
 import io.radicalbit.nsdb.statement.StatementParser._
-import io.radicalbit.nsdb.statement.{StatementParser, TimeRangeExtractor}
 import org.apache.commons.io.FileUtils
-import org.apache.lucene.index.{IndexNotFoundException, IndexWriter}
-import org.apache.lucene.search.MatchAllDocsQuery
+import org.apache.lucene.index.IndexWriter
 import org.apache.lucene.store.MMapDirectory
-import spire.implicits._
-import spire.math.Interval
 
-import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 /**
-  * Actor responsible for:
-  *
-  * - Accumulating write and delete operations which will be performed by [[ShardPerformerActor]].
-  *
-  * - Retrieving data from shards, aggregates and returns it to the sender.
+  * Actor responsible for accumulating write and delete operations which will be performed by [[ShardPerformerActor]].
   *
   * @param basePath shards indexes path.
   * @param db shards db.
   * @param namespace shards namespace.
   */
-class ShardAccumulatorActor(val basePath: String, val db: String, val namespace: String)
+class ShardAccumulatorActor(val basePath: String, val db: String, val namespace: String, val readerActor: ActorRef)
     extends Actor
     with ShardsActor
     with ActorLogging {
@@ -67,10 +52,10 @@ class ShardAccumulatorActor(val basePath: String, val db: String, val namespace:
 
   private val statementParser = new StatementParser()
 
-  /**
-    * Materialized configuration key. true if sharding is enabled.
-    */
-  lazy val sharding: Boolean = context.system.settings.config.getBoolean("nsdb.sharding.enabled")
+//  /**
+//    * Materialized configuration key. true if sharding is enabled.
+//    */
+//  lazy val sharding: Boolean = context.system.settings.config.getBoolean("nsdb.sharding.enabled")
 
   implicit val dispatcher: ExecutionContextExecutor = context.system.dispatcher
 
@@ -99,13 +84,13 @@ class ShardAccumulatorActor(val basePath: String, val db: String, val namespace:
     */
   private var performingOps: Map[String, ShardOperation] = Map.empty
 
-  private def handleQueryResults(metric: String, out: Try[Seq[Bit]]) = {
-    out.recoverWith {
-      case _: IndexNotFoundException => Success(Seq.empty)
-    }
-  }
+//  private def handleQueryResults(metric: String, out: Try[Seq[Bit]]) = {
+//    out.recoverWith {
+//      case _: IndexNotFoundException => Success(Seq.empty)
+//    }
+//  }
 
-  private def deleteMetricData(metric: String) = {
+  private def deleteMetricData(metric: String): Unit = {
     val folders = Option(Paths.get(basePath, db, namespace, "shards").toFile.list())
       .map(_.toSeq)
       .getOrElse(Seq.empty)
@@ -116,49 +101,49 @@ class ShardAccumulatorActor(val basePath: String, val db: String, val namespace:
     )
   }
 
-  /**
-    * Applies, if needed, ordering and limiting to results from multiple shards.
-    * @param shardResult sequence of shard results.
-    * @param statement the initial sql statement.
-    * @param schema metric's schema.
-    * @return a single result obtained from the manipulation of multiple results from different shards.
-    */
-  private def applyOrderingWithLimit(shardResult: Try[Seq[Bit]], statement: SelectSQLStatement, schema: Schema) = {
-    Try(shardResult.get).map(s => {
-      val maybeSorted = if (statement.order.isDefined) {
-        val o = schema.fields.find(_.name == statement.order.get.dimension).get.indexType.ord
-        implicit val ord: Ordering[JSerializable] =
-          if (statement.order.get.isInstanceOf[DescOrderOperator]) o.reverse
-          else o
-        s.sortBy(_.fields(statement.order.get.dimension))
-      } else s
-
-      if (statement.limit.isDefined) maybeSorted.take(statement.limit.get.value) else maybeSorted
-    })
-  }
+//  /**
+//    * Applies, if needed, ordering and limiting to results from multiple shards.
+//    * @param shardResult sequence of shard results.
+//    * @param statement the initial sql statement.
+//    * @param schema metric's schema.
+//    * @return a single result obtained from the manipulation of multiple results from different shards.
+//    */
+//  private def applyOrderingWithLimit(shardResult: Try[Seq[Bit]], statement: SelectSQLStatement, schema: Schema) = {
+//    Try(shardResult.get).map(s => {
+//      val maybeSorted = if (statement.order.isDefined) {
+//        val o = schema.fields.find(_.name == statement.order.get.dimension).get.indexType.ord
+//        implicit val ord: Ordering[JSerializable] =
+//          if (statement.order.get.isInstanceOf[DescOrderOperator]) o.reverse
+//          else o
+//        s.sortBy(_.fields(statement.order.get.dimension))
+//      } else s
+//
+//      if (statement.limit.isDefined) maybeSorted.take(statement.limit.get.value) else maybeSorted
+//    })
+//  }
 
   /**
     * Any existing shard is retrieved, the [[ShardPerformerActor]] is initialized and actual writes are scheduled.
     */
   override def preStart: Unit = {
-    Option(Paths.get(basePath, db, namespace, "shards").toFile.list())
-      .map(_.toSet)
-      .getOrElse(Set.empty)
-      .filter(_.split("_").length == 3)
-      .map(_.split("_"))
-      .foreach {
-        case Array(metric, from, to) =>
-          val directory =
-            new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${metric}_${from}_$to"))
-          val newIndex = new TimeSeriesIndex(directory)
-          shards += (ShardKey(metric, from.toLong, to.toLong) -> newIndex)
-          val directoryFacets =
-            new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${metric}_${from}_$to", "facet"))
-          val taxoDirectoryFacets =
-            new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${metric}_${from}_$to", "facet", "taxo"))
-          val newFacetIndex = new FacetIndex(directoryFacets, taxoDirectoryFacets)
-          facetIndexShards += (ShardKey(metric, from.toLong, to.toLong) -> newFacetIndex)
-      }
+//    Option(Paths.get(basePath, db, namespace, "shards").toFile.list())
+//      .map(_.toSet)
+//      .getOrElse(Set.empty)
+//      .filter(_.split("_").length == 3)
+//      .map(_.split("_"))
+//      .foreach {
+//        case Array(metric, from, to) =>
+//          val directory =
+//            new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${metric}_${from}_$to"))
+//          val newIndex = new TimeSeriesIndex(directory)
+//          shards += (ShardKey(metric, from.toLong, to.toLong) -> newIndex)
+//          val directoryFacets =
+//            new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${metric}_${from}_$to", "facet"))
+//          val taxoDirectoryFacets =
+//            new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${metric}_${from}_$to", "facet", "taxo"))
+//          val newFacetIndex = new FacetIndex(directoryFacets, taxoDirectoryFacets)
+//          facetIndexShards += (ShardKey(metric, from.toLong, to.toLong) -> newFacetIndex)
+//      }
 
     performerActor =
       context.actorOf(ShardPerformerActor.props(basePath, db, namespace), s"shard-performer-service-$db-$namespace")
@@ -222,191 +207,191 @@ class ShardAccumulatorActor(val basePath: String, val db: String, val namespace:
       sender() ! MetricDropped(db, namespace, metric)
   }
 
-  private def filterShardsThroughTime[T](expression: Option[Expression], indexes: mutable.Map[ShardKey, T]) = {
-    val intervals = TimeRangeExtractor.extractTimeRange(expression)
-    indexes.filter {
-      case (key, _) if intervals.nonEmpty =>
-        intervals
-          .map(i => Interval.closed(key.from, key.to).intersect(i) != Interval.empty[Long])
-          .foldLeft(false)((x, y) => x || y)
-      case _ => true
-    }.toSeq
-  }
+//  private def filterShardsThroughTime[T](expression: Option[Expression], indexes: mutable.Map[ShardKey, T]) = {
+//    val intervals = TimeRangeExtractor.extractTimeRange(expression)
+//    indexes.filter {
+//      case (key, _) if intervals.nonEmpty =>
+//        intervals
+//          .map(i => Interval.closed(key.from, key.to).intersect(i) != Interval.empty[Long])
+//          .foldLeft(false)((x, y) => x || y)
+//      case _ => true
+//    }.toSeq
+//  }
 
-  /**
-    * Groups results coming from different shards according to the group by clause provided in the query.
-    * @param shardResults results coming from different shards.
-    * @param dimension the group by clause dimension
-    * @param aggregationFunction the aggregate function corresponding to the aggregation operator (sum, count ecc.) contained in the query.
-    * @return the grouped results.
-    */
-  private def groupShardResults[W](shardResults: Seq[Try[Seq[Bit]]], dimension: String)(
-      aggregationFunction: Seq[Bit] => W): Try[Seq[W]] = {
-    Try(
-      shardResults
-        .flatMap(_.get)
-        .groupBy(_.dimensions(dimension))
-        .mapValues(aggregationFunction)
-        .values
-        .toSeq)
-  }
+//  /**
+//    * Groups results coming from different shards according to the group by clause provided in the query.
+//    * @param shardResults results coming from different shards.
+//    * @param dimension the group by clause dimension
+//    * @param aggregationFunction the aggregate function corresponding to the aggregation operator (sum, count ecc.) contained in the query.
+//    * @return the grouped results.
+//    */
+//  private def groupShardResults[W](shardResults: Seq[Try[Seq[Bit]]], dimension: String)(
+//      aggregationFunction: Seq[Bit] => W): Try[Seq[W]] = {
+//    Try(
+//      shardResults
+//        .flatMap(_.get)
+//        .groupBy(_.dimensions(dimension))
+//        .mapValues(aggregationFunction)
+//        .values
+//        .toSeq)
+//  }
 
-  /**
-    * Retrieves and order results from different shards in case the statement does not contains aggregations
-    * and a where condition involving timestamp has been provided.
-    * @param statement raw statement.
-    * @param parsedStatement parsed statement.
-    * @param indexes shard indexes to retrieve data from.
-    * @param schema metric's schema.
-    * @return a single sequence of results obtained from different shards.
-    */
-  private def retrieveAndorderPlainResults(statement: SelectSQLStatement,
-                                           parsedStatement: ParsedSimpleQuery,
-                                           indexes: Seq[(ShardKey, TimeSeriesIndex)],
-                                           schema: Schema): Try[Seq[Bit]] = {
-    val (_, metric, q, _, limit, fields, sort) = ParsedSimpleQuery.unapply(parsedStatement).get
-    if (statement.getTimeOrdering.isDefined || statement.order.isEmpty) {
-      val result: ListBuffer[Try[Seq[Bit]]] = ListBuffer.empty
+//  /**
+//    * Retrieves and order results from different shards in case the statement does not contains aggregations
+//    * and a where condition involving timestamp has been provided.
+//    * @param statement raw statement.
+//    * @param parsedStatement parsed statement.
+//    * @param indexes shard indexes to retrieve data from.
+//    * @param schema metric's schema.
+//    * @return a single sequence of results obtained from different shards.
+//    */
+//  private def retrieveAndorderPlainResults(statement: SelectSQLStatement,
+//                                           parsedStatement: ParsedSimpleQuery,
+//                                           indexes: Seq[(ShardKey, TimeSeriesIndex)],
+//                                           schema: Schema): Try[Seq[Bit]] = {
+//    val (_, metric, q, _, limit, fields, sort) = ParsedSimpleQuery.unapply(parsedStatement).get
+//    if (statement.getTimeOrdering.isDefined || statement.order.isEmpty) {
+//      val result: ListBuffer[Try[Seq[Bit]]] = ListBuffer.empty
+//
+//      val eventuallyOrdered =
+//        statement.getTimeOrdering.map(indexes.sortBy(_._1.from)(_)).getOrElse(indexes)
+//
+//      eventuallyOrdered.takeWhile {
+//        case (_, index) =>
+//          val partials = handleQueryResults(metric, Try(index.query(q, fields, limit, sort)(identity)))
+//          result += partials
+//
+//          val combined = Try(result.flatMap(_.get))
+//
+//          combined.isSuccess && combined.get.lengthCompare(statement.limit.map(_.value).getOrElse(Int.MaxValue)) < 0
+//      }
+//
+//      Try(result.flatMap(_.get))
+//
+//    } else {
+//
+//      val shardResults = indexes.map {
+//        case (_, index) =>
+//          handleQueryResults(metric, Try(index.query(q, fields, limit, sort)(identity)))
+//      }
+//
+//      Try(shardResults.flatMap(_.get)).map(s => {
+//        val o = schema.fields.find(_.name == statement.order.get.dimension).get.indexType.ord
+//        implicit val ord: Ordering[JSerializable] =
+//          if (statement.order.get.isInstanceOf[DescOrderOperator]) o.reverse else o
+//        val sorted = s.sortBy(_.dimensions(statement.order.get.dimension))
+//        sorted.take(statement.limit.get.value)
+//      })
+//
+//    }
+//  }
 
-      val eventuallyOrdered =
-        statement.getTimeOrdering.map(indexes.sortBy(_._1.from)(_)).getOrElse(indexes)
-
-      eventuallyOrdered.takeWhile {
-        case (_, index) =>
-          val partials = handleQueryResults(metric, Try(index.query(q, fields, limit, sort)(identity)))
-          result += partials
-
-          val combined = Try(result.flatMap(_.get))
-
-          combined.isSuccess && combined.get.lengthCompare(statement.limit.map(_.value).getOrElse(Int.MaxValue)) < 0
-      }
-
-      Try(result.flatMap(_.get))
-
-    } else {
-
-      val shardResults = indexes.map {
-        case (_, index) =>
-          handleQueryResults(metric, Try(index.query(q, fields, limit, sort)(identity)))
-      }
-
-      Try(shardResults.flatMap(_.get)).map(s => {
-        val o = schema.fields.find(_.name == statement.order.get.dimension).get.indexType.ord
-        implicit val ord: Ordering[JSerializable] =
-          if (statement.order.get.isInstanceOf[DescOrderOperator]) o.reverse else o
-        val sorted = s.sortBy(_.dimensions(statement.order.get.dimension))
-        sorted.take(statement.limit.get.value)
-      })
-
-    }
-  }
-
-  /**
-    * behaviour for read operations.
-    *
-    * - [[GetMetrics]] retrieve and return all the metrics.
-    *
-    * - [[ExecuteSelectStatement]] execute a given sql statement.
-    */
-  def readOps: Receive = {
-    case GetMetrics(_, _) =>
-      sender() ! MetricsGot(db, namespace, shards.keys.map(_.metric).toSet)
-    case GetCount(_, ns, metric) =>
-      val hits = shardsForMetric(metric).map {
-        case (_, index) =>
-          index.query(new MatchAllDocsQuery(), Seq.empty, Int.MaxValue, None)(identity).size
-      }.sum
-      sender ! CountGot(db, ns, metric, hits)
-    case ExecuteSelectStatement(statement, schema) =>
-      val postProcessedResult: Try[Seq[Bit]] =
-        statementParser.parseStatement(statement, schema) match {
-          case Success(parsedStatement @ ParsedSimpleQuery(_, metric, _, false, limit, fields, _)) =>
-            val indexes =
-              if (sharding)
-                filterShardsThroughTime(statement.condition.map(_.expression), shardsForMetric(statement.metric))
-              else Seq((ShardKey(metric, 0, 0), getIndex(ShardKey(metric, 0, 0))))
-
-            val orderedResults = retrieveAndorderPlainResults(statement, parsedStatement, indexes, schema)
-
-            if (fields.lengthCompare(1) == 0 && fields.head.count) {
-              orderedResults.map(seq => {
-                val recordCount = seq.map(_.value.asInstanceOf[Int]).sum
-                val count       = if (recordCount <= limit) recordCount else limit
-                Seq(Bit(0, count, Map(seq.head.dimensions.head._1 -> count)))
-              })
-            } else
-              orderedResults.map(
-                s =>
-                  s.map(
-                    b =>
-                      if (b.dimensions.contains("count(*)")) b.copy(dimensions = b.dimensions + ("count(*)" -> s.size))
-                      else b)
-              )
-
-          case Success(ParsedSimpleQuery(_, metric, q, true, limit, fields, sort)) if fields.lengthCompare(1) == 0 =>
-            val distinctField = fields.head.name
-
-            val filteredIndexes =
-              filterShardsThroughTime(statement.condition.map(_.expression), facetsShardsFromMetric(statement.metric))
-
-            val results = filteredIndexes.map {
-              case (_, index) =>
-                handleQueryResults(metric, Try(index.getDistinctField(q, fields.map(_.name).head, sort, limit)))
-            }
-
-            val shardResults = groupShardResults(results, distinctField) { values =>
-              Bit(0, 0, Map[String, JSerializable]((distinctField, values.head.dimensions(distinctField))))
-            }
-
-            applyOrderingWithLimit(shardResults, statement, schema)
-
-          case Success(ParsedAggregatedQuery(_, metric, q, collector: CountAllGroupsCollector[_], sort, limit)) =>
-            val result = filterShardsThroughTime(statement.condition.map(_.expression),
-                                                 facetsShardsFromMetric(statement.metric)).map {
-              case (_, index) =>
-                handleQueryResults(
-                  metric,
-                  Try(index
-                    .getCount(q, collector.groupField, sort, limit, schema.fieldsMap(collector.groupField).indexType)))
-            }
-
-            val shardResults = groupShardResults(result, statement.groupBy.get) { values =>
-              Bit(0, values.map(_.value.asInstanceOf[Long]).sum, values.head.dimensions)
-            }
-
-            applyOrderingWithLimit(shardResults, statement, schema)
-
-          case Success(ParsedAggregatedQuery(_, metric, q, collector, sort, limit)) =>
-            val shardResults = shardsForMetric(statement.metric).toSeq.map {
-              case (_, index) =>
-                handleQueryResults(metric, Try(index.query(q, collector.clear, limit, sort)))
-            }
-            val rawResult =
-              groupShardResults(shardResults, statement.groupBy.get) { values =>
-                val v                                        = schema.fields.find(_.name == "value").get.indexType.asInstanceOf[NumericType[_, _]]
-                implicit val numeric: Numeric[JSerializable] = v.numeric
-                collector match {
-                  case _: MaxAllGroupsCollector[_, _] =>
-                    Bit(0, values.map(_.value).max, values.head.dimensions)
-                  case _: MinAllGroupsCollector[_, _] =>
-                    Bit(0, values.map(_.value).min, values.head.dimensions)
-                  case _: SumAllGroupsCollector[_, _] =>
-                    Bit(0, values.map(_.value).sum, values.head.dimensions)
-                }
-              }
-
-            applyOrderingWithLimit(rawResult, statement, schema)
-
-          case Failure(ex) => Failure(ex)
-          case _           => Failure(new InvalidStatementException("Not a select statement."))
-        }
-
-      postProcessedResult match {
-        case Success(bits)                          => sender() ! SelectStatementExecuted(db, namespace, statement.metric, bits)
-        case Failure(ex: InvalidStatementException) => sender() ! SelectStatementFailed(ex.message)
-        case Failure(ex)                            => sender() ! SelectStatementFailed(ex.getMessage)
-      }
-  }
+//  /**
+//    * behaviour for read operations.
+//    *
+//    * - [[GetMetrics]] retrieve and return all the metrics.
+//    *
+//    * - [[ExecuteSelectStatement]] execute a given sql statement.
+//    */
+//  def readOps: Receive = {
+//    case GetMetrics(_, _) =>
+//      sender() ! MetricsGot(db, namespace, shards.keys.map(_.metric).toSet)
+//    case GetCount(_, ns, metric) =>
+//      val hits = shardsForMetric(metric).map {
+//        case (_, index) =>
+//          index.query(new MatchAllDocsQuery(), Seq.empty, Int.MaxValue, None)(identity).size
+//      }.sum
+//      sender ! CountGot(db, ns, metric, hits)
+//    case ExecuteSelectStatement(statement, schema) =>
+//      val postProcessedResult: Try[Seq[Bit]] =
+//        statementParser.parseStatement(statement, schema) match {
+//          case Success(parsedStatement @ ParsedSimpleQuery(_, metric, _, false, limit, fields, _)) =>
+//            val indexes =
+//              if (sharding)
+//                filterShardsThroughTime(statement.condition.map(_.expression), shardsForMetric(statement.metric))
+//              else Seq((ShardKey(metric, 0, 0), getIndex(ShardKey(metric, 0, 0))))
+//
+//            val orderedResults = retrieveAndorderPlainResults(statement, parsedStatement, indexes, schema)
+//
+//            if (fields.lengthCompare(1) == 0 && fields.head.count) {
+//              orderedResults.map(seq => {
+//                val recordCount = seq.map(_.value.asInstanceOf[Int]).sum
+//                val count       = if (recordCount <= limit) recordCount else limit
+//                Seq(Bit(0, count, Map(seq.head.dimensions.head._1 -> count)))
+//              })
+//            } else
+//              orderedResults.map(
+//                s =>
+//                  s.map(
+//                    b =>
+//                      if (b.dimensions.contains("count(*)")) b.copy(dimensions = b.dimensions + ("count(*)" -> s.size))
+//                      else b)
+//              )
+//
+//          case Success(ParsedSimpleQuery(_, metric, q, true, limit, fields, sort)) if fields.lengthCompare(1) == 0 =>
+//            val distinctField = fields.head.name
+//
+//            val filteredIndexes =
+//              filterShardsThroughTime(statement.condition.map(_.expression), facetsShardsFromMetric(statement.metric))
+//
+//            val results = filteredIndexes.map {
+//              case (_, index) =>
+//                handleQueryResults(metric, Try(index.getDistinctField(q, fields.map(_.name).head, sort, limit)))
+//            }
+//
+//            val shardResults = groupShardResults(results, distinctField) { values =>
+//              Bit(0, 0, Map[String, JSerializable]((distinctField, values.head.dimensions(distinctField))))
+//            }
+//
+//            applyOrderingWithLimit(shardResults, statement, schema)
+//
+//          case Success(ParsedAggregatedQuery(_, metric, q, collector: CountAllGroupsCollector[_], sort, limit)) =>
+//            val result = filterShardsThroughTime(statement.condition.map(_.expression),
+//                                                 facetsShardsFromMetric(statement.metric)).map {
+//              case (_, index) =>
+//                handleQueryResults(
+//                  metric,
+//                  Try(index
+//                    .getCount(q, collector.groupField, sort, limit, schema.fieldsMap(collector.groupField).indexType)))
+//            }
+//
+//            val shardResults = groupShardResults(result, statement.groupBy.get) { values =>
+//              Bit(0, values.map(_.value.asInstanceOf[Long]).sum, values.head.dimensions)
+//            }
+//
+//            applyOrderingWithLimit(shardResults, statement, schema)
+//
+//          case Success(ParsedAggregatedQuery(_, metric, q, collector, sort, limit)) =>
+//            val shardResults = shardsForMetric(statement.metric).toSeq.map {
+//              case (_, index) =>
+//                handleQueryResults(metric, Try(index.query(q, collector.clear, limit, sort)))
+//            }
+//            val rawResult =
+//              groupShardResults(shardResults, statement.groupBy.get) { values =>
+//                val v                                        = schema.fields.find(_.name == "value").get.indexType.asInstanceOf[NumericType[_, _]]
+//                implicit val numeric: Numeric[JSerializable] = v.numeric
+//                collector match {
+//                  case _: MaxAllGroupsCollector[_, _] =>
+//                    Bit(0, values.map(_.value).max, values.head.dimensions)
+//                  case _: MinAllGroupsCollector[_, _] =>
+//                    Bit(0, values.map(_.value).min, values.head.dimensions)
+//                  case _: SumAllGroupsCollector[_, _] =>
+//                    Bit(0, values.map(_.value).sum, values.head.dimensions)
+//                }
+//              }
+//
+//            applyOrderingWithLimit(rawResult, statement, schema)
+//
+//          case Failure(ex) => Failure(ex)
+//          case _           => Failure(new InvalidStatementException("Not a select statement."))
+//        }
+//
+//      postProcessedResult match {
+//        case Success(bits)                          => sender() ! SelectStatementExecuted(db, namespace, statement.metric, bits)
+//        case Failure(ex: InvalidStatementException) => sender() ! SelectStatementFailed(ex.message)
+//        case Failure(ex)                            => sender() ! SelectStatementFailed(ex.getMessage)
+//      }
+//  }
 
   /**
     * behaviour for accumulate operations.
@@ -437,17 +422,18 @@ class ShardAccumulatorActor(val basePath: String, val db: String, val namespace:
         case Failure(ex) =>
           sender() ! DeleteStatementFailed(db = db, namespace = namespace, metric = statement.metric, ex.getMessage)
       }
-    case Refresh(writeIds, keys) =>
+    case msg @ Refresh(writeIds, keys) =>
       opBufferMap --= writeIds
       performingOps = Map.empty
       keys.foreach { key =>
         getIndex(key).refresh()
         getFacetIndex(key).refresh()
       }
+      readerActor ! msg
   }
 
   override def receive: Receive = {
-    readOps orElse ddlOps orElse accumulate
+    ddlOps orElse accumulate
   }
 }
 
@@ -455,6 +441,6 @@ object ShardAccumulatorActor {
 
   case class Refresh(writeIds: Seq[String], keys: Seq[ShardKey])
 
-  def props(basePath: String, db: String, namespace: String): Props =
-    Props(new ShardAccumulatorActor(basePath, db, namespace))
+  def props(basePath: String, db: String, namespace: String, readerActor: ActorRef): Props =
+    Props(new ShardAccumulatorActor(basePath, db, namespace, readerActor))
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.actors
+
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import akka.util.Timeout
+import io.radicalbit.nsdb.actors.ShardAccumulatorActor.Refresh
+import io.radicalbit.nsdb.common.JSerializable
+import io.radicalbit.nsdb.common.exception.InvalidStatementException
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.common.statement.{DescOrderOperator, Expression, SelectSQLStatement}
+import io.radicalbit.nsdb.index.lucene._
+import io.radicalbit.nsdb.index.{FacetIndex, NumericType, TimeSeriesIndex}
+import io.radicalbit.nsdb.model.Schema
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
+import io.radicalbit.nsdb.statement.StatementParser._
+import io.radicalbit.nsdb.statement.{StatementParser, TimeRangeExtractor}
+import org.apache.lucene.index.IndexNotFoundException
+import org.apache.lucene.search.MatchAllDocsQuery
+import org.apache.lucene.store.MMapDirectory
+import spire.implicits._
+import spire.math.Interval
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/**
+  * Actor responsible for:
+  *
+  * - Accumulating write and delete operations which will be performed by [[ShardPerformerActor]].
+  *
+  * - Retrieving data from shards, aggregates and returns it to the sender.
+  *
+  * @param basePath shards indexes path.
+  * @param db shards db.
+  * @param namespace shards namespace.
+  */
+class ShardReaderActor(val basePath: String, val db: String, val namespace: String)
+    extends Actor
+    with ShardsActor
+    with ActorLogging {
+  import scala.collection.mutable
+
+  private val statementParser = new StatementParser()
+
+  /**
+    * Materialized configuration key. true if sharding is enabled.
+    */
+  lazy val sharding: Boolean = context.system.settings.config.getBoolean("nsdb.sharding.enabled")
+
+  implicit val dispatcher: ExecutionContextExecutor = context.system.dispatcher
+
+  /**
+    * Actor responsible for the actual writes into indexes.
+    */
+  var performerActor: ActorRef = _
+
+  implicit val timeout: Timeout =
+    Timeout(context.system.settings.config.getDuration("nsdb.publisher.timeout", TimeUnit.SECONDS), TimeUnit.SECONDS)
+
+  /**
+    * Writes scheduler interval.
+    */
+  lazy val interval = FiniteDuration(
+    context.system.settings.config.getDuration("nsdb.write.scheduler.interval", TimeUnit.SECONDS),
+    TimeUnit.SECONDS)
+
+//  /**
+//    * Map containing all the accumulated operations that will be passed to the [[PerformShardWrites]].
+//    */
+//  private val opBufferMap: mutable.Map[String, ShardOperation] = mutable.Map.empty
+//
+//  /**
+//    * operations currently being written by the [[io.radicalbit.nsdb.actors.ShardPerformerActor]].
+//    */
+//  private var performingOps: Map[String, ShardOperation] = Map.empty
+
+  private def handleQueryResults(metric: String, out: Try[Seq[Bit]]) = {
+    out.recoverWith {
+      case _: IndexNotFoundException => Success(Seq.empty)
+    }
+  }
+
+//  private def deleteMetricData(metric: String): Unit = {
+//    val folders = Option(Paths.get(basePath, db, namespace, "shards").toFile.list())
+//      .map(_.toSeq)
+//      .getOrElse(Seq.empty)
+//      .filter(folderName => folderName.split("_").head == metric)
+//
+//    folders.foreach(
+//      folderName => FileUtils.deleteDirectory(Paths.get(basePath, db, namespace, "shards", folderName).toFile)
+//    )
+//  }
+
+  /**
+    * Applies, if needed, ordering and limiting to results from multiple shards.
+    * @param shardResult sequence of shard results.
+    * @param statement the initial sql statement.
+    * @param schema metric's schema.
+    * @return a single result obtained from the manipulation of multiple results from different shards.
+    */
+  private def applyOrderingWithLimit(shardResult: Try[Seq[Bit]], statement: SelectSQLStatement, schema: Schema) = {
+    Try(shardResult.get).map(s => {
+      val maybeSorted = if (statement.order.isDefined) {
+        val o = schema.fields.find(_.name == statement.order.get.dimension).get.indexType.ord
+        implicit val ord: Ordering[JSerializable] =
+          if (statement.order.get.isInstanceOf[DescOrderOperator]) o.reverse
+          else o
+        s.sortBy(_.fields(statement.order.get.dimension))
+      } else s
+
+      if (statement.limit.isDefined) maybeSorted.take(statement.limit.get.value) else maybeSorted
+    })
+  }
+
+  /**
+    * Any existing shard is retrieved
+    */
+  override def preStart: Unit = {
+    Option(Paths.get(basePath, db, namespace, "shards").toFile.list())
+      .map(_.toSet)
+      .getOrElse(Set.empty)
+      .filter(_.split("_").length == 3)
+      .map(_.split("_"))
+      .foreach {
+        case Array(metric, from, to) =>
+          val directory =
+            new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${metric}_${from}_$to"))
+          val newIndex = new TimeSeriesIndex(directory)
+          shards += (ShardKey(metric, from.toLong, to.toLong) -> newIndex)
+          val directoryFacets =
+            new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${metric}_${from}_$to", "facet"))
+          val taxoDirectoryFacets =
+            new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${metric}_${from}_$to", "facet", "taxo"))
+          val newFacetIndex = new FacetIndex(directoryFacets, taxoDirectoryFacets)
+          facetIndexShards += (ShardKey(metric, from.toLong, to.toLong) -> newFacetIndex)
+      }
+
+//    performerActor =
+//      context.actorOf(ShardPerformerActor.props(basePath, db, namespace), s"shard-performer-service-$db-$namespace")
+//
+//    context.system.scheduler.schedule(0.seconds, interval) {
+//      if (opBufferMap.nonEmpty && performingOps.isEmpty) {
+//        performingOps = opBufferMap.toMap
+//        performerActor ! PerformShardWrites(performingOps)
+//      }
+//    }
+  }
+
+  private def filterShardsThroughTime[T](expression: Option[Expression], indexes: mutable.Map[ShardKey, T]) = {
+    val intervals = TimeRangeExtractor.extractTimeRange(expression)
+    indexes.filter {
+      case (key, _) if intervals.nonEmpty =>
+        intervals
+          .map(i => Interval.closed(key.from, key.to).intersect(i) != Interval.empty[Long])
+          .foldLeft(false)((x, y) => x || y)
+      case _ => true
+    }.toSeq
+  }
+
+  /**
+    * Groups results coming from different shards according to the group by clause provided in the query.
+    * @param shardResults results coming from different shards.
+    * @param dimension the group by clause dimension
+    * @param aggregationFunction the aggregate function corresponding to the aggregation operator (sum, count ecc.) contained in the query.
+    * @return the grouped results.
+    */
+  private def groupShardResults[W](shardResults: Seq[Try[Seq[Bit]]], dimension: String)(
+      aggregationFunction: Seq[Bit] => W): Try[Seq[W]] = {
+    Try(
+      shardResults
+        .flatMap(_.get)
+        .groupBy(_.dimensions(dimension))
+        .mapValues(aggregationFunction)
+        .values
+        .toSeq)
+  }
+
+  /**
+    * Retrieves and order results from different shards in case the statement does not contains aggregations
+    * and a where condition involving timestamp has been provided.
+    * @param statement raw statement.
+    * @param parsedStatement parsed statement.
+    * @param indexes shard indexes to retrieve data from.
+    * @param schema metric's schema.
+    * @return a single sequence of results obtained from different shards.
+    */
+  private def retrieveAndorderPlainResults(statement: SelectSQLStatement,
+                                           parsedStatement: ParsedSimpleQuery,
+                                           indexes: Seq[(ShardKey, TimeSeriesIndex)],
+                                           schema: Schema): Try[Seq[Bit]] = {
+    val (_, metric, q, _, limit, fields, sort) = ParsedSimpleQuery.unapply(parsedStatement).get
+    if (statement.getTimeOrdering.isDefined || statement.order.isEmpty) {
+      val result: ListBuffer[Try[Seq[Bit]]] = ListBuffer.empty
+
+      val eventuallyOrdered =
+        statement.getTimeOrdering.map(indexes.sortBy(_._1.from)(_)).getOrElse(indexes)
+
+      eventuallyOrdered.takeWhile {
+        case (_, index) =>
+          val partials = handleQueryResults(metric, Try(index.query(q, fields, limit, sort)(identity)))
+          result += partials
+
+          val combined = Try(result.flatMap(_.get))
+
+          combined.isSuccess && combined.get.lengthCompare(statement.limit.map(_.value).getOrElse(Int.MaxValue)) < 0
+      }
+
+      Try(result.flatMap(_.get))
+
+    } else {
+
+      val shardResults = indexes.map {
+        case (_, index) =>
+          handleQueryResults(metric, Try(index.query(q, fields, limit, sort)(identity)))
+      }
+
+      Try(shardResults.flatMap(_.get)).map(s => {
+        val o = schema.fields.find(_.name == statement.order.get.dimension).get.indexType.ord
+        implicit val ord: Ordering[JSerializable] =
+          if (statement.order.get.isInstanceOf[DescOrderOperator]) o.reverse else o
+        val sorted = s.sortBy(_.dimensions(statement.order.get.dimension))
+        sorted.take(statement.limit.get.value)
+      })
+
+    }
+  }
+
+  /**
+    * behaviour for read operations.
+    *
+    * - [[GetMetrics]] retrieve and return all the metrics.
+    *
+    * - [[ExecuteSelectStatement]] execute a given sql statement.
+    */
+  def readOps: Receive = {
+    case GetMetrics(_, _) =>
+      sender() ! MetricsGot(db, namespace, shards.keys.map(_.metric).toSet)
+    case GetCount(_, ns, metric) =>
+      val hits = shardsForMetric(metric).map {
+        case (_, index) =>
+          index.query(new MatchAllDocsQuery(), Seq.empty, Int.MaxValue, None)(identity).size
+      }.sum
+      sender ! CountGot(db, ns, metric, hits)
+    case ExecuteSelectStatement(statement, schema) =>
+      val postProcessedResult: Try[Seq[Bit]] =
+        statementParser.parseStatement(statement, schema) match {
+          case Success(parsedStatement @ ParsedSimpleQuery(_, metric, _, false, limit, fields, _)) =>
+            val indexes =
+              if (sharding)
+                filterShardsThroughTime(statement.condition.map(_.expression), shardsForMetric(statement.metric))
+              else Seq((ShardKey(metric, 0, 0), getIndex(ShardKey(metric, 0, 0))))
+
+            val orderedResults = retrieveAndorderPlainResults(statement, parsedStatement, indexes, schema)
+
+            if (fields.lengthCompare(1) == 0 && fields.head.count) {
+              orderedResults.map(seq => {
+                val recordCount = seq.map(_.value.asInstanceOf[Int]).sum
+                val count       = if (recordCount <= limit) recordCount else limit
+                Seq(Bit(0, count, Map(seq.head.dimensions.head._1 -> count)))
+              })
+            } else
+              orderedResults.map(
+                s =>
+                  s.map(
+                    b =>
+                      if (b.dimensions.contains("count(*)")) b.copy(dimensions = b.dimensions + ("count(*)" -> s.size))
+                      else b)
+              )
+
+          case Success(ParsedSimpleQuery(_, metric, q, true, limit, fields, sort)) if fields.lengthCompare(1) == 0 =>
+            val distinctField = fields.head.name
+
+            val filteredIndexes =
+              filterShardsThroughTime(statement.condition.map(_.expression), facetsShardsFromMetric(statement.metric))
+
+            val results = filteredIndexes.map {
+              case (_, index) =>
+                handleQueryResults(metric, Try(index.getDistinctField(q, fields.map(_.name).head, sort, limit)))
+            }
+
+            val shardResults = groupShardResults(results, distinctField) { values =>
+              Bit(0, 0, Map[String, JSerializable]((distinctField, values.head.dimensions(distinctField))))
+            }
+
+            applyOrderingWithLimit(shardResults, statement, schema)
+
+          case Success(ParsedAggregatedQuery(_, metric, q, collector: CountAllGroupsCollector[_], sort, limit)) =>
+            val result = filterShardsThroughTime(statement.condition.map(_.expression),
+                                                 facetsShardsFromMetric(statement.metric)).map {
+              case (_, index) =>
+                handleQueryResults(
+                  metric,
+                  Try(index
+                    .getCount(q, collector.groupField, sort, limit, schema.fieldsMap(collector.groupField).indexType)))
+            }
+
+            val shardResults = groupShardResults(result, statement.groupBy.get) { values =>
+              Bit(0, values.map(_.value.asInstanceOf[Long]).sum, values.head.dimensions)
+            }
+
+            applyOrderingWithLimit(shardResults, statement, schema)
+
+          case Success(ParsedAggregatedQuery(_, metric, q, collector, sort, limit)) =>
+            val shardResults = shardsForMetric(statement.metric).toSeq.map {
+              case (_, index) =>
+                handleQueryResults(metric, Try(index.query(q, collector.clear, limit, sort)))
+            }
+            val rawResult =
+              groupShardResults(shardResults, statement.groupBy.get) { values =>
+                val v                                        = schema.fields.find(_.name == "value").get.indexType.asInstanceOf[NumericType[_, _]]
+                implicit val numeric: Numeric[JSerializable] = v.numeric
+                collector match {
+                  case _: MaxAllGroupsCollector[_, _] =>
+                    Bit(0, values.map(_.value).max, values.head.dimensions)
+                  case _: MinAllGroupsCollector[_, _] =>
+                    Bit(0, values.map(_.value).min, values.head.dimensions)
+                  case _: SumAllGroupsCollector[_, _] =>
+                    Bit(0, values.map(_.value).sum, values.head.dimensions)
+                }
+              }
+
+            applyOrderingWithLimit(rawResult, statement, schema)
+
+          case Failure(ex) => Failure(ex)
+          case _           => Failure(new InvalidStatementException("Not a select statement."))
+        }
+
+      postProcessedResult match {
+        case Success(bits)                          => sender() ! SelectStatementExecuted(db, namespace, statement.metric, bits)
+        case Failure(ex: InvalidStatementException) => sender() ! SelectStatementFailed(ex.message)
+        case Failure(ex)                            => sender() ! SelectStatementFailed(ex.getMessage)
+      }
+    case Refresh(_, keys) =>
+      keys.foreach { key =>
+        getIndex(key).refresh()
+        getFacetIndex(key).refresh()
+      }
+  }
+
+  override def receive: Receive = readOps
+
+}
+
+object ShardReaderActor {
+
+  def props(basePath: String, db: String, namespace: String): Props =
+    Props(new ShardReaderActor(basePath, db, namespace))
+}

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -85,32 +85,11 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
     context.system.settings.config.getDuration("nsdb.write.scheduler.interval", TimeUnit.SECONDS),
     TimeUnit.SECONDS)
 
-//  /**
-//    * Map containing all the accumulated operations that will be passed to the [[PerformShardWrites]].
-//    */
-//  private val opBufferMap: mutable.Map[String, ShardOperation] = mutable.Map.empty
-//
-//  /**
-//    * operations currently being written by the [[io.radicalbit.nsdb.actors.ShardPerformerActor]].
-//    */
-//  private var performingOps: Map[String, ShardOperation] = Map.empty
-
   private def handleQueryResults(metric: String, out: Try[Seq[Bit]]) = {
     out.recoverWith {
       case _: IndexNotFoundException => Success(Seq.empty)
     }
   }
-
-//  private def deleteMetricData(metric: String): Unit = {
-//    val folders = Option(Paths.get(basePath, db, namespace, "shards").toFile.list())
-//      .map(_.toSeq)
-//      .getOrElse(Seq.empty)
-//      .filter(folderName => folderName.split("_").head == metric)
-//
-//    folders.foreach(
-//      folderName => FileUtils.deleteDirectory(Paths.get(basePath, db, namespace, "shards", folderName).toFile)
-//    )
-//  }
 
   /**
     * Applies, if needed, ordering and limiting to results from multiple shards.
@@ -155,16 +134,6 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
           val newFacetIndex = new FacetIndex(directoryFacets, taxoDirectoryFacets)
           facetIndexShards += (ShardKey(metric, from.toLong, to.toLong) -> newFacetIndex)
       }
-
-//    performerActor =
-//      context.actorOf(ShardPerformerActor.props(basePath, db, namespace), s"shard-performer-service-$db-$namespace")
-//
-//    context.system.scheduler.schedule(0.seconds, interval) {
-//      if (opBufferMap.nonEmpty && performingOps.isEmpty) {
-//        performingOps = opBufferMap.toMap
-//        performerActor ! PerformShardWrites(performingOps)
-//      }
-//    }
   }
 
   private def filterShardsThroughTime[T](expression: Option[Expression], indexes: mutable.Map[ShardKey, T]) = {


### PR DESCRIPTION
This PR introduces a new actor `ShardReader` which has the responsibility to handle the read flow (e.g. query and get commands execution).
So now there are two separated actors:
- `ShardAccumulatorActor` which continues to handle the write logic as same as before and furthermore, it refre the reader actor when a bulk of writes is committed
- `ShardReaderActor` which handle the read logic and receive refresh 
