### PR TITLE
Add debian package specification using native packager

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,7 @@ lazy val `nsdb-rpc` = project
 lazy val `nsdb-cluster` = project
   .settings(Commons.settings: _*)
   .settings(PublishSettings.dontPublish: _*)
-  .enablePlugins(JavaAppPackaging, DockerPlugin)
+  .enablePlugins(JavaAppPackaging, SbtNativePackager)
   .settings(libraryDependencies ++= Dependencies.Cluster.libraries)
   .settings(
     compile in MultiJvm <<= (compile in MultiJvm) triggeredBy (compile in Test),
@@ -138,6 +138,12 @@ lazy val `nsdb-cluster` = project
   .configs(MultiJvm)
   .settings(assemblyJarName in assembly := "nsdb-cluster.jar")
   .settings(
+    /* Docker Settings - to create, run as:
+       $ sbt `project nsdb-cluster` docker:publishLocal
+
+       See here for details:
+       http://www.scala-sbt.org/sbt-native-packager/formats/docker.html
+     */
     mappings in Docker ++= {
       val confDir = baseDirectory.value / "src/main/resources"
 
@@ -160,6 +166,18 @@ lazy val `nsdb-cluster` = project
       Cmd("HEALTHCHECK", "--timeout=3s", "CMD", "curl", "-f", "http://localhost:9000/status || exit 1"),
       Cmd("CMD", s"bin/cluster -Dlogback.configurationFile=conf/logback.xml -DconfDir=conf/")
     )
+  )
+  .settings(
+    /* Debian Settings - to create, run as:
+       $ sbt `project nsdb-cluster` debian:packageBin
+
+       See here for details:
+       http://www.scala-sbt.org/sbt-native-packager/formats/debian.html
+     */
+    version in Debian := version.value,
+    maintainer in Debian := "Radicalbit <info@radicalbit.io>",
+    packageSummary in Debian := "NSDb is an open source, brand new distributed time series Db, streaming oriented, optimized for the serving layer and completely based on Scala and Akka",
+    packageDescription in Debian := "NSDb is an open source, brand new distributed time series Db, streaming oriented, optimized for the serving layer and completely based on Scala and Akka"
   )
   .settings(
     mappings in Universal ++= {


### PR DESCRIPTION
Read the [required](https://www.scala-sbt.org/sbt-native-packager/formats/debian.html#requirements) applications to build the debian package.
In my case I used an Ubuntu VM to achieve the goal.