### PR TITLE
Introduce Retry mechanism in persistence 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val root = project
   .in(file("."))
   .settings(
     name := "nsdb",
-    crossScalaVersions := Seq("2.11.11", "2.12.6"),
+    crossScalaVersions := Seq("2.11.11", "2.12.7"),
     publish := {},
     publishLocal := {}
   )

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val root = project
   .in(file("."))
   .settings(
     name := "nsdb",
-    crossScalaVersions := Seq("2.11.11", "2.12.4"),
+    crossScalaVersions := Seq("2.11.11", "2.12.6"),
     publish := {},
     publishLocal := {}
   )

--- a/nsdb-cluster/src/main/resources/cluster.conf
+++ b/nsdb-cluster/src/main/resources/cluster.conf
@@ -153,6 +153,10 @@ nsdb {
     }
   }
 
+  write {
+    retry-attempts = 10
+  }
+
   global.timeout = 30 seconds
   global.timeout = ${?GLOBAL_TIMEOUT}
   http-endpoint.timeout = 60 seconds

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
@@ -36,7 +36,7 @@ import scala.concurrent.duration._
   * @param metadataCache the global metadata cache actor.
   * @param schemaCache the global schema cache actor.
   */
-class ClusterListener(metadataCache: ActorRef, schemaCache: ActorRef) extends Actor with ActorLogging {
+class ClusterListener(nodeActorsGuardianProps: Props) extends Actor with ActorLogging {
 
   val cluster = Cluster(context.system)
 
@@ -65,9 +65,8 @@ class ClusterListener(metadataCache: ActorRef, schemaCache: ActorRef) extends Ac
       val indexBasePath = config.getString("nsdb.index.base-path")
 
       val nodeActorsGuardian =
-        context.system.actorOf(
-          NodeActorsGuardian.props(metadataCache, schemaCache).withDeploy(Deploy(scope = RemoteScope(member.address))),
-          name = s"guardian_$nodeName")
+        context.system.actorOf(nodeActorsGuardianProps.withDeploy(Deploy(scope = RemoteScope(member.address))),
+                               name = s"guardian_$nodeName")
 
       (nodeActorsGuardian ? GetNodeChildActors)
         .map {
@@ -106,6 +105,6 @@ class ClusterListener(metadataCache: ActorRef, schemaCache: ActorRef) extends Ac
 
 object ClusterListener {
 
-  def props(metadataCache: ActorRef, schemaCache: ActorRef) =
-    Props(new ClusterListener(metadataCache, schemaCache))
+  def props(nodeActorsGuardianProps: Props) =
+    Props(new ClusterListener(nodeActorsGuardianProps))
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
@@ -183,8 +183,8 @@ object MetricsDataActor {
                       enclosingConfig.getInt("upper-bound"))
   }
 
-  def props(basePath: String, nodeName: String, localWriteCoordinator: ActorRef): Props =
-    Props(new MetricsDataActor(basePath, nodeName, localWriteCoordinator))
+  def props(basePath: String, nodeName: String, localCommitLogCoordinator: ActorRef): Props =
+    Props(new MetricsDataActor(basePath, nodeName, localCommitLogCoordinator))
 
   case class AddRecordToLocation(db: String, namespace: String, bit: Bit, location: Location)
   case class DeleteRecordFromLocation(db: String, namespace: String, bit: Bit, location: Location)

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -97,7 +97,7 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
   lazy val metadataCache = Await.result((guardian ? GetMetadataCache).mapTo[ActorRef], 5.seconds)
   lazy val schemaCache   = Await.result((guardian ? GetSchemaCache).mapTo[ActorRef], 5.seconds)
 
-  system.actorOf(ClusterListener.props(metadataCache, schemaCache), name = "clusterListener")
+  system.actorOf(ClusterListener.props(NodeActorsGuardian.props(metadataCache, schemaCache)), name = "clusterListener")
 
   lazy val nodeName = s"${cluster.selfAddress.host.getOrElse("noHost")}_${cluster.selfAddress.port.getOrElse(2552)}"
 

--- a/nsdb-cluster/src/test/resources/application.conf
+++ b/nsdb-cluster/src/test/resources/application.conf
@@ -56,6 +56,10 @@ nsdb {
     }
   }
 
+  write {
+    retry-attempts = 10
+  }
+
   read-coordinator.timeout = 30 seconds
   metadata-coordinator.timeout = 30 seconds
   write-coordinator.timeout = 30 seconds

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
@@ -49,7 +49,7 @@ class MetricAccumulatorActor(val basePath: String,
                              val db: String,
                              val namespace: String,
                              val readerActor: ActorRef,
-                             val localWriteCoordinator: ActorRef)
+                             val localCommitLogCoordinator: ActorRef)
     extends ActorPathLogging
     with MetricsActor {
 
@@ -97,7 +97,7 @@ class MetricAccumulatorActor(val basePath: String,
     * Any existing shard is retrieved, the [[MetricPerformerActor]] is initialized and actual writes are scheduled.
     */
   override def preStart: Unit = {
-    performerActor = context.actorOf(MetricPerformerActor.props(basePath, db, namespace, localWriteCoordinator),
+    performerActor = context.actorOf(MetricPerformerActor.props(basePath, db, namespace, localCommitLogCoordinator),
                                      s"shard-performer-service-$db-$namespace")
 
     context.system.scheduler.schedule(0.seconds, interval) {
@@ -214,6 +214,6 @@ object MetricAccumulatorActor {
             db: String,
             namespace: String,
             readerActor: ActorRef,
-            localWriteCoordinator: ActorRef): Props =
-    Props(new MetricAccumulatorActor(basePath, db, namespace, readerActor, localWriteCoordinator))
+            localCommitLogCoordinator: ActorRef): Props =
+    Props(new MetricAccumulatorActor(basePath, db, namespace, readerActor, localCommitLogCoordinator))
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
@@ -191,6 +191,6 @@ object MetricPerformerActor {
   case class PersistedBit(db: String, namespace: String, metric: String, timestamp: Long, bit: Bit, location: Location)
   case object PersistedBitsAck
 
-  def props(basePath: String, db: String, namespace: String, localWriteCoordinator: ActorRef): Props =
-    Props(new MetricPerformerActor(basePath, db, namespace, localWriteCoordinator))
+  def props(basePath: String, db: String, namespace: String, localCommitLogCoordinator: ActorRef): Props =
+    Props(new MetricPerformerActor(basePath, db, namespace, localCommitLogCoordinator))
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricsActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricsActor.scala
@@ -63,16 +63,16 @@ trait MetricsActor { this: Actor =>
 
   /**
     * Retrieves or creates an index for the given [[Location]]
-    * @param key the key containing the metric and the time interval to identify the index to retrieve or create
+    * @param loc the location containing the metric and the time interval to identify the index to retrieve or create
     * @return the index for the key
     */
-  protected def getIndex(key: Location): TimeSeriesIndex =
+  protected def getIndex(loc: Location): TimeSeriesIndex =
     shards.getOrElse(
-      key, {
+      loc, {
         val directory =
-          new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${key.metric}_${key.from}_${key.to}"))
+          new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${loc.metric}_${loc.from}_${loc.to}"))
         val newIndex = new TimeSeriesIndex(directory)
-        shards += (key -> newIndex)
+        shards += (loc -> newIndex)
         newIndex
       }
     )

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricsActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricsActor.scala
@@ -54,7 +54,7 @@ trait MetricsActor { this: Actor =>
   /**
     * all facet shard indexes for the given db and namespace grouped by [[Location]]
     */
-  protected val facetIndexShards: mutable.Map[Location, AllFacetIndexes] = mutable.Map.empty
+  private[actors] val facetIndexShards: mutable.Map[Location, AllFacetIndexes] = mutable.Map.empty
 
   protected def shardsForMetric(metric: String): mutable.Map[Location, TimeSeriesIndex] =
     shards.filter(_._1.metric == metric)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardOperation.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardOperation.scala
@@ -43,14 +43,14 @@ sealed trait ShardOperation {
   val location: Location
 }
 
-case class DeleteShardRecordOperation(namespace: String, location: Location, bit: Bit) extends ShardOperation
+case class DeleteShardRecordOperation(namespace: String, location: Location, bit: Bit)    extends ShardOperation
 case class DeleteShardQueryOperation(namespace: String, location: Location, query: Query) extends ShardOperation
-case class WriteShardOperation(namespace: String, location: Location, bit: Bit) extends ShardOperation
+case class WriteShardOperation(namespace: String, location: Location, bit: Bit)           extends ShardOperation
 
 object ShardOperation {
 
   /**
-  * Gets the operation that needs to be applied if there is any error performing the input one.
+    * Gets the operation that needs to be applied if there is any error performing the input one.
     * @param action The input action.
     * @return
     */

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardOperation.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardOperation.scala
@@ -41,8 +41,19 @@ sealed trait ShardOperation {
     * operation key. @see ShardKey
     */
   val location: Location
+
+  /**
+    * Operation that needs to be applied if there is any error performing the parent one.
+    */
+  val compensation: Option[ShardOperation]
 }
 
-case class DeleteShardRecordOperation(namespace: String, location: Location, bit: Bit)    extends ShardOperation
-case class DeleteShardQueryOperation(namespace: String, location: Location, query: Query) extends ShardOperation
-case class WriteShardOperation(namespace: String, location: Location, bit: Bit)           extends ShardOperation
+case class DeleteShardRecordOperation(namespace: String, location: Location, bit: Bit) extends ShardOperation {
+  override val compensation: Option[ShardOperation] = None
+}
+case class DeleteShardQueryOperation(namespace: String, location: Location, query: Query) extends ShardOperation {
+  override val compensation: Option[ShardOperation] = None
+}
+case class WriteShardOperation(namespace: String, location: Location, bit: Bit) extends ShardOperation {
+  override val compensation: Option[ShardOperation] = Some(DeleteShardRecordOperation(namespace, location, bit))
+}

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/OrderedTaxonomyFacetCounts.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/OrderedTaxonomyFacetCounts.scala
@@ -53,13 +53,13 @@ class OrderedTaxonomyFacetCounts(
         case Type.LONG   => Ordering.by[LabelAndValue, Long](e => e.value.longValue())
         case Type.INT    => Ordering.by[LabelAndValue, Int](e => e.value.intValue())
         case Type.DOUBLE => Ordering.by[LabelAndValue, Double](e => e.value.doubleValue())
-
+        case _           => Ordering.by[LabelAndValue, String](e => e.label)
       }
       if (isReverse) ordering.reverse else ordering
     }
 
     facetResult.map { fr =>
       new FacetResult(fr.dim, fr.path, fr.value, fr.labelValues.sorted.take(topN), fr.childCount)
-    } getOrElse (new FacetResult(dim, path.toArray, 0, Array.empty, 0))
+    } getOrElse new FacetResult(dim, path.toArray, 0, Array.empty, 0)
   }
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -46,7 +46,7 @@ package object post_proc {
           seq.sortBy(_.fields(statement.order.get.dimension)._1)
         } else seq
         if (statement.limit.isDefined) Right(maybeSorted.take(statement.limit.get.value)) else Right(maybeSorted)
-      case l @ Left(t) => l
+      case l @ Left(_) => l
     }
   }
 

--- a/nsdb-core/src/test/resources/application.conf
+++ b/nsdb-core/src/test/resources/application.conf
@@ -65,4 +65,8 @@ nsdb{
     }
   }
 
+  write {
+    retry-attempts = 10
+  }
+
 }

--- a/nsdb-core/src/test/resources/application.conf
+++ b/nsdb-core/src/test/resources/application.conf
@@ -66,7 +66,7 @@ nsdb{
   }
 
   write {
-    retry-attempts = 10
+    retry-attempts = 3
   }
 
 }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricPerformerActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricPerformerActorSpec.scala
@@ -19,49 +19,84 @@ package io.radicalbit.nsdb.actors
 import java.nio.file.{Files, Paths}
 import java.util.UUID
 
-import akka.actor.{ActorSystem, Props}
+import akka.actor.SupervisorStrategy.Stop
+import akka.actor._
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import io.radicalbit.nsdb.actors.MetricAccumulatorActor.Refresh
 import io.radicalbit.nsdb.actors.MetricPerformerActor.PerformShardWrites
+import io.radicalbit.nsdb.common.exception.TooManyRetriesException
 import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.index.BrokenTimeSeriesIndex
 import io.radicalbit.nsdb.model.Location
-import org.scalatest.{BeforeAndAfter, FlatSpecLike, Matchers}
+import org.apache.lucene.store.MMapDirectory
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
+import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
+
+class TestSupervisorActor(probe: ActorRef) extends Actor with ActorLogging {
+
+  val exceptionsCaught: ListBuffer[TooManyRetriesException] = ListBuffer.empty
+
+  override val supervisorStrategy: SupervisorStrategy = OneForOneStrategy(maxNrOfRetries = 1) {
+    case e: TooManyRetriesException =>
+      log.error(e, "TooManyRetriesException {}", e.getMessage)
+      exceptionsCaught += e
+      Stop
+    case t =>
+      log.error(t, "generic exception")
+      super.supervisorStrategy.decider.apply(t)
+  }
+
+  override def receive: Receive = {
+    case msg => probe ! msg
+  }
+}
 
 class MetricPerformerActorSpec
     extends TestKit(ActorSystem("IndexerActorSpec"))
     with ImplicitSender
     with FlatSpecLike
     with Matchers
-    with BeforeAndAfter {
+    with BeforeAndAfterAll {
 
   val probe      = TestProbe()
   val probeActor = probe.ref
 
-  val basePath                   = "target/test_index"
-  val db                         = "db"
-  val namespace                  = "namespace"
-  val localWriteCoordinator      = TestProbe()
-  val localWriteCoordinatorActor = localWriteCoordinator.ref
-  val indexerPerformerActor =
-    TestActorRef[MetricPerformerActor](MetricPerformerActor.props(basePath, db, namespace, localWriteCoordinatorActor),
-                                       probeActor)
+  val basePath                  = "target/test_index"
+  val db                        = "db"
+  val namespace                 = "namespace"
+  val localCommitLogCoordinator = TestProbe()
 
-  before {
+  val testSupervisor                 = TestActorRef[TestSupervisorActor](Props(new TestSupervisorActor(probeActor)))
+  val localCommitLogCoordinatorActor = localCommitLogCoordinator.ref
+  val indexerPerformerActor =
+    TestActorRef[MetricPerformerActor](
+      MetricPerformerActor.props(basePath, db, namespace, localCommitLogCoordinatorActor),
+      testSupervisor,
+      "indexerPerformerActor")
+
+  val errorLocation = Location("IndexerPerformerActorMetric", "node1", 1, 1)
+  val bit           = Bit(System.currentTimeMillis, 25, Map("content" -> "content"), Map.empty)
+
+  override def beforeAll: Unit = {
     import scala.collection.JavaConverters._
     if (Paths.get(basePath, db).toFile.exists())
       Files.walk(Paths.get(basePath, db)).iterator().asScala.map(_.toFile).toSeq.reverse.foreach(_.delete)
+
+    val directory =
+      new MMapDirectory(Paths
+        .get(basePath, db, namespace, "shards", s"${errorLocation.metric}_${errorLocation.from}_${errorLocation.to}"))
+
+    indexerPerformerActor.underlyingActor.shards += (errorLocation -> new BrokenTimeSeriesIndex(directory))
   }
 
   "ShardPerformerActor" should "write and delete properly" in within(5.seconds) {
 
-    val key = Location("IndexerPerformerActorMetric", "node1", 0, 0)
-
-    val bit = Bit(System.currentTimeMillis, 25, Map("content" -> "content"), Map.empty)
+    val loc = Location("IndexerPerformerActorMetric", "node1", 0, 0)
 
     val operations =
-      Map(UUID.randomUUID().toString -> WriteShardOperation(namespace, key, bit))
+      Map(UUID.randomUUID().toString -> WriteShardOperation(namespace, loc, bit))
 
     probe.send(indexerPerformerActor, PerformShardWrites(operations))
     awaitAssert {
@@ -69,9 +104,27 @@ class MetricPerformerActorSpec
     }
 
     awaitAssert {
-      val msg = localWriteCoordinator.expectMsgType[MetricPerformerActor.PersistedBits]
+      val msg = localCommitLogCoordinator.expectMsgType[MetricPerformerActor.PersistedBits]
       msg.persistedBits.size shouldBe 1
     }
 
+  }
+
+  "ShardPerformerActor" should "retry in case of error" in within(5.seconds) {
+
+    val operations =
+      Map(UUID.randomUUID().toString -> WriteShardOperation(namespace, errorLocation, bit))
+
+    probe.send(indexerPerformerActor, PerformShardWrites(operations))
+    awaitAssert {
+      probe.expectMsgType[Refresh]
+    }
+
+    awaitAssert {
+      val msg = localCommitLogCoordinator.expectMsgType[MetricPerformerActor.PersistedBits]
+      msg.persistedBits.size shouldBe 0
+    }
+
+    testSupervisor.underlyingActor.exceptionsCaught.size shouldBe 1
   }
 }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/BrokenTimeSeriesIndex.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/BrokenTimeSeriesIndex.scala
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-package io.radicalbit.nsdb.common.exception
+package io.radicalbit.nsdb.index
+import io.radicalbit.nsdb.common.protocol.Bit
+import org.apache.lucene.index.IndexWriter
+import org.apache.lucene.store.BaseDirectory
 
-import scala.util.control.NoStackTrace
+import scala.util.{Failure, Try}
 
-/**
-  * Trait for Nsdb Exceptions. It extends [[NoStackTrace]] for efficiency purpose.
-  */
-sealed trait NsdbException extends RuntimeException with NoStackTrace
+class BrokenTimeSeriesIndex(override val directory: BaseDirectory) extends TimeSeriesIndex(directory) {
+  override def write(data: Bit)(implicit writer: IndexWriter): Try[Long] =
+    Failure(new RuntimeException("How could it be useful to test failures if it does not fail at all"))
 
-class InvalidStatementException(val message: String) extends NsdbException
-class TypeNotSupportedException(val message: String) extends NsdbException
-class NsdbSecurityException(val message: String)     extends NsdbException
-class TooManyRetriesException(val message: String)   extends NsdbException
+}

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/BrokenTimeSeriesIndex.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/BrokenTimeSeriesIndex.scala
@@ -22,7 +22,11 @@ import org.apache.lucene.store.BaseDirectory
 import scala.util.{Failure, Try}
 
 class BrokenTimeSeriesIndex(override val directory: BaseDirectory) extends TimeSeriesIndex(directory) {
-  override def write(data: Bit)(implicit writer: IndexWriter): Try[Long] =
-    Failure(new RuntimeException("How could it be useful to test failures if it does not fail at all"))
 
+  private val genericFailure = Failure(
+    new RuntimeException("How could it be useful to test failures if it does not fail at all"))
+
+  override def write(data: Bit)(implicit writer: IndexWriter): Try[Long] = genericFailure
+
+  override def delete(data: Bit)(implicit writer: IndexWriter): Try[Long] = genericFailure
 }

--- a/nsdb-it/src/test/resources/minicluster.conf
+++ b/nsdb-it/src/test/resources/minicluster.conf
@@ -152,6 +152,10 @@ nsdb {
     }
   }
 
+  write {
+    retry-attempts = 10
+  }
+
   global.timeout = 30 seconds
   global.timeout = ${?GLOBAL_TIMEOUT}
   http-endpoint.timeout = 60 seconds

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NSDbMiniClusterDefinition.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NSDbMiniClusterDefinition.scala
@@ -16,9 +16,17 @@
 
 package io.radicalbit.nsdb.minicluster
 
-class NsdbMiniClusterNode(val akkaRemotePort: Int,
-                          val httpPort: Int,
-                          val grpcPort: Int,
-                          val dataDir: String,
-                          val commitLogDir: String)
-    extends NsdbMiniClusterDefinition {}
+import akka.actor.{ActorRef, Props}
+import com.typesafe.scalalogging.LazyLogging
+import io.radicalbit.nsdb.cluster.{NSDBAActors, NSDBAkkaCluster}
+import io.radicalbit.nsdb.common.NsdbConfig
+
+/**
+  * Overrides node actor props in order to inject custom behaviours useful for test purpose.
+  */
+trait TestCluster extends NSDBAkkaCluster with NSDBAActors with NsdbConfig {
+  override def nodeActorGuardianProps(metadataCache: ActorRef, schemaCache: ActorRef): Props =
+    super.nodeActorGuardianProps(metadataCache, schemaCache)
+}
+
+trait NSDbMiniClusterDefinition extends TestCluster with NsdbMiniClusterConf with LazyLogging {}

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NSDbMiniClusterNode.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NSDbMiniClusterNode.scala
@@ -16,7 +16,9 @@
 
 package io.radicalbit.nsdb.minicluster
 
-import com.typesafe.scalalogging.LazyLogging
-import io.radicalbit.nsdb.cluster.ProductionCluster
-
-trait NsdbMiniClusterDefinition extends ProductionCluster with NsdbMiniClusterConf with LazyLogging {}
+class NSDbMiniClusterNode(val akkaRemotePort: Int,
+                          val httpPort: Int,
+                          val grpcPort: Int,
+                          val dataDir: String,
+                          val commitLogDir: String)
+    extends NSDbMiniClusterDefinition {}

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NsdbMiniCluster.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NsdbMiniCluster.scala
@@ -33,12 +33,12 @@ trait NsdbMiniCluster extends LazyLogging {
 
   protected[this] def nodesNumber: Int
 
-  lazy val nodes: Set[NsdbMiniClusterNode] =
+  lazy val nodes: Set[NSDbMiniClusterNode] =
     (for {
       i <- 0 until nodesNumber
       _ = Thread.sleep(1000)
     } yield
-      new NsdbMiniClusterNode(
+      new NSDbMiniClusterNode(
         akkaRemotePort = startingAkkaRemotePort + i,
         httpPort = startingHttpPort + i,
         grpcPort = startingGrpcPort + i,

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -28,7 +28,7 @@ import scala.util.parsing.input.CharSequenceReader
 /**
   * Parser combinator for sql statements.
   * It successfully validates and parses a subset of the Ansi Sql grammar.
-  * It mixs in [[PackratParsers]] which turns the parser into a look ahead parser which can handle left recursive grammars
+  * It mixes in [[PackratParsers]] which turns the parser into a look ahead parser which can handle left recursive grammars
   * Here is the (simplified) EBNF grammar supported by Nsdb Parser.
   * {{{
   *   S := InsertStatement | SelectStatement | DeleteStatement | DropStatement

--- a/project/Commons.scala
+++ b/project/Commons.scala
@@ -22,7 +22,7 @@ import sbtassembly.PathList
 
 object Commons {
 
-  val scalaVer = "2.12.6"
+  val scalaVer = "2.12.7"
 
   val settings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := scalaVer,

--- a/project/Commons.scala
+++ b/project/Commons.scala
@@ -22,7 +22,7 @@ import sbtassembly.PathList
 
 object Commons {
 
-  val scalaVer = "2.12.4"
+  val scalaVer = "2.12.6"
 
   val settings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := scalaVer,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ import sbt._
 object Dependencies {
 
   object scalaLang {
-    lazy val version   = "2.12.6"
+    lazy val version   = "2.12.7"
     lazy val namespace = "org.scala-lang"
     lazy val compiler  = namespace % "scala-compiler" % version
   }


### PR DESCRIPTION
This PR introduces the retry mechanism in the persistence process that happens in the background.
Basically, if any error occurs during index and facets writes, the operation is enqueued to be retried.
Retry operations include compensations (which are idempotent) and the retry in itself.
After a configurable attempts, the node is marked as inconsistent and will be shut down