### PR TITLE
Use "nsdb" instead of "nsdb-cluster" as package name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,29 +146,29 @@ lazy val `nsdb-cluster` = project
        See here for details:
        http://www.scala-sbt.org/sbt-native-packager/formats/docker.html
      */
+    packageName in Docker := "nsdb",
     mappings in Docker ++= {
       val confDir = baseDirectory.value / "src/main/resources"
 
       for {
         (file, relativePath) <- (confDir.*** --- confDir) x relativeTo(confDir)
-      } yield file -> s"/opt/${name.value}/conf/$relativePath"
+      } yield file -> s"/opt/${(packageName in Docker).value}/conf/$relativePath"
     },
     mappings in Docker ++= {
       val confDir = baseDirectory.value / "../docker-scripts"
 
       for {
         (file, relativePath) <- (confDir.*** --- confDir) x relativeTo(confDir)
-      } yield file -> s"/opt/${name.value}/bin/$relativePath"
+      } yield file -> s"/opt/${(packageName in Docker).value}/bin/$relativePath"
     },
-    packageName in Docker := name.value,
     version in Docker := version.value,
     maintainer in Docker := organization.value,
     dockerRepository := Some("tools.radicalbit.io"),
-    defaultLinuxInstallLocation in Docker := s"/opt/${name.value}",
+    defaultLinuxInstallLocation in Docker := s"/opt/${(packageName in Docker).value}",
     dockerCommands := Seq(
       Cmd("FROM", "tools.radicalbit.io/service-java-base:1.0"),
       Cmd("LABEL", s"""MAINTAINER="${organization.value}""""),
-      Cmd("WORKDIR", s"/opt/${name.value}"),
+      Cmd("WORKDIR", s"/opt/${(packageName in Docker).value}"),
       Cmd("RUN", "addgroup", "-S", "nsdb", "&&", "adduser", "-S", "nsdb", "-G", "nsdb"),
       Cmd("ADD", "opt", "/opt"),
       ExecCmd("RUN", "chown", "-R", "nsdb:nsdb", "."),
@@ -184,6 +184,7 @@ lazy val `nsdb-cluster` = project
        See here for details:
        http://www.scala-sbt.org/sbt-native-packager/formats/debian.html
      */
+    name in Debian := "nsdb",
     version in Debian := version.value,
     maintainer in Debian := "Radicalbit <info@radicalbit.io>",
     packageSummary in Debian := "NSDb is an open source, brand new distributed time series Db, streaming oriented, optimized for the serving layer and completely based on Scala and Akka",
@@ -197,7 +198,7 @@ lazy val `nsdb-cluster` = project
        http://www.scala-sbt.org/sbt-native-packager/formats/rpm.html
      */
     version in Rpm := version.value,
-    packageName in Rpm := name.value,
+    packageName in Rpm := "nsdb",
     rpmRelease := "1",
     packageSummary in Rpm := "NSDb is an open source, brand new distributed time series Db, streaming oriented, optimized for the serving layer and completely based on Scala and Akka",
     packageDescription in Rpm := "NSDb is an open source, brand new distributed time series Db, streaming oriented, optimized for the serving layer and completely based on Scala and Akka",
@@ -206,6 +207,7 @@ lazy val `nsdb-cluster` = project
     rpmLicense := Some("Apache")
   )
   .settings(
+    packageName in Universal := s"nsdb-${version.value}",
     mappings in Universal ++= {
       val confDir = baseDirectory.value / "src/main/resources"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ version: '3'
 services:
 
     nsdb:
-      image: tools.radicalbit.io/nsdb-cluster:0.6.0-SNAPSHOT
+      image: tools.radicalbit.io/nsdb:0.6.0-SNAPSHOT
       volumes:
         - ./nsdb-cluster/src/main/resources:/opt/nsdb-cluster/conf
         - ./data:/opt/nsdb-cluster/data

--- a/docs/CLI_doc.md
+++ b/docs/CLI_doc.md
@@ -14,13 +14,14 @@ NSDb CLI makes use of gRPC client to communicate with NSDb cluster.
 ## Commands Usage
 CLI launch command:
 ```sh
-./nsdb-console --host 127.0.0.1 --port 7817 --database database_name
+./nsdb-cli --host 127.0.0.1 --port 7817 --database database_name
 ```
-accepts 3 parameters:
+accepts 4 parameters:
 ```
---host : NSDb host address, default value is localhost
---port : NSDb host port, default value is 7817
---database: database name on which establish connection
+--host : NSDb host address, default value is localhost (mandatory)
+--port : NSDb host port, default value is 7817 (mandatory)
+--database: database name on which establish connection (mandatory)
+--with: table max with (optional)
 ```
 
 To perform previously described operations users must select the namespace on which execute statements:

--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -16,9 +16,9 @@ $ sbt dist
 Once project packaging is completed, unzip archive created in path : `nsdb-cluster/target/universal`.
 ```bash
 $ cd nsdb/nsdb-cluster/target/universal
-$ unzip nsdb-cluster-0.1.3-SNAPSHOT.zip
-$ cd nsdb-cluster-0.1.3-SNAPSHOT/bin
-$ ./cluster
+$ unzip nsdb-0.6.0-SNAPSHOT.zip
+$ cd nsdb-0.6.0-SNAPSHOT/bin
+$ ./nsdb-cluster
 ```
 In order to check if the application is up and running properly user can call health-check API:
 ```bash
@@ -27,7 +27,7 @@ RUNNING
 ```
 Command Line Interface(CLI) can be launched executing in the same path:
 ```
-$ ./nsdb-console --host 127.0.0.1 --port 7817 --database database_name
+$ ./nsdb-cli --host 127.0.0.1 --port 7817 --database database_name
 ```
 For a comprehensive documentation regarding NSDb CLI refer to  [CLI doc](CLI_doc.md).
 
@@ -47,13 +47,11 @@ version: '3'
 services:
 
     nsdb:
-      image: tools.radicalbit.io/nsdb:0.0.3-SNAPSHOT
+      image: tools.radicalbit.io/nsdb:0.6.0-SNAPSHOT
       environment:
-        HTTP_INTERFACE: 0.0.0.0
-        HTTP_PORT: 9002
         AKKA_HOSTNAME: nsdb-node-1
       ports:
-        - 9010:9002
+        - 9010:9000
         - 9000:7817
 ```
 
@@ -65,7 +63,7 @@ version: '3'
 services:
 
     nsdb:
-      image: tools.radicalbit.io/nsdb:0.0.3-SNAPSHOT
+      image: tools.radicalbit.io/nsdb:0.6.0-SNAPSHOT
       volumes:
         - .conf:/opt/nsdb-cluster/conf
         - /host/data/path:/opt/nsdb-cluster/data
@@ -78,9 +76,16 @@ services:
 ```
 To start NSDb container:
 
+```bash
+$ docker-compose up
 ```
-$ docker-compose-up
+Command Line Interface(CLI) can be launched executing:
+```bash
+$ docker run --rm -it tools.radicalbit.io/nsdb:0.6.0-SNAPSHOT bin/nsdb-cli --host %HOST_IP% --port 7817 --database database_name
 ```
+where `%HOST_IP%` is the IP where NSDb is running.
+
+For a comprehensive documentation regarding NSDb CLI refer to  [CLI doc](CLI_doc.md).
 
 ## Next steps
 NSDb exposes data retrieval and insertion using both:


### PR DESCRIPTION
Use `nsdb` instead of `nsdb-cluster` as package name.

Below a table who summarize the changes:

| Package type | Previous value | Current value |
|--------------|----------------|---------------|
| `Universal` | `nsdb-cluster-<VERSION>.zip` | `nsdb-<VERSION>.zip` |
| `Rpm` | `nsdb-custer-<VERSION>-1.noarch.rpm` | `nsdb-<VERSION>-1.noarch.rpm` |
| `Debian` | `nsdb-cluster_<VERSION>_all.deb` | `nsdb_<VERSION>_all.deb` |
| `Docker` | `tools.radicalbit.io/nsdb-cluster:<VERSION>` | `tools.radicalbit.io/nsdb:<VERSION>` |
