### PR TITLE
Tags support in kafka connect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,11 @@ version: '3'
 services:
 
     nsdb:
-      image: tools.radicalbit.io/nsdb:0.6.0-SNAPSHOT
+      image: tools.radicalbit.io/nsdb:0.7.0-SNAPSHOT
       volumes:
         - ./nsdb-cluster/src/main/resources:/opt/nsdb-cluster/conf
-        - ./data:/opt/nsdb-cluster/data
-        - ./ext-lib:/opt/nsdb-cluster/ext-lib
+        - ./data:/opt/nsdb/data
+        - ./ext-lib:/opt/nsdb/ext-lib
         - ./certs:/opt/certs
       ports:
         - 9443:9443

--- a/docs/SQL_doc.md
+++ b/docs/SQL_doc.md
@@ -135,7 +135,7 @@ FROM <metric_name>
 [GROUP BY <dimension_name>]
 ```
 If the query includes a `WHERE`  clause the `GROUP BY` clause must appear after the `WHERE` clause.
-> NOTE: `GROUP BY` clause accepts a **single** dimension/field on which apply the grouping
+> NOTE: `GROUP BY` clause accepts a **single** tag/field on which apply the grouping. It is not possible to use a dimension for grouping.
 
 When defining a `GROUP BY` clause **value functions** can be defined in `SELECT` clause.
 
@@ -214,9 +214,10 @@ By the way there are some small differences meant in time-series concept that in
 ### Simple Syntax
 
  ```sql
- INSERT INTO <metric_name> [TS=<timestamp_value>] DIM ( [<dimension_name> = <dimension_value>*] ) VAL = <value>
+ INSERT INTO <metric_name> [TS=<timestamp_value>] DIM ( [<dimension_name> = <dimension_value>*] ) TAGS ( [<tag_name> = <tag_value>*] ) VAL = <value>
  ```
- The above mentioned syntax inserts a single Bit whose dimensions tuples  `(name, value)` are declared after `DIM` clause. Value field is assigned using `VAL` clause , that accepts a numerical value.
+ The above mentioned syntax inserts a single Bit whose dimensions tuples  `(name, value)` are declared after `DIM` clause and tag tuples after `TAGS` clause.
+ Value field is assigned using `VAL` clause , that accepts a numerical value.
  Timestamp index definition is not mandatory, but it can be defined using `TS` clause.
 
  > NOTE: , if  `TS` clause's value is not defined, it is assigned the epoch-timestamp of the istant the insertion is performed .

--- a/docs/Websocket.md
+++ b/docs/Websocket.md
@@ -31,8 +31,7 @@ In order to subscribe a query, after connection is being opened, user has to sen
     "db": "[string]",
     "namespace": "[string]",
     "metric": "[string]",
-    "queryString" : "[string]",
-    "filters": "[optional array of Filter]"
+    "queryString" : "[string]"
 }
 ```
 
@@ -43,13 +42,7 @@ In order to subscribe a query, after connection is being opened, user has to sen
     "db": "db",
     "namespace": "namespace",
     "metric": "metric",
-    "queryString" : "select * from metric limit 1",
-    "filters": [{ "dimension": "dimName1",
-                  "value" : "value",
-                  "operator": "=" },
-                { "dimension": "dimName2",
-                  "value" : 1,
-                  "operator": ">=" }]
+    "queryString" : "select * from metric limit 1"
 }
 ```
 

--- a/nsdb-cluster/src/main/resources/cluster.conf
+++ b/nsdb-cluster/src/main/resources/cluster.conf
@@ -128,6 +128,7 @@ nsdb {
     directory = "/tmp/"
     // Size expressed in KB
     max-size = 10000000
+    check-interval = 30 seconds
   }
 
   cluster{

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
@@ -35,7 +35,7 @@ class NsdbNodeEndpoint(readCoordinator: ActorRef,
 
   override val config: Config = system.settings.config
 
-  override protected val logger: LoggingAdapter = Logging.getLogger(system, this)
+  override protected implicit val logger: LoggingAdapter = Logging.getLogger(system, this)
 
   new GrpcEndpoint(readCoordinator = readCoordinator,
                    writeCoordinator = writeCoordinator,

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
@@ -143,7 +143,8 @@ class MetricsDataActor(val basePath: String, val nodeName: String, localWriteCoo
         case Some(child) => child forward msg
         case None        => sender() ! SelectStatementExecuted(statement.db, statement.namespace, statement.metric, Seq.empty)
       }
-    case AddRecordToLocation(db, namespace, bit, location) =>
+    case msg @ AddRecordToLocation(db, namespace, bit, location) =>
+      log.debug("received message {}", msg)
       getOrCreateChildren(db, namespace)._2
         .forward(AddRecordToShard(db, namespace, Location(location.metric, nodeName, location.from, location.to), bit))
     case DeleteRecordFromLocation(db, namespace, bit, location) =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -136,8 +136,11 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
                                         schema: Schema,
                                         uniqueLocationsByNode: Map[String, Seq[Location]])(
       aggregationFunction: Seq[Bit] => Bit): Future[Either[SelectStatementFailed, Seq[Bit]]] =
-    gatherNodeResults(statement, schema, uniqueLocationsByNode)(seq =>
-      seq.groupBy(_.tags(groupBy)).map(m => aggregationFunction(m._2)).toSeq)
+    gatherNodeResults(statement, schema, uniqueLocationsByNode) {
+      case seq if uniqueLocationsByNode.size > 1 =>
+        seq.groupBy(_.tags(groupBy)).map(m => aggregationFunction(m._2)).toSeq
+      case seq => seq
+    }
 
   /**
     * Initial state in which actor waits metadata warm-up completion.

--- a/nsdb-core/src/main/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetSumDoubleAssociations.java
+++ b/nsdb-core/src/main/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetSumDoubleAssociations.java
@@ -71,7 +71,7 @@ public class TaxonomyFacetSumDoubleAssociations extends DoubleTaxonomyFacets{
                                 ((bytes[offset + 2] & 0xFF) << 8) |
                                 (bytes[offset + 3] & 0xFF);
                         offset += 4;
-                        byte[] doubleBytes = Arrays.copyOfRange(bytes, 4, bytes.length);
+                        byte[] doubleBytes = Arrays.copyOfRange(bytes, offset, bytes.length);
 
                         offset += 8;
                         values[ord] += DoublePoint.decodeDimension(doubleBytes, 0);

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
@@ -161,8 +161,9 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
       postProcFun: Seq[Bit] => Seq[Bit]): Future[Either[SelectStatementFailed, Seq[Bit]]] = {
     Future
       .sequence(actors.map {
-        case (_, actor) => (actor ? ExecuteSelectStatement(statement, schema, actors.map(_._1)))
-          .recoverWith{case t => Future(SelectStatementFailed(t.getMessage))}
+        case (_, actor) =>
+          (actor ? ExecuteSelectStatement(statement, schema, actors.map(_._1)))
+            .recoverWith { case t => Future(SelectStatementFailed(t.getMessage)) }
       })
       .map { e =>
         val errs = e.collect { case a: SelectStatementFailed => a }

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
@@ -17,6 +17,7 @@
 package io.radicalbit.nsdb.web
 
 import akka.actor.ActorRef
+import akka.event.LoggingAdapter
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
@@ -89,7 +90,7 @@ object Formats extends DefaultJsonProtocol with SprayJsonSupport {
 class ApiResources(val publisherActor: ActorRef,
                    val readCoordinator: ActorRef,
                    val writeCoordinator: ActorRef,
-                   val authenticationProvider: NSDBAuthProvider)(implicit val timeout: Timeout)
+                   val authenticationProvider: NSDBAuthProvider)(implicit val timeout: Timeout, logger: LoggingAdapter)
     extends CommandApi
     with QueryApi
     with DataApi {

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
@@ -19,6 +19,7 @@ package io.radicalbit.nsdb.web
 import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorRef
+import akka.event.LoggingAdapter
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
@@ -34,7 +35,7 @@ import scala.concurrent.Await
 import scala.util.{Failure, Success}
 
 /**
-  * Instantiate Nsdb Http Server exposing apis defined in [[ApiResources]]
+  * Instantiate NSDb Http Server exposing apis defined in [[ApiResources]]
   * If SSL/TLS protocol is enable in [[SSLSupport]] an Https server is started instead Http ones.
   */
 trait WebResources extends StaticResources with WsResources with CorsSupport with SSLSupport { this: NsdbSecurity =>
@@ -48,7 +49,8 @@ trait WebResources extends StaticResources with WsResources with CorsSupport wit
   implicit lazy val httpTimeout: Timeout =
     Timeout(config.getDuration("nsdb.http-endpoint.timeout", TimeUnit.SECONDS), TimeUnit.SECONDS)
 
-  def initWebEndpoint(writeCoordinator: ActorRef, readCoordinator: ActorRef, publisher: ActorRef) =
+  def initWebEndpoint(writeCoordinator: ActorRef, readCoordinator: ActorRef, publisher: ActorRef)(
+      implicit logger: LoggingAdapter) =
     authProvider match {
       case Success(provider) =>
         val api: Route = wsResources(publisher, provider) ~ new ApiResources(

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
@@ -114,11 +114,11 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
   }
 
   val testRoutes = Route.seal(
-    emptyQueryApi.queryApi
+    emptyQueryApi.queryApi()(system.log)
   )
 
   val testSecuredRoutes = Route.seal(
-    secureQueryApi.queryApi
+    secureQueryApi.queryApi()(system.log)
   )
 
   "QueryApi" should "not allow get" in {

--- a/nsdb-kafka-connect/README.md
+++ b/nsdb-kafka-connect/README.md
@@ -34,7 +34,8 @@ The NSDb sink supports KCQL, [Kafka Connect Query Language](https://github.com/L
 
 The following capabilites can be achieved using KCQL:
 
-- Dimensions selection and mapping
+- Dimensions and tags selection and mapping
+- Tags selection among the mapping above
 - Value mapping
 - Timestamp Mapping
 - Target bit selection
@@ -47,8 +48,8 @@ INSERT INTO bitA SELECT x AS a, y AS value FROM topicA WITHTIMESTAMP z
 -- Select field x as dimension a, field z as dimension c, field y as value and the current time as the timestamp from topicB to bitB
 INSERT INTO bitB SELECT x AS a, y AS value, z as c FROM topicB WITHTIMESTAMP sys_time()
 
--- Select field d as the db, field n as the namespace, field x as dimension a, field z as dimension c, field y as value and the current time as the timestamp from topicB to bitB
-INSERT INTO bitC SELECT d as db, n as namespace, x AS a, y AS value, z as c FROM topicC WITHTIMESTAMP sys_time()
+-- Select field d as the db, field n as the namespace, field x as tag a, field z as tag b, field t as dimension c, field y as value and the current time as the timestamp from topicC to bitC
+INSERT INTO bitC SELECT d as db, n as namespace, x AS a, y AS value, z as b, t as c FROM topicC WITHTIMESTAMP sys_time() WITHTAG(a,b)
 ```
 
 ## example
@@ -60,6 +61,6 @@ echo '{"name":"manufacturing-nsdb-sink",
 "nsdb.kcql":
 "INSERT INTO bitA SELECT x AS a, y AS value FROM topicA WITHTIMESTAMP z;
  INSERT INTO bitB SELECT x AS a, y AS value, z as c FROM topicB WITHTIMESTAMP sys_time();
- INSERT INTO bitC SELECT d as db, n as namespace, x AS a, y AS value, z as c FROM topicC WITHTIMESTAMP sys_time()"
+ INSERT INTO bitC SELECT d as db, n as namespace, x AS a, y AS value, z as b, t as c FROM topicC WITHTIMESTAMP sys_time() WITHTAG(a,b)"
 }}' | curl -X POST -d @- http://kafkaconnecthost:8083/connectors --header "content-Type:application/json"
 ```

--- a/nsdb-kafka-connect/docker-compose.yml
+++ b/nsdb-kafka-connect/docker-compose.yml
@@ -123,11 +123,11 @@ services:
 
   nsdb:
       hostname: nsdb
-      image: tools.radicalbit.io/nsdb-cluster:0.1.3-SNAPSHOT
+      image: tools.radicalbit.io/nsdb:0.7.0-SNAPSHOT
       volumes:
         - ../nsdb-cluster/src/main/resources:/opt/nsdb-cluster/conf
-        - ./data:/opt/nsdb-cluster/data
-        - ./lib:/opt/nsdb-cluster/ext-lib
+        - ./data:/opt/nsdb/data
+        - ./lib:/opt/nsdb/ext-lib
         - ./certs:/opt/certs
       ports:
         - 9443:9443

--- a/nsdb-kafka-connect/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NsdbSinkTask.scala
+++ b/nsdb-kafka-connect/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NsdbSinkTask.scala
@@ -53,7 +53,7 @@ class NsdbSinkTask extends SinkTask {
         kcqls = props.get(NsdbConfigs.NSDB_KCQL).split(";").map(Kcql.parse).groupBy(_.getSource),
         globalDb = Option(props.get(NsdbConfigs.NSDB_DB)),
         globalNamespace = Option(props.get(NsdbConfigs.NSDB_NAMESPACE)),
-        defaultValue = Option(props.get(NsdbConfigs.NSDB_DEFAULT_VALUE))
+        defaultValueStr = Option(props.get(NsdbConfigs.NSDB_DEFAULT_VALUE))
       ))
   }
 

--- a/nsdb-kafka-connect/src/test/scala/io/radicalbit/nsdb/connector/kafka/sink/ParsedKcqlSpec.scala
+++ b/nsdb-kafka-connect/src/test/scala/io/radicalbit/nsdb/connector/kafka/sink/ParsedKcqlSpec.scala
@@ -46,7 +46,7 @@ class ParsedKcqlSpec extends FlatSpec with Matchers with OneInstancePerTest {
     ParsedKcql("INSERT INTO metric SELECT x AS db, y AS namespace, z AS value FROM topic WITHTIMESTAMP y",
                None,
                None,
-               None) shouldBe ParsedKcql("x", "y", "metric", None, Map("value" -> "z", "timestamp" -> "y"))
+               None) shouldBe ParsedKcql("x", "y", "metric", None, Some("y"), Some("z"), Map.empty, Map.empty)
   }
 
   "KcqlFields" should "accept kcqls without db and namespace mapping but with global configs instead" in {
@@ -55,7 +55,10 @@ class ParsedKcqlSpec extends FlatSpec with Matchers with OneInstancePerTest {
       "y",
       "metric",
       None,
-      Map("value" -> "z", "timestamp" -> "y"))
+      Some("y"),
+      Some("z"),
+      Map.empty,
+      Map.empty)
   }
 
   "KcqlFields" should "successfully convert queries with or without aliases" in {
@@ -65,27 +68,36 @@ class ParsedKcqlSpec extends FlatSpec with Matchers with OneInstancePerTest {
                                                                        "y",
                                                                        "metric",
                                                                        None,
-                                                                       Map("value" -> "z", "timestamp" -> "y"))
+                                                                       Some("y"),
+                                                                       Some("z"),
+                                                                       Map.empty,
+                                                                       Map.empty)
 
     val withDimensionNoAlias =
       "INSERT INTO metric SELECT x AS db, y AS namespace, z AS value, d FROM topic WITHTIMESTAMP t"
 
-    ParsedKcql(withDimensionNoAlias, None, None, None) shouldBe ParsedKcql(
-      "x",
-      "y",
-      "metric",
-      None,
-      Map("value" -> "z", "timestamp" -> "t", "d" -> "d"))
+    ParsedKcql(withDimensionNoAlias, None, None, None) shouldBe ParsedKcql("x",
+                                                                           "y",
+                                                                           "metric",
+                                                                           None,
+                                                                           Some("t"),
+                                                                           Some("z"),
+                                                                           Map.empty,
+                                                                           Map("d" -> "d"))
 
     val withDimensionAlias =
       "INSERT INTO metric SELECT x AS db, y AS namespace, z AS value, d as dimension FROM topic WITHTIMESTAMP y"
 
-    ParsedKcql(withDimensionAlias, None, None, None) shouldBe ParsedKcql(
-      "x",
-      "y",
-      "metric",
-      None,
-      Map("value" -> "z", "timestamp" -> "y", "dimension" -> "d"))
+    ParsedKcql(withDimensionAlias, None, None, None) shouldBe ParsedKcql("x",
+                                                                         "y",
+                                                                         "metric",
+                                                                         None,
+                                                                         Some("y"),
+                                                                         Some("z"),
+                                                                         Map.empty,
+                                                                         Map("dimension" -> "d"))
   }
+
+  "KcqlFields" should "successfully support tags" in {}
 
 }

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -32,7 +32,7 @@ import scala.util.parsing.input.CharSequenceReader
   * Here is the (simplified) EBNF grammar supported by Nsdb Parser.
   * {{{
   *   S := InsertStatement | SelectStatement | DeleteStatement | DropStatement
-  *   InsertStatement := "insert into" literal ("ts =" digit)? "dim" "(" (literal = literal)+ ")" "VAL" = digit
+  *   InsertStatement := "insert into" literal ("ts =" digit)? "dim" "(" (literal = literal)+ ")" "tags" "(" (literal = literal)+ ")" "VAL" = digit
   *   DropStatement := "drop metric" literal
   *   DeleteStatement := "delete" "from" literal ("where" expression)?
   *   SelectStatement := "select" "distinct"? selectFields "from" literal ("where" expression)? ("group by" literal)? ("order by" literal ("desc")?)? (limit digit)?

--- a/version.sbt
+++ b/version.sbt
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-version in ThisBuild := "0.6.0-SNAPSHOT"
+version in ThisBuild := "0.7.0-SNAPSHOT"


### PR DESCRIPTION
This PR allows the kafka connect users to specify if a mapped dimension is a tag or not.
This has made possible by the `WITHTAGS` syntactic construct provided by the KCQL library.