### PR TITLE
Fix publish-subscribe 

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
@@ -85,7 +85,7 @@ class NodeActorsGuardian(metadataCache: ActorRef, schemaCache: ActorRef) extends
   private val writeCoordinator =
     context.actorOf(
       WriteCoordinator
-        .props(metadataCoordinator, schemaCoordinator, publisherActor, mediator)
+        .props(metadataCoordinator, schemaCoordinator, mediator)
         .withDeploy(Deploy(scope = RemoteScope(selfMember.address))),
       s"write-coordinator_$nodeName"
     )
@@ -118,6 +118,9 @@ class NodeActorsGuardian(metadataCache: ActorRef, schemaCache: ActorRef) extends
     case GetCommitLogCoordinators =>
       log.debug("gossiping commit logs for node {}", nodeName)
       mediator ! Publish(COORDINATORS_TOPIC, SubscribeCommitLogCoordinator(commitLogCoordinator, nodeName))
+    case GetPublishers =>
+      log.debug("gossiping publishers for node {}", nodeName)
+      mediator ! Publish(COORDINATORS_TOPIC, SubscribePublisher(publisherActor, nodeName))
   }
 }
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -100,7 +100,6 @@ trait WriteCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers 
   lazy val fakeMetadataCoordinator = system.actorOf(Props[FakeMetadataCoordinator])
   lazy val writeCoordinatorActor = system actorOf WriteCoordinator.props(fakeMetadataCoordinator,
                                                                          schemaCoordinator,
-                                                                         publisherActor,
                                                                          system.actorOf(Props.empty))
 
   val record1 = Bit(System.currentTimeMillis, 1, Map("content" -> s"content"), Map.empty)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
@@ -55,6 +55,7 @@ class WriteCoordinatorSpec
     writeCoordinatorActor ! WarmUpCompleted
     schemaCoordinator ! WarmUpSchemas(List.empty)
     Await.result(writeCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "node1"), 10 seconds)
+    Await.result(writeCoordinatorActor ? SubscribePublisher(publisherActor, "node1"), 10 seconds)
     Await.result(writeCoordinatorActor ? DeleteNamespace(db, namespace), 10 seconds)
     Await.result(schemaCoordinator ? UpdateSchemaFromRecord(db, namespace, "testMetric", record1), 10 seconds)
   }

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/Bit.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/Bit.scala
@@ -61,11 +61,11 @@ case class Bit(timestamp: Long,
     m.map { case (k, v) => k -> (v, classType) }
 
   /**
-  * Compare the bit to another one ignoring the timestamp.
+    * Compare the bit to another one ignoring the timestamp.
     * @param other the bit to be compared
     * @return true if everything but timestamp is equals
     */
-  def timelessEquals(other: Bit): Boolean  = {
+  def timelessEquals(other: Bit): Boolean = {
     this.value == other.value && this.dimensions == other.dimensions && this.tags == other.tags
   }
 

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/Bit.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/Bit.scala
@@ -59,4 +59,14 @@ case class Bit(timestamp: Long,
   private def extractFields(m: Map[String, JSerializable],
                             classType: FieldClassType): Map[String, (JSerializable, FieldClassType)] =
     m.map { case (k, v) => k -> (v, classType) }
+
+  /**
+  * Compare the bit to another one ignoring the timestamp.
+    * @param other the bit to be compared
+    * @return true if everything but timestamp is equals
+    */
+  def timelessEquals(other: Bit): Boolean  = {
+    this.value == other.value && this.dimensions == other.dimensions && this.tags == other.tags
+  }
+
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -70,11 +70,13 @@ object MessageProtocol {
 
     case class SubscribeMetricsDataActor(actor: ActorRef, nodeName: String)
     case class SubscribeCommitLogCoordinator(actor: ActorRef, nodeName: String)
+    case class SubscribePublisher(actor: ActorRef, nodeName: String)
 
     case object GetConnectedDataNodes
 
     case object GetMetricsDataActors
     case object GetCommitLogCoordinators
+    case object GetPublishers
   }
 
   /**
@@ -116,8 +118,8 @@ object MessageProtocol {
     case class AllMetricsDeleted(db: String, namespace: String)
 
     case class CommitLogCoordinatorSubscribed(actor: ActorRef, nodeName: String)
-
     case class MetricsDataActorSubscribed(actor: ActorRef, nodeName: String)
+    case class PublisherSubscribed(actor: ActorRef, nodeName: String)
 
     case class ConnectedDataNodesGot(nodes: Seq[String])
   }

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
@@ -33,7 +33,7 @@ import org.json4s.jackson.Serialization.write
 
 trait WsResources {
 
-  implicit val formats: DefaultFormats.type
+  implicit def formats: Formats
 
   implicit def system: ActorSystem
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/WebSocketSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/WebSocketSpec.scala
@@ -31,8 +31,6 @@ import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.concurrent.duration._
-
 class FakeReadCoordinatorActor extends Actor {
   def receive: Receive = {
     case ExecuteStatement(_) =>
@@ -40,7 +38,7 @@ class FakeReadCoordinatorActor extends Actor {
   }
 }
 
-class WebSocketTest() extends FlatSpec with ScalatestRouteTest with Matchers with WsResources {
+class WebSocketSpec() extends FlatSpec with ScalatestRouteTest with Matchers with WsResources {
 
   implicit val formats = DefaultFormats
 
@@ -103,10 +101,10 @@ class WebSocketTest() extends FlatSpec with ScalatestRouteTest with Matchers wit
         val response = parse(subscribed).extractOpt[SubscribedByQueryString].get
 
         wsClient.sendMessage(
-          s"""{"db":"db","namespace":"registry","metric":"people","quid":${response.quid}} """
+          s"""{"db":"db","namespace":"registry","metric":"people","quid":"${response.quid}"} """
         )
         val subscribedQId = wsClient.expectMessage().asTextMessage.getStrictText
-        parse(subscribed).extractOpt[SubscribedByQuid].isDefined shouldBe true
+        parse(subscribedQId).extractOpt[SubscribedByQuid].isDefined shouldBe true
 
         //TODO find out how to test combining somehow the actorsystem coming from ScalatestRouteTest and from Testkit
       }

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/cluster/PublishSubscribeClusterSpec.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/cluster/PublishSubscribeClusterSpec.scala
@@ -1,0 +1,152 @@
+package io.radicalbit.nsdb.cluster
+
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.concurrent.TimeUnit
+
+import akka.cluster.{Cluster, MemberStatus}
+import akka.util.Timeout
+import io.radicalbit.nsdb.actors.PublisherActor.Events.{RecordsPublished, SubscribedByQueryString}
+import io.radicalbit.nsdb.api.scala.NSDB
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.minicluster.MiniClusterSpec
+import io.radicalbit.nsdb.minicluster.converters.BitConverters.BitConverter
+import io.radicalbit.nsdb.minicluster.ws.WebSocketClient
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext}
+
+class PublishSubscribeClusterSpec extends MiniClusterSpec {
+
+  override val nodesNumber: Int = 2
+
+  implicit val timeout: Timeout = Timeout(5, TimeUnit.SECONDS)
+
+  lazy val bit = Bit(timestamp = System.currentTimeMillis(),
+                     dimensions = Map("city" -> "Mouseton", "gender" -> "F"),
+                     value = 2,
+                     tags = Map.empty)
+
+  test("join cluster") {
+    assert(
+      Cluster(minicluster.nodes.head.system).state.members
+        .count(_.status == MemberStatus.Up) == minicluster.nodes.size)
+  }
+
+  test("subscribe to a query and receive real time updates") {
+    val firstNode  = minicluster.nodes.head
+    val secondNode = minicluster.nodes.last
+
+    val nsdbFirstNode =
+      Await.result(NSDB.connect(host = "127.0.0.1", port = firstNode.grpcPort)(ExecutionContext.global), 10.seconds)
+    val nsdbSecondNode =
+      Await.result(NSDB.connect(host = "127.0.0.1", port = secondNode.grpcPort)(ExecutionContext.global), 10.seconds)
+
+    val firstNodeWsClient  = new WebSocketClient("localhost", firstNode.httpPort)
+    val secondNodeWsClient = new WebSocketClient("localhost", firstNode.httpPort)
+
+    Await.result(nsdbFirstNode.write(bit.asApiBit("db", "namespace", "metric1")), 10.seconds)
+    Await.result(nsdbSecondNode.write(bit.asApiBit("db", "namespace", "metric2")), 10.seconds)
+
+    waitIndexing()
+
+    //subscription phase
+    firstNodeWsClient.subscribe("db", "namespace", "metric1")
+
+    val firstSubscriptionBuffer = firstNodeWsClient.receivedBuffer()
+
+    assert(firstSubscriptionBuffer.length == 1)
+
+    val y = parse(firstSubscriptionBuffer.head.asTextMessage.getStrictText)
+    val x = (parse(firstSubscriptionBuffer.head.asTextMessage.getStrictText) \ "records")
+
+    val z = y.extractOpt[Seq[SubscribedByQueryString]]
+
+    val firstSubscribedResponse =  (parse(firstSubscriptionBuffer.head.asTextMessage.getStrictText) \ "records").extractOpt[Seq[Bit]]
+    assert(firstSubscribedResponse.isDefined)
+    assert(firstSubscribedResponse.get.size == 1)
+    assert(firstSubscribedResponse.get.head.timelessEquals(bit))
+
+    secondNodeWsClient.subscribe("db", "namespace", "metric2")
+
+    val secondSubscriptionBuffer = secondNodeWsClient.receivedBuffer()
+
+    assert(secondSubscriptionBuffer.length == 1)
+
+    val secondSubscribedResponse =  parse(secondSubscriptionBuffer.head.asTextMessage.getStrictText).extractOpt[SubscribedByQueryString]
+    assert(secondSubscribedResponse.isDefined)
+    assert(secondSubscribedResponse.get.records.size == 1)
+    assert(secondSubscribedResponse.get.records.head.timelessEquals(bit))
+
+    //streaming phase
+    Await.result(nsdbFirstNode.write(bit.asApiBit("db", "namespace", "metric1")), 10.seconds)
+    Await.result(nsdbSecondNode.write(bit.asApiBit("db", "namespace", "metric2")), 10.seconds)
+
+
+    val firstStreamingBuffer = firstNodeWsClient.receivedBuffer()
+    assert(firstStreamingBuffer.length == 1)
+
+    val firstStreamingResponse =  parse(firstStreamingBuffer.head.asTextMessage.getStrictText).extractOpt[RecordsPublished]
+
+    assert(firstStreamingResponse.isDefined)
+    assert(firstStreamingResponse.get.records.size == 1)
+    assert(firstStreamingResponse.get.records.head.timelessEquals(bit))
+
+    val secondStreamingBuffer = secondNodeWsClient.receivedBuffer()
+
+    assert(firstSubscriptionBuffer.length == 1)
+
+    val secondStreamingResponse =  parse(secondStreamingBuffer.head.asTextMessage.getStrictText).extractOpt[RecordsPublished]
+
+    assert(secondStreamingResponse.isDefined)
+    assert(secondStreamingResponse.get.records.size == 1)
+    assert(secondStreamingResponse.get.records.head.timelessEquals(bit))
+
+  }
+
+  test("support cross-node subscription and publishing") {
+    val firstNode  = minicluster.nodes.head
+    val secondNode = minicluster.nodes.last
+
+    val nsdbFirstNode =
+      Await.result(NSDB.connect(host = "127.0.0.1", port = firstNode.grpcPort)(ExecutionContext.global), 10.seconds)
+    val nsdbSecondNode =
+      Await.result(NSDB.connect(host = "127.0.0.1", port = secondNode.grpcPort)(ExecutionContext.global), 10.seconds)
+
+    val firstNodeWsClient  = new WebSocketClient("localhost", firstNode.httpPort)
+    val secondNodeWsClient = new WebSocketClient("localhost", firstNode.httpPort)
+
+    //subscription phase
+    firstNodeWsClient.subscribe("db", "namespace", "metric1")
+
+    assert(firstNodeWsClient.receivedBuffer().length == 1)
+
+    secondNodeWsClient.subscribe("db", "namespace", "metric2")
+
+    assert(secondNodeWsClient.receivedBuffer().length == 1)
+
+    //streaming phase
+    Await.result(nsdbSecondNode.write(bit.asApiBit("db", "namespace", "metric1")), 10.seconds)
+    Await.result(nsdbFirstNode.write(bit.asApiBit("db", "namespace", "metric2")), 10.seconds)
+
+    assert(firstNodeWsClient.receivedBuffer().length == 1)
+
+    assert(secondNodeWsClient.receivedBuffer().length == 1)
+  }
+}

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/cluster/WriteCoordinatorClusterSpec.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/cluster/WriteCoordinatorClusterSpec.scala
@@ -59,7 +59,7 @@ class WriteCoordinatorClusterSpec extends MiniClusterSpec {
       .dimension("city", "Mouseton")
       .dimension("notimportant", None)
       .dimension("Someimportant", Some(2))
-      .dimension("gender", "M")
+      .tag("gender", "M")
       .dimension("bigDecimalLong", new java.math.BigDecimal("12"))
       .dimension("bigDecimalDouble", new java.math.BigDecimal("12.5"))
       .dimension("OptionBigDecimal", Some(new java.math.BigDecimal("15.5")))

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/MiniClusterSpec.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/MiniClusterSpec.scala
@@ -1,9 +1,12 @@
 package io.radicalbit.nsdb.minicluster
-import org.scalatest.{BeforeAndAfterAll, FunSuite, OneInstancePerTest, Sequential}
+import org.json4s.DefaultFormats
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 trait MiniClusterSpec extends FunSuite with BeforeAndAfterAll {
 
   val nodesNumber: Int
+
+  implicit val formats = DefaultFormats
 
   lazy val minicluster: NsdbMiniCluster = new MiniClusterStarter(nodesNumber)
 

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NsdbMiniCluster.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NsdbMiniCluster.scala
@@ -44,12 +44,13 @@ trait NsdbMiniCluster extends LazyLogging {
         dataDir = s"$rootFolder/data${startingAkkaRemotePort + i}"
       )).toSet
 
-  def start(cleanup: Boolean = false) = {
+  def start(cleanup: Boolean = false): Unit = {
     if (cleanup)
       FileUtils.deleteDirectory(new File(rootFolder))
     nodes
     Thread.sleep(5000)
   }
+
   def stop(): Unit = {
     import scala.concurrent.duration._
     nodes.foreach(n => Await.result(n.system.terminate(), 10.seconds))

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/ws/SynchronizedBuffer.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/ws/SynchronizedBuffer.scala
@@ -1,0 +1,29 @@
+package io.radicalbit.nsdb.minicluster.ws
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.collection.mutable.ListBuffer
+
+trait SynchronizedBuffer[T] {
+
+  private[this] val buffer = new AtomicReference(ListBuffer[T]())
+
+  def accumulate(fn: T): Unit = {
+    update(_ += fn)
+  }
+
+  def pop(ref: T): Unit = {
+    update(_ -= ref)
+  }
+
+  def clearBuffer() = buffer.compareAndSet(buffer.get(), ListBuffer.empty)
+
+  def getBuffer() = buffer.get()
+
+  private[this] def update(fn: ListBuffer[T] => ListBuffer[T]): Unit = {
+    while (true) {
+      val listenerMap = buffer.get()
+      if (buffer.compareAndSet(listenerMap, fn(listenerMap)))
+        return // success
+    }
+  }
+}

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/ws/WebSocketClient.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/ws/WebSocketClient.scala
@@ -12,6 +12,11 @@ import com.typesafe.scalalogging.LazyLogging
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
 
+/**
+  * Utility class that creates a WebSocket with convenience methods to subscribe to a NSDb query
+  * @param host the host to connect to
+  * @param port the port to connect to
+  */
 class WebSocketClient(host: String, port: Int) extends LazyLogging with SynchronizedBuffer[Message] {
   implicit val system       = ActorSystem()
   implicit val materializer = ActorMaterializer()
@@ -25,7 +30,7 @@ class WebSocketClient(host: String, port: Int) extends LazyLogging with Synchron
   val messageSink: Sink[Message, NotUsed] =
     Flow[Message]
       .map { message =>
-        logger.info(s"Received text message: [$message]")
+        logger.debug(s"Received text message: [$message]")
         accumulate(message)
       }
       .to(Sink.ignore)
@@ -51,7 +56,7 @@ class WebSocketClient(host: String, port: Int) extends LazyLogging with Synchron
   def receivedBuffer(clear: Boolean = true): ListBuffer[Message] = {
     Thread.sleep(1000)
 
-    val buf = getBuffer()
+    val buf = buffer
     if (clear) clearBuffer()
     buf
   }

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/ws/WebSocketClient.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/ws/WebSocketClient.scala
@@ -1,0 +1,69 @@
+package io.radicalbit.nsdb.minicluster.ws
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.ws._
+import akka.stream.scaladsl._
+import akka.stream.{ActorMaterializer, OverflowStrategy}
+import akka.{Done, NotUsed}
+import com.typesafe.scalalogging.LazyLogging
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.Future
+
+class WebSocketClient(host: String, port: Int) extends LazyLogging with SynchronizedBuffer[Message] {
+  implicit val system       = ActorSystem()
+  implicit val materializer = ActorMaterializer()
+  import system.dispatcher
+  val req           = WebSocketRequest(uri = s"ws://$host:$port/ws-stream")
+  val webSocketFlow = Http().webSocketClientFlow(req)
+
+  val messageSource: Source[Message, ActorRef] =
+    Source.actorRef[TextMessage.Strict](bufferSize = 10, OverflowStrategy.fail)
+
+  val messageSink: Sink[Message, NotUsed] =
+    Flow[Message]
+      .map { message =>
+        logger.info(s"Received text message: [$message]")
+        accumulate(message)
+      }
+      .to(Sink.ignore)
+
+  val ((ws, upgradeResponse), closed) =
+    messageSource
+      .viaMat(webSocketFlow)(Keep.both)
+      .toMat(messageSink)(Keep.both)
+      .run()
+
+  val connected = upgradeResponse.flatMap { upgrade =>
+    if (upgrade.response.status == StatusCodes.SwitchingProtocols) {
+      Future.successful(Done)
+    } else {
+      throw new RuntimeException(s"Connection failed: ${upgrade.response.status}")
+    }
+  }
+
+  def send(msg: String): Unit = {
+    ws ! TextMessage.Strict(msg)
+  }
+
+  def receivedBuffer(clear: Boolean = true): ListBuffer[Message] = {
+    Thread.sleep(1000)
+
+    val buf = getBuffer()
+    if (clear) clearBuffer()
+    buf
+  }
+
+  def subscribe(db: String, namespace: String, metric: String): Unit =
+    ws ! TextMessage.Strict(
+      s"""{"db":"$db","namespace":"$namespace","metric":"$metric","queryString":"select * from $metric limit 1"}""")
+}
+
+object WebSocketClient extends App {
+
+  val x = new WebSocketClient("localhost", 9010)
+
+  x.subscribe("db", "namespace", "metirc")
+}

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/ws/WebSocketClient.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/ws/WebSocketClient.scala
@@ -60,10 +60,3 @@ class WebSocketClient(host: String, port: Int) extends LazyLogging with Synchron
     ws ! TextMessage.Strict(
       s"""{"db":"$db","namespace":"$namespace","metric":"$metric","queryString":"select * from $metric limit 1"}""")
 }
-
-object WebSocketClient extends App {
-
-  val x = new WebSocketClient("localhost", 9010)
-
-  x.subscribe("db", "namespace", "metirc")
-}


### PR DESCRIPTION
This PR is for making the previous single node publish-subscribe feature support cluster by basically extending the high level gossip protocol for data and commit logs actor also for publisher actors.
When a a write event comes into the system, it will be spreaded across all the publishers, hence, regardless of which node is subscribed to a specific query, every event received on any node will be properly published 