### PR TITLE
Metadata warm-up

### DIFF
--- a/nsdb-cluster/src/main/resources/cluster.conf
+++ b/nsdb-cluster/src/main/resources/cluster.conf
@@ -25,6 +25,7 @@ akka {
 
     control-aware-dispatcher {
       mailbox-type = "akka.dispatch.UnboundedControlAwareMailbox"
+
     }
 
     debug {
@@ -151,8 +152,8 @@ nsdb {
   rpc-akka-endpoint.timeout = 30 seconds
   rpc-akka-endpoint.timeout = ${?RPC_AKKA_TIMEOUT}
 
-  read-coordinatoor.timeout = 30 seconds
-  read-coordinatoor.timeout = ${?READ_COORDINATOR_TIMEOUT}
+  read-coordinator.timeout = 30 seconds
+  read-coordinator.timeout = ${?READ_COORDINATOR_TIMEOUT}
   metadata-coordinator.timeout = 30 seconds
   metadata-coordinator.timeout = ${?METADATA_COORDINATOR_TIMEOUT}
   write-coordinator.timeout = 30 seconds

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
@@ -68,6 +68,8 @@ class ClusterListener(writeCoordinator: ActorRef, readCoordinator: ActorRef, met
         name = s"metadata_$nameNode"
       )
 
+      mediator ! Subscribe("warm-up", readCoordinator)
+      mediator ! Subscribe("warm-up", writeCoordinator)
       mediator ! Subscribe("metadata", metadataActor)
 
       log.info(s"subscribing data actor for node $nameNode")

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -94,6 +94,7 @@ class MetadataCoordinator(cache: ActorRef) extends Actor with ActorLogging with 
         .map(l => LocationsGot(db, namespace, metric, l.value))
       f.pipeTo(sender())
     case GetWriteLocation(db, namespace, metric, timestamp) =>
+      //TODO Remove debugging code
       (cache ? GetLocationsFromCache(MetricKey(db, namespace, metric)))
         .flatMap {
           case CachedLocations(_, values) if values.nonEmpty =>
@@ -115,7 +116,7 @@ class MetadataCoordinator(cache: ActorRef) extends Actor with ActorLogging with 
             val randomNode = Random.shuffle(cluster.state.members).head
             val nodeName =
               s"${randomNode.address.host.getOrElse("noHost")}_${randomNode.address.port.getOrElse(2552)}"
-            (self ? AddLocation(db, namespace, Location(metric, nodeName, 0, shardingInterval.toMillis))).map {
+            (self ? AddLocation(db, namespace, Location(metric, nodeName, timestamp, timestamp + shardingInterval.toMillis))).map {
               case LocationAdded(_, _, location) => LocationGot(db, namespace, metric, Some(location))
               case AddLocationFailed(_, _, _)    => LocationGot(db, namespace, metric, None)
             }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -22,7 +22,6 @@ import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.NsdbPerfLogger
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.WarmUpCompleted
 import io.radicalbit.nsdb.cluster.coordinator.ReadCoordinator.Commands.GetConnectedNodes
 import io.radicalbit.nsdb.cluster.coordinator.ReadCoordinator.Events.ConnectedNodesGot
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
@@ -52,6 +51,9 @@ class ReadCoordinator(metadataCoordinator: ActorRef, namespaceSchemaActor: Actor
 
   override def receive: Receive = warmUp
 
+  /**
+    * Initial state in which actor waits metadata warm-up completion.
+    */
   def warmUp: Receive = {
     case WarmUpCompleted =>
       context.become(operating)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -18,7 +18,7 @@ package io.radicalbit.nsdb.cluster.coordinator
 
 import java.util.concurrent.TimeUnit
 
-import akka.actor.{Actor, ActorLogging, ActorRef, Props, Stash, UnboundedStash}
+import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.NsdbPerfLogger

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -59,6 +59,7 @@ class ReadCoordinator(metadataCoordinator: ActorRef, namespaceSchemaActor: Actor
       metricsDataActors += (nodeName -> actor)
       sender() ! MetricsDataActorSubscribed(actor, nodeName)
     case msq =>
+      // Requests received during warm-up are ignored, this results in a timeout
       log.error(s"Received ignored message $msq during warmUp")
   }
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
@@ -36,7 +36,7 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{
   GetLocations,
   GetWriteLocation
 }
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{LocationGot, LocationsGot, WarmUpCompleted}
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{LocationGot, LocationsGot}
 import io.radicalbit.nsdb.cluster.coordinator.WriteCoordinator.{CreateDump, DumpCreated, Restore, Restored}
 import io.radicalbit.nsdb.cluster.index.Location
 import io.radicalbit.nsdb.cluster.util.FileUtils
@@ -208,6 +208,9 @@ class WriteCoordinator(commitLogCoordinator: Option[ActorRef],
 
   override def receive: Receive = warmUp
 
+  /**
+    * Initial state in which actor waits metadata warm-up completion.
+    */
   def warmUp: Receive = {
     case WarmUpCompleted =>
       unstashAll()

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
@@ -126,11 +126,16 @@ class GrpcEndpoint(readCoordinator: ActorRef, writeCoordinator: ActorRef)(implic
     override def showMetrics(
         request: ShowMetrics
     ): Future[GrpcMetricsGot] = {
-      //TODO: add failure handling
       log.debug("Received command ShowMetrics for namespace {}", request.namespace)
       (readCoordinator ? GetMetrics(request.db, request.namespace)).map {
         case MetricsGot(db, namespace, metrics) =>
           GrpcMetricsGot(db, namespace, metrics.toList, completedSuccessfully = true)
+        case _ =>
+          GrpcMetricsGot(request.db,
+                         request.namespace,
+                         List.empty,
+                         completedSuccessfully = false,
+                         "Unknown server error")
       }
     }
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/MetadataIndex.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/MetadataIndex.scala
@@ -84,8 +84,7 @@ class MetadataIndex(override val directory: BaseDirectory) extends Index[Locatio
   def getMetadata(metric: String): Seq[Location] = {
     val queryTerm = new TermQuery(new Term(_keyField, metric))
 
-    val reader                           = DirectoryReader.open(directory)
-    implicit val searcher: IndexSearcher = new IndexSearcher(reader)
+    implicit val searcher: IndexSearcher = getSearcher
 
     Try(query(queryTerm, Seq.empty, Integer.MAX_VALUE, None)(identity)) match {
       case Success(metadataSeq) => metadataSeq

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/MetadataIndex.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/MetadataIndex.scala
@@ -16,6 +16,7 @@
 
 package io.radicalbit.nsdb.cluster.index
 
+import com.typesafe.scalalogging.Logger
 import io.radicalbit.nsdb.index.Index
 import io.radicalbit.nsdb.statement.StatementParser.SimpleField
 import org.apache.lucene.document.Field.Store
@@ -81,7 +82,12 @@ class MetadataIndex(override val directory: BaseDirectory) extends Index[Locatio
   }
 
   def getMetadata(metric: String): Seq[Location] = {
-    Try(query(_keyField, metric, Seq.empty, Integer.MAX_VALUE)(identity)) match {
+    val queryTerm = new TermQuery(new Term(_keyField, metric))
+
+    val reader                           = DirectoryReader.open(directory)
+    implicit val searcher: IndexSearcher = new IndexSearcher(reader)
+
+    Try(query(queryTerm, Seq.empty, Integer.MAX_VALUE, None)(identity)) match {
       case Success(metadataSeq) => metadataSeq
       case Failure(_)           => Seq.empty
     }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/util/FileUtils.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/util/FileUtils.scala
@@ -16,10 +16,13 @@
 
 package io.radicalbit.nsdb.cluster.util
 
+import java.io
 import java.io.{File, FileOutputStream, InputStream, OutputStream}
+import java.nio.file.Paths
 import java.util.zip.{ZipEntry, ZipFile}
 
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 /**
   * Contains utility methods to handle files.
@@ -39,7 +42,8 @@ object FileUtils {
     * @param path a string path.
     * @return all the first level sub directories of the given directory.
     */
-  def getSubDirs(path: String): Array[File] = new File(path).listFiles(_.isDirectory)
+  def getSubDirs(path: String): List[File] =
+    Option(new File(path).listFiles(_.isDirectory)).map(_.toList).getOrElse(List.empty)
 
   /**
     * Unzip a file into a target folder.

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataTest.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataTest.scala
@@ -78,8 +78,6 @@ class MetadataTest extends MultiNodeSpec(MetadataTest) with STMultiNodeSpec with
 
   val metadataCoordinator = system.actorSelection("/user/guardian/metadata-coordinator")
 
-  metadataCoordinator ! WarmUpLocations(List.empty)
-
   def join(from: RoleName, to: RoleName): Unit = {
     runOn(from) {
       cluster join node(to).address

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataTest.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataTest.scala
@@ -8,7 +8,7 @@ import akka.remote.testconductor.RoleName
 import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec}
 import akka.testkit.{ImplicitSender, TestProbe}
 import com.typesafe.config.ConfigFactory
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{AddLocation, GetLocations}
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{AddLocation, GetLocations, WarmUpLocations}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{LocationAdded, LocationsGot}
 import io.radicalbit.nsdb.cluster.index.Location
 import io.radicalbit.rtsae.STMultiNodeSpec
@@ -30,7 +30,7 @@ object MetadataTest extends MultiNodeConfig {
     |akka.log-dead-letters-during-shutdown = off
     |nsdb{
     |
-    |  read-coordinatoor.timeout = 10 seconds
+    |  read-coordinator.timeout = 10 seconds
     |  namespace-schema.timeout = 10 seconds
     |  namespace-data.timeout = 10 seconds
     |  publisher.timeout = 10 seconds
@@ -77,6 +77,8 @@ class MetadataTest extends MultiNodeSpec(MetadataTest) with STMultiNodeSpec with
   val guardian = system.actorOf(Props[DatabaseActorsGuardian], "guardian")
 
   val metadataCoordinator = system.actorSelection("/user/guardian/metadata-coordinator")
+
+  metadataCoordinator ! WarmUpLocations(List.empty)
 
   def join(from: RoleName, to: RoleName): Unit = {
     runOn(from) {

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedCacheSpec.scala
@@ -30,7 +30,7 @@ object ReplicatedMetadataCacheSpec extends MultiNodeConfig {
     |akka.log-dead-letters-during-shutdown = off
     |nsdb{
     |
-    |  read-coordinatoor.timeout = 10 seconds
+    |  read-coordinator.timeout = 10 seconds
     |  namespace-schema.timeout = 10 seconds
     |  namespace-data.timeout = 10 seconds
     |  publisher.timeout = 10 seconds

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorClusterTest.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorClusterTest.scala
@@ -10,10 +10,10 @@ import akka.testkit.ImplicitSender
 import com.typesafe.config.ConfigFactory
 import io.radicalbit.nsdb.cluster.actor.DatabaseActorsGuardian
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.GetLocations
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{LocationsGot, WarmUpCompleted}
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.LocationsGot
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.MapInput
-import io.radicalbit.nsdb.protocol.MessageProtocol.Events.InputMapped
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{InputMapped, WarmUpCompleted}
 import io.radicalbit.rtsae.STMultiNodeSpec
 
 import scala.concurrent.duration._

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorClusterTest.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorClusterTest.scala
@@ -10,7 +10,7 @@ import akka.testkit.ImplicitSender
 import com.typesafe.config.ConfigFactory
 import io.radicalbit.nsdb.cluster.actor.DatabaseActorsGuardian
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.GetLocations
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.LocationsGot
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{LocationsGot, WarmUpCompleted}
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.MapInput
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.InputMapped
@@ -82,6 +82,8 @@ class WriteCoordinatorClusterTest
 
   val metadataCoordinator = system.actorSelection("/user/guardian/metadata-coordinator")
   val writeCoordinator    = system.actorSelection("/user/guardian/write-coordinator")
+
+  writeCoordinator ! WarmUpCompleted
 
   def join(from: RoleName, to: RoleName): Unit = {
     runOn(from) {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/LocationActorTest.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/LocationActorTest.scala
@@ -16,7 +16,7 @@
 
 package io.radicalbit.nsdb.cluster.actor
 
-import akka.actor.ActorSystem
+import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
 import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
@@ -37,6 +37,12 @@ import org.scalatest._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
+class FakeMetadataCoordinator extends Actor with ActorLogging {
+  def receive: Receive = {
+    case _ => log.info("received message")
+  }
+}
+
 class LocationActorTest
     extends TestKit(ActorSystem("SchemaActorSpec"))
     with ImplicitSender
@@ -45,8 +51,9 @@ class LocationActorTest
     with OneInstancePerTest
     with BeforeAndAfter {
 
-  val probe         = TestProbe()
-  val metadataActor = system.actorOf(MetadataActor.props("target/test_index/LocationActorTest", null))
+  val probe               = TestProbe()
+  val metadataCoordinator = system.actorOf(Props[FakeMetadataCoordinator])
+  val metadataActor       = system.actorOf(MetadataActor.props("target/test_index/LocationActorTest", metadataCoordinator))
 
   lazy val db        = "db"
   lazy val namespace = "namespaceTest"

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSpec.scala
@@ -24,7 +24,6 @@ import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import io.radicalbit.nsdb.actors.SchemaActor
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.AddRecordToLocation
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.WarmUpCompleted
 import io.radicalbit.nsdb.cluster.index.Location
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSpec.scala
@@ -24,6 +24,7 @@ import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import io.radicalbit.nsdb.actors.SchemaActor
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.AddRecordToLocation
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.WarmUpCompleted
 import io.radicalbit.nsdb.cluster.index.Location
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
@@ -59,6 +60,8 @@ class ReadCoordinatorSpec
   override def beforeAll = {
     import scala.concurrent.duration._
     implicit val timeout = Timeout(5 second)
+
+    readCoordinatorActor ! WarmUpCompleted
 
     Await.result(readCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "node1"), 10 seconds)
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
@@ -21,8 +21,8 @@ import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.WarmUpCompleted
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.WarmUpCompleted
 import org.scalatest._
 
 import scala.concurrent.Await

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
@@ -21,6 +21,7 @@ import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.WarmUpCompleted
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import org.scalatest._
 
@@ -50,6 +51,7 @@ class WriteCoordinatorSpec
   implicit val timeout = Timeout(10 seconds)
 
   override def beforeAll: Unit = {
+    writeCoordinatorActor ! WarmUpCompleted
     Await.result(writeCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "node1"), 10 seconds)
     Await.result(writeCoordinatorActor ? DeleteNamespace(db, namespace), 10 seconds)
     Await.result(namespaceSchemaActor ? UpdateSchemaFromRecord(db, namespace, "testMetric", record1), 10 seconds)

--- a/nsdb-core/src/main/resources/application.conf
+++ b/nsdb-core/src/main/resources/application.conf
@@ -44,7 +44,7 @@ nsdb {
     storage = ""
   }
 
-  read-coordinatoor.timeout = 10 seconds
+  read-coordinator.timeout = 10 seconds
   write-coordinator.timeout = 10 seconds
   namespace-schema.timeout = 10 seconds
   namespace-data.timeout = 10 seconds

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/Index.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/Index.scala
@@ -226,7 +226,7 @@ trait Index[T] {
   }
 
   /**
-    * Returns all the entries whiere `field` = `value`
+    * Returns all the entries where `field` = `value`
     * @param field the field name to use to filter data.
     * @param value the value to check the field with.
     * @param fields sequence of fields that must be included in the result.

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -69,6 +69,8 @@ object MessageProtocol {
     */
   object Events {
 
+    case object WarmUpCompleted
+
     sealed trait ErrorCode
     case class MetricNotFound(metric: String) extends ErrorCode
     case object Generic                       extends ErrorCode

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
@@ -17,7 +17,6 @@
 package io.radicalbit.nsdb.web.routes
 
 import javax.ws.rs.Path
-
 import akka.actor.ActorRef
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
 import akka.http.scaladsl.model.StatusCodes.{InternalServerError, NotFound}


### PR DESCRIPTION
In this PR, metrics shard metadata are retrieved from metadata index also on startup.
This implies the introduction of a warm-up behavior in coordinator start-up waiting for MetadataLocations.