### PR TITLE
[hotfix] scala 2.11 compilation

### DIFF
--- a/nsdb-cluster/src/main/resources/cluster.conf
+++ b/nsdb-cluster/src/main/resources/cluster.conf
@@ -128,6 +128,7 @@ nsdb {
     directory = "/tmp/"
     // Size expressed in KB
     max-size = 10000000
+    check-interval = 30 seconds
   }
 
   cluster{

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,7 @@ object Dependencies {
   }
 
   object akka {
-    lazy val version   = "2.5.14"
+    lazy val version   = "2.5.16"
     lazy val namespace = "com.typesafe.akka"
 
     lazy val actor           = namespace %% "akka-actor"              % version
@@ -264,7 +264,8 @@ object Dependencies {
     lazy val libraries = Seq(
       scala_logging.scala_logging,
       akka.actor,
-      akka_http.default
+      akka_http.default,
+      akka.stream
     )
   }
 


### PR DESCRIPTION
In order to get the artifacts correctly generated under scala 2.11, it's been necessary to remove some scala 2.12 specific implementations and dependencies usage