### PR TITLE
Improve Shards Passivation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -310,6 +310,8 @@ lazy val `nsdb-sql` = project
 
 lazy val `nsdb-java-api` = project
   .settings(Commons.crossScalaVersionSettings: _*)
+  .settings(scalaVersion := "2.11.11")
+  .settings(crossPaths := false)
   .settings(PublishSettings.settings: _*)
   .settings(libraryDependencies ++= Dependencies.JavaAPI.libraries)
   .enablePlugins(AutomateHeaderPlugin)
@@ -364,7 +366,9 @@ lazy val `nsdb-flink-connector` = project
   .dependsOn(`nsdb-scala-api`)
 
 lazy val `nsdb-kafka-connect` = project
-  .settings(Commons.crossScalaVersionSettings: _*)
+  .settings(Commons.nonCrossSettings: _*)
+  .settings(scalaVersion := "2.11.11")
+  .settings(crossPaths := false)
   .settings(PublishSettings.settings: _*)
   .settings(libraryDependencies ++= Dependencies.KafkaConnect.libraries)
   .settings(

--- a/nsdb-cluster/src/main/resources/cluster.conf
+++ b/nsdb-cluster/src/main/resources/cluster.conf
@@ -148,6 +148,7 @@ nsdb {
 
   sharding {
     interval = 1d
+    passivate-after = 1h
   }
 
   security {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetadataActor.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetadataActor.scala
@@ -53,7 +53,7 @@ class MetadataActor(val basePath: String, metadataCoordinator: ActorRef)
   private def getLocationIndex(db: String, namespace: String): LocationIndex =
     locationIndexes.getOrElse(
       (db, namespace), {
-        val newIndex = new LocationIndex(createHybridDirectory(Paths.get(basePath, db, namespace, "metadata")))
+        val newIndex = new LocationIndex(createMmapDirectory(Paths.get(basePath, db, namespace, "metadata")))
         locationIndexes += ((db, namespace) -> newIndex)
         newIndex
       }
@@ -63,7 +63,7 @@ class MetadataActor(val basePath: String, metadataCoordinator: ActorRef)
     metricInfoIndexes.getOrElse(
       (db, namespace), {
         val newIndex =
-          new MetricInfoIndex(createHybridDirectory(Paths.get(basePath, db, namespace, "metadata", "info")))
+          new MetricInfoIndex(createMmapDirectory(Paths.get(basePath, db, namespace, "metadata", "info")))
         metricInfoIndexes += ((db, namespace) -> newIndex)
         newIndex
       }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetadataActor.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetadataActor.scala
@@ -26,9 +26,9 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.extension.RemoteAddress
 import io.radicalbit.nsdb.cluster.index.{LocationIndex, MetricInfo, MetricInfoIndex}
 import io.radicalbit.nsdb.cluster.util.FileUtils
+import io.radicalbit.nsdb.index.DirectorySupport
 import io.radicalbit.nsdb.model.Location
 import org.apache.lucene.index.IndexWriter
-import org.apache.lucene.store.MMapDirectory
 
 import scala.collection.mutable
 
@@ -38,19 +38,22 @@ import scala.collection.mutable
   *
   * @param basePath index base path.
   */
-class MetadataActor(val basePath: String, metadataCoordinator: ActorRef) extends Actor with ActorLogging {
+class MetadataActor(val basePath: String, metadataCoordinator: ActorRef)
+    extends Actor
+    with ActorLogging
+    with DirectorySupport {
 
   lazy val locationIndexes: mutable.Map[(String, String), LocationIndex]     = mutable.Map.empty
   lazy val metricInfoIndexes: mutable.Map[(String, String), MetricInfoIndex] = mutable.Map.empty
 
-  lazy val metadataTopic = context.system.settings.config.getString("nsdb.cluster.pub-sub.metadata-topic")
+  private lazy val metadataTopic = context.system.settings.config.getString("nsdb.cluster.pub-sub.metadata-topic")
 
-  val remoteAddress = RemoteAddress(context.system)
+  private val remoteAddress = RemoteAddress(context.system)
 
   private def getLocationIndex(db: String, namespace: String): LocationIndex =
     locationIndexes.getOrElse(
       (db, namespace), {
-        val newIndex = new LocationIndex(new MMapDirectory(Paths.get(basePath, db, namespace, "metadata")))
+        val newIndex = new LocationIndex(createHybridDirectory(Paths.get(basePath, db, namespace, "metadata")))
         locationIndexes += ((db, namespace) -> newIndex)
         newIndex
       }
@@ -59,7 +62,8 @@ class MetadataActor(val basePath: String, metadataCoordinator: ActorRef) extends
   private def getMetricInfoIndex(db: String, namespace: String): MetricInfoIndex =
     metricInfoIndexes.getOrElse(
       (db, namespace), {
-        val newIndex = new MetricInfoIndex(new MMapDirectory(Paths.get(basePath, db, namespace, "metadata", "info")))
+        val newIndex =
+          new MetricInfoIndex(createHybridDirectory(Paths.get(basePath, db, namespace, "metadata", "info")))
         metricInfoIndexes += ((db, namespace) -> newIndex)
         newIndex
       }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/SchemaActor.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/SchemaActor.scala
@@ -52,7 +52,7 @@ class SchemaActor(val basePath: String, schemaCoordinator: ActorRef)
   private def getOrCreateSchemaIndex(db: String, namespace: String): SchemaIndex =
     schemaIndexes.getOrElse(
       (db, namespace), {
-        val newIndex = new SchemaIndex(createHybridDirectory(Paths.get(basePath, db, namespace, "schemas")))
+        val newIndex = new SchemaIndex(createMmapDirectory(Paths.get(basePath, db, namespace, "schemas")))
         schemaIndexes += ((db, namespace) -> newIndex)
         newIndex
       }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
@@ -633,10 +633,10 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
         namespaces.foreach { namespace =>
           val metrics = FileUtils.getSubDirs(namespace)
           metrics.foreach { metric =>
-            val schemaIndex = new SchemaIndex(createHybridDirectory(Paths.get(metric.getAbsolutePath, "schemas")))
+            val schemaIndex = new SchemaIndex(createMmapDirectory(Paths.get(metric.getAbsolutePath, "schemas")))
             schemaIndex.getSchema(metric.getName).foreach { schema =>
               log.debug("restoring metric {}", metric.getName)
-              val metricsIndex = new TimeSeriesIndex(createHybridDirectory(metric.toPath))
+              val metricsIndex = new TimeSeriesIndex(createMmapDirectory(metric.toPath))
               val minTimestamp = metricsIndex
                 .query(schema,
                        new MatchAllDocsQuery(),
@@ -710,18 +710,18 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
                       .foreach {
                         case SchemaGot(_, _, _, Some(schema)) =>
                           val schemasDir =
-                            createHybridDirectory(Paths.get(basePath, db, namespace, "schemas", metricName))
+                            createMmapDirectory(Paths.get(basePath, db, namespace, "schemas", metricName))
                           val schemaIndex  = new SchemaIndex(schemasDir)
                           val schemaWriter = schemaIndex.getWriter
                           schemaIndex.write(schema)(schemaWriter)
                           schemaWriter.close()
 
                           val dumpMetricIndex =
-                            new TimeSeriesIndex(createHybridDirectory(Paths.get(tmpPath, db, namespace, metricName)))
+                            new TimeSeriesIndex(createMmapDirectory(Paths.get(tmpPath, db, namespace, metricName)))
                           dirNames.foreach { dirMetric =>
                             val shardWriter: IndexWriter = dumpMetricIndex.getWriter
                             val shardsDir =
-                              createHybridDirectory(Paths.get(basePath, db, namespace, "shards", dirMetric.getName))
+                              createMmapDirectory(Paths.get(basePath, db, namespace, "shards", dirMetric.getName))
                             val shardIndex = new TimeSeriesIndex(shardsDir)
                             shardIndex.all(schema, bit => dumpMetricIndex.write(bit)(shardWriter))
                             shardWriter.close()

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
@@ -43,7 +43,7 @@ import io.radicalbit.nsdb.cluster.{NsdbPerfLogger, createNodeName}
 import io.radicalbit.nsdb.commit_log.CommitLogWriterActor._
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement.DeleteSQLStatement
-import io.radicalbit.nsdb.index.{SchemaIndex, TimeSeriesIndex}
+import io.radicalbit.nsdb.index.{DirectorySupport, SchemaIndex, TimeSeriesIndex}
 import io.radicalbit.nsdb.model.{Location, Schema}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
@@ -83,6 +83,7 @@ object WriteCoordinator {
   */
 class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef, mediator: ActorRef)
     extends ActorPathLogging
+    with DirectorySupport
     with NsdbPerfLogger
     with Stash {
 
@@ -632,10 +633,10 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
         namespaces.foreach { namespace =>
           val metrics = FileUtils.getSubDirs(namespace)
           metrics.foreach { metric =>
-            val schemaIndex = new SchemaIndex(new MMapDirectory(Paths.get(metric.getAbsolutePath, "schemas")))
+            val schemaIndex = new SchemaIndex(createHybridDirectory(Paths.get(metric.getAbsolutePath, "schemas")))
             schemaIndex.getSchema(metric.getName).foreach { schema =>
               log.debug("restoring metric {}", metric.getName)
-              val metricsIndex = new TimeSeriesIndex(new MMapDirectory(metric.toPath))
+              val metricsIndex = new TimeSeriesIndex(createHybridDirectory(metric.toPath))
               val minTimestamp = metricsIndex
                 .query(schema,
                        new MatchAllDocsQuery(),
@@ -709,18 +710,18 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
                       .foreach {
                         case SchemaGot(_, _, _, Some(schema)) =>
                           val schemasDir =
-                            new MMapDirectory(Paths.get(basePath, db, namespace, "schemas", metricName))
+                            createHybridDirectory(Paths.get(basePath, db, namespace, "schemas", metricName))
                           val schemaIndex  = new SchemaIndex(schemasDir)
                           val schemaWriter = schemaIndex.getWriter
                           schemaIndex.write(schema)(schemaWriter)
                           schemaWriter.close()
 
                           val dumpMetricIndex =
-                            new TimeSeriesIndex(new MMapDirectory(Paths.get(tmpPath, db, namespace, metricName)))
+                            new TimeSeriesIndex(createHybridDirectory(Paths.get(tmpPath, db, namespace, metricName)))
                           dirNames.foreach { dirMetric =>
                             val shardWriter: IndexWriter = dumpMetricIndex.getWriter
                             val shardsDir =
-                              new MMapDirectory(Paths.get(basePath, db, namespace, "shards", dirMetric.getName))
+                              createHybridDirectory(Paths.get(basePath, db, namespace, "shards", dirMetric.getName))
                             val shardIndex = new TimeSeriesIndex(shardsDir)
                             shardIndex.all(schema, bit => dumpMetricIndex.write(bit)(shardWriter))
                             shardWriter.close()

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/LocationIndex.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/LocationIndex.scala
@@ -23,7 +23,7 @@ import org.apache.lucene.document.Field.Store
 import org.apache.lucene.document._
 import org.apache.lucene.index.{IndexWriter, Term}
 import org.apache.lucene.search._
-import org.apache.lucene.store.BaseDirectory
+import org.apache.lucene.store.Directory
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
@@ -32,7 +32,7 @@ import scala.util.{Failure, Success, Try}
   * Index for storing metric locations.
   * @param directory index bae directory.
   */
-class LocationIndex(override val directory: BaseDirectory) extends SimpleIndex[Location] {
+class LocationIndex(override val directory: Directory) extends SimpleIndex[Location] {
   override val _keyField: String = "_metric"
 
   override def validateRecord(data: Location): Try[Seq[Field]] = {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndex.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndex.scala
@@ -17,16 +17,16 @@
 package io.radicalbit.nsdb.cluster.index
 
 import io.radicalbit.nsdb.index.SimpleIndex
+import io.radicalbit.nsdb.index.lucene.Index._
 import io.radicalbit.nsdb.statement.StatementParser.SimpleField
 import org.apache.lucene.document.Field.Store
 import org.apache.lucene.document._
 import org.apache.lucene.index.{IndexWriter, Term}
 import org.apache.lucene.search._
-import org.apache.lucene.store.{BaseDirectory, Directory}
+import org.apache.lucene.store.Directory
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
-import io.radicalbit.nsdb.index.lucene.Index._
 
 /**
   * Metric Info.

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndex.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndex.scala
@@ -22,7 +22,7 @@ import org.apache.lucene.document.Field.Store
 import org.apache.lucene.document._
 import org.apache.lucene.index.{IndexWriter, Term}
 import org.apache.lucene.search._
-import org.apache.lucene.store.BaseDirectory
+import org.apache.lucene.store.{BaseDirectory, Directory}
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
@@ -39,7 +39,7 @@ case class MetricInfo(metric: String, shardInterval: Long)
   * Index for storing metric info (shard interval).
   * @param directory index bae directory.
   */
-class MetricInfoIndex(override val directory: BaseDirectory) extends SimpleIndex[MetricInfo] {
+class MetricInfoIndex(override val directory: Directory) extends SimpleIndex[MetricInfo] {
   override val _keyField: String = "_metric"
 
   override def validateRecord(data: MetricInfo): Try[Seq[Field]] = {

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -42,6 +42,7 @@ object MetadataSpec extends MultiNodeConfig {
     |
     |  sharding {
     |    interval = 1d
+    |    passivate-after = 1h
     |  }
     |
     |  read {

--- a/nsdb-cluster/src/test/resources/application.conf
+++ b/nsdb-cluster/src/test/resources/application.conf
@@ -46,6 +46,7 @@ nsdb {
 
   sharding {
     interval = 1d
+    passivate-after = 1h
   }
 
   read {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
@@ -105,8 +105,7 @@ class WriteCoordinatorErrorsSpec
   lazy val subscriber = TestActorRef[TestSubscriber](Props[TestSubscriber])
   lazy val publisherActor =
     TestActorRef[PublisherActor](PublisherActor.props(system.actorOf(Props[FakeReadCoordinatorActor])))
-  lazy val mockedMetadataCoordinator =
-    system.actorOf(LocalMetadataCoordinator.props(system.actorOf(Props[LocalMetadataCache])))
+  lazy val mockedMetadataCoordinator = system.actorOf(Props[MockedMetadataCoordinator])
   lazy val writeCoordinatorActor = system actorOf WriteCoordinator.props(mockedMetadataCoordinator,
                                                                          schemaCoordinator,
                                                                          system.actorOf(Props.empty))

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
@@ -105,7 +105,8 @@ class WriteCoordinatorErrorsSpec
   lazy val subscriber = TestActorRef[TestSubscriber](Props[TestSubscriber])
   lazy val publisherActor =
     TestActorRef[PublisherActor](PublisherActor.props(system.actorOf(Props[FakeReadCoordinatorActor])))
-  lazy val mockedMetadataCoordinator = system.actorOf(Props[MockedMetadataCoordinator])
+  lazy val mockedMetadataCoordinator =
+    system.actorOf(LocalMetadataCoordinator.props(system.actorOf(Props[LocalMetadataCache])))
   lazy val writeCoordinatorActor = system actorOf WriteCoordinator.props(mockedMetadataCoordinator,
                                                                          schemaCoordinator,
                                                                          system.actorOf(Props.empty))

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/index/LocationIndexTest.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/index/LocationIndexTest.scala
@@ -16,17 +16,20 @@
 
 package io.radicalbit.nsdb.cluster.index
 
+import java.nio.file.Files
+import java.util.UUID
+
+import io.radicalbit.nsdb.index.DirectorySupport
 import io.radicalbit.nsdb.model.Location
 import org.apache.lucene.analysis.standard.StandardAnalyzer
 import org.apache.lucene.index.{IndexWriter, IndexWriterConfig}
-import org.apache.lucene.store.RAMDirectory
 import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
 
-class LocationIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
+class LocationIndexTest extends FlatSpec with Matchers with OneInstancePerTest with DirectorySupport {
 
   "LocationsIndex" should "write and read properly" in {
 
-    lazy val directory = new RAMDirectory()
+    lazy val directory = createMmapDirectory(Files.createTempDirectory(UUID.randomUUID().toString))
 
     implicit val writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer))
 
@@ -51,7 +54,7 @@ class LocationIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
 
   "LocationsIndex" should "get a single location for a metric" in {
 
-    lazy val directory = new RAMDirectory()
+    lazy val directory = createMmapDirectory(Files.createTempDirectory(UUID.randomUUID().toString))
 
     implicit val writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer))
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndexTest.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndexTest.scala
@@ -16,14 +16,17 @@
 
 package io.radicalbit.nsdb.cluster.index
 
-import org.apache.lucene.store.RAMDirectory
+import java.nio.file.Files
+import java.util.UUID
+
+import io.radicalbit.nsdb.index.DirectorySupport
 import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
 
-class MetricInfoIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
+class MetricInfoIndexTest extends FlatSpec with Matchers with OneInstancePerTest with DirectorySupport {
 
   "MetricInfoIndex" should "write and read properly" in {
 
-    lazy val directory = new RAMDirectory()
+    lazy val directory = createMmapDirectory(Files.createTempDirectory(UUID.randomUUID().toString))
 
     val metricInfoIndex = new MetricInfoIndex(directory)
 
@@ -49,7 +52,7 @@ class MetricInfoIndexTest extends FlatSpec with Matchers with OneInstancePerTest
 
   "MetricInfoIndex" should "write and delete properly" in {
 
-    lazy val directory = new RAMDirectory()
+    lazy val directory = createMmapDirectory(Files.createTempDirectory(UUID.randomUUID().toString))
 
     val metricInfoIndex = new MetricInfoIndex(directory)
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
@@ -192,13 +192,13 @@ class MetricAccumulatorActor(val basePath: String,
           sender() ! DeleteStatementFailed(db = db, namespace = namespace, metric = statement.metric, ex.getMessage)
       }
     case msg @ Refresh(writeIds, keys) =>
-      garbageCollectIndexes()
       opBufferMap --= writeIds
       performingOps = Map.empty
       keys.foreach { key =>
         getIndex(key).refresh()
         facetIndexesFor(key).refresh()
       }
+      garbageCollectIndexes()
       readerActor ! Broadcast(msg)
   }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
@@ -192,6 +192,7 @@ class MetricAccumulatorActor(val basePath: String,
           sender() ! DeleteStatementFailed(db = db, namespace = namespace, metric = statement.metric, ex.getMessage)
       }
     case msg @ Refresh(writeIds, keys) =>
+      garbageCollectIndexes()
       opBufferMap --= writeIds
       performingOps = Map.empty
       keys.foreach { key =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
@@ -122,6 +122,8 @@ class MetricPerformerActor(val basePath: String,
           facetsIndexWriter.close()
       }
 
+      garbageCollectIndexes()
+
       val persistedBits = performedBitOperations
       context.parent ! Refresh(opBufferMap.keys.toSeq, groupedByKey.keys.toSeq)
       (localCommitLogCoordinator ? PersistedBits(persistedBits)).recover {

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricsActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricsActor.scala
@@ -21,7 +21,6 @@ import java.nio.file.Paths
 import akka.actor.Actor
 import io.radicalbit.nsdb.index._
 import io.radicalbit.nsdb.model.Location
-import org.apache.lucene.store.MMapDirectory
 
 import scala.collection.mutable
 
@@ -29,7 +28,7 @@ import scala.collection.mutable
   * Trait containing common operation to be executed on metrics indexes.
   * Mixed in by [[MetricAccumulatorActor]] and [[MetricPerformerActor]],
   */
-trait MetricsActor { this: Actor =>
+trait MetricsActor extends DirectorySupport { this: Actor =>
 
   /**
     * basePath shards indexes path.
@@ -70,7 +69,7 @@ trait MetricsActor { this: Actor =>
     shards.getOrElse(
       loc, {
         val directory =
-          new MMapDirectory(Paths.get(basePath, db, namespace, "shards", s"${loc.metric}_${loc.from}_${loc.to}"))
+          createMmapDirectory(Paths.get(basePath, db, namespace, "shards", s"${loc.metric}_${loc.from}_${loc.to}"))
         val newIndex = new TimeSeriesIndex(directory)
         shards += (loc -> newIndex)
         newIndex

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricsActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricsActor.scala
@@ -120,6 +120,7 @@ trait MetricsActor extends DirectorySupport { this: Actor =>
           facetIndex.close()
         }
         facetIndexShards -= location
+        shardsAccess -= location
       case _ => // do nothing
     }
   }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricsActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricsActor.scala
@@ -61,6 +61,7 @@ trait MetricsActor extends DirectorySupport { this: Actor =>
     locations.map(location => (location, getIndex(location)))
   protected def facetsShardsFromLocations(locations: Seq[Location]): Seq[(Location, AllFacetIndexes)] =
     locations.map(location => (location, facetIndexesFor(location)))
+
   /**
     * last access for a given [[Location]]
     */

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -17,8 +17,9 @@
 package io.radicalbit.nsdb.actors
 
 import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
 
-import akka.actor.Props
+import akka.actor.{Props, ReceiveTimeout}
 import io.radicalbit.nsdb.actors.ShardReaderActor.RefreshShard
 import io.radicalbit.nsdb.index.lucene.Index.handleNoIndexResults
 import io.radicalbit.nsdb.index.{AllFacetIndexes, DirectorySupport, TimeSeriesIndex}
@@ -30,6 +31,7 @@ import io.radicalbit.nsdb.statement.StatementParser._
 import io.radicalbit.nsdb.util.ActorPathLogging
 import org.apache.lucene.store.Directory
 
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -52,10 +54,18 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
 
   lazy val facetIndexes = new AllFacetIndexes(basePath = basePath, db = db, namespace = namespace, location = location)
 
+  lazy val passivateAfter = FiniteDuration(
+    context.system.settings.config.getDuration("nsdb.sharding.passivate-after").toNanos,
+    TimeUnit.NANOSECONDS)
+
+  context.setReceiveTimeout(passivateAfter)
+
   override def receive: Receive = {
     case GetCountWithLocations(_, _, metric, _) =>
-      val count = Try { index.getCount() }.recover { case _ => 0 }.getOrElse(0)
+      val count = Try { index.getCount }.recover { case _ => 0 }.getOrElse(0)
       sender ! CountGot(db, namespace, metric, count)
+    case ReceiveTimeout =>
+      context.stop(self)
     case ExecuteSelectStatement(statement, schema, _) =>
       StatementParser.parseStatement(statement, schema) match {
         case Success(ParsedSimpleQuery(_, _, q, false, limit, fields, sort)) =>
@@ -117,6 +127,11 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
     case RefreshShard =>
       index.refresh()
       facetIndexes.refresh()
+  }
+
+  override def postStop(): Unit = {
+    facetIndexes.close()
+    directory.close()
   }
 }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -21,14 +21,14 @@ import java.nio.file.Paths
 import akka.actor.Props
 import io.radicalbit.nsdb.actors.ShardReaderActor.RefreshShard
 import io.radicalbit.nsdb.index.lucene.Index.handleNoIndexResults
-import io.radicalbit.nsdb.index.{AllFacetIndexes, TimeSeriesIndex}
+import io.radicalbit.nsdb.index.{AllFacetIndexes, DirectorySupport, TimeSeriesIndex}
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.{ExecuteSelectStatement, GetCountWithLocations}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{CountGot, SelectStatementExecuted, SelectStatementFailed}
 import io.radicalbit.nsdb.statement.StatementParser
 import io.radicalbit.nsdb.statement.StatementParser._
 import io.radicalbit.nsdb.util.ActorPathLogging
-import org.apache.lucene.store.MMapDirectory
+import org.apache.lucene.store.Directory
 
 import scala.util.{Failure, Success, Try}
 
@@ -41,10 +41,11 @@ import scala.util.{Failure, Success, Try}
   * @param location the shard location.
   */
 class ShardReaderActor(val basePath: String, val db: String, val namespace: String, val location: Location)
-    extends ActorPathLogging {
+    extends ActorPathLogging
+    with DirectorySupport {
 
-  lazy val directory =
-    new MMapDirectory(
+  lazy val directory: Directory =
+    createMmapDirectory(
       Paths.get(basePath, db, namespace, "shards", s"${location.metric}_${location.from}_${location.to}"))
 
   lazy val index = new TimeSeriesIndex(directory)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -19,7 +19,7 @@ package io.radicalbit.nsdb.actors
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
-import akka.actor.{Props, ReceiveTimeout}
+import akka.actor.{PoisonPill, Props, ReceiveTimeout}
 import io.radicalbit.nsdb.actors.ShardReaderActor.RefreshShard
 import io.radicalbit.nsdb.index.lucene.Index.handleNoIndexResults
 import io.radicalbit.nsdb.index.{AllFacetIndexes, DirectorySupport, TimeSeriesIndex}
@@ -65,7 +65,7 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
       val count = Try { index.getCount }.recover { case _ => 0 }.getOrElse(0)
       sender ! CountGot(db, namespace, metric, count)
     case ReceiveTimeout =>
-      context.stop(self)
+      self ! PoisonPill
     case ExecuteSelectStatement(statement, schema, _) =>
       StatementParser.parseStatement(statement, schema) match {
         case Success(ParsedSimpleQuery(_, _, q, false, limit, fields, sort)) =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -105,7 +105,7 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
               sender ! SelectStatementFailed(ex.getMessage)
           }
 
-        case Success(ParsedAggregatedQuery(_, _, q, aggregationType, _, _)) =>
+        case Success(ParsedAggregatedQuery(_, _, _, aggregationType, _, _)) =>
           sender ! SelectStatementFailed(s"$aggregationType is not currently supported.")
 
         case Success(_) => sender ! SelectStatementFailed("Unsupported query type")

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/RollingCommitLogFileChecker.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/RollingCommitLogFileChecker.scala
@@ -88,7 +88,7 @@ class RollingCommitLogFileChecker(db: String, namespace: String, metric: String)
         closedEntries.foreach {
           closedEntry =>
             pendingOutdatedEntries.foreach {
-              case (file, (pending, closed)) =>
+              case (file, (pending, _)) =>
                 if (pending.toList.contains(closedEntry)) {
                   log.debug(s"removing entry: $closedEntry in file ${file.getName} processing file: $fileName")
                   pendingOutdatedEntries(file)._1 -= closedEntry

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AllFacetIndexes.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AllFacetIndexes.scala
@@ -25,19 +25,20 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter
 import org.apache.lucene.index.{IndexNotFoundException, IndexWriter, IndexWriterConfig, SimpleMergedSegmentWarmer}
 import org.apache.lucene.search.Query
-import org.apache.lucene.store.MMapDirectory
 import org.apache.lucene.util.InfoStream
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 
-class AllFacetIndexes(basePath: String, db: String, namespace: String, location: Location) extends LazyLogging {
+class AllFacetIndexes(basePath: String, db: String, namespace: String, location: Location)
+    extends LazyLogging
+    with DirectorySupport {
 
   private val directory =
-    new MMapDirectory(
+    createMmapDirectory(
       Paths.get(basePath, db, namespace, "shards", s"${location.metric}_${location.from}_${location.to}", "facet"))
 
-  private val taxoDirectory = new MMapDirectory(
+  private val taxoDirectory = createMmapDirectory(
     Paths
       .get(basePath, db, namespace, "shards", s"${location.metric}_${location.from}_${location.to}", "facet", "taxo"))
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/DirectorySupport.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/DirectorySupport.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.index
+
+import java.nio.file.Path
+
+import org.apache.lucene.store.{FileSwitchDirectory, MMapDirectory, NIOFSDirectory}
+
+import scala.collection.JavaConverters._
+
+/**
+  * Trait containing common Lucene [[org.apache.lucene.store.Directory]] custom factory methods.
+  */
+trait DirectorySupport {
+
+  /**
+    * extensions for norms, docvaules and term dictionaries
+    */
+  private val PRIMARY_EXTENSIONS = Set("nvd", "dvd", "tim")
+
+  def createMmapDirectory(path: Path): MMapDirectory = new MMapDirectory(path)
+
+  /**
+    * Creates an hybrid Lucene Directory subclass that Maps in memory all the files with primaries extensions, all other files are served through NIOFS
+    * @param path the root path
+    * @return the hybrid directory
+    */
+  def createHybridDirectory(path: Path): FileSwitchDirectory =
+    new FileSwitchDirectory(PRIMARY_EXTENSIONS.asJava, new MMapDirectory(path), new NIOFSDirectory(path), true) {
+
+      /**
+        * to avoid listall() call twice
+        */
+      override def listAll(): Array[String] = getPrimaryDir.listAll()
+    }
+
+}

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/DirectorySupport.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/DirectorySupport.scala
@@ -18,34 +18,13 @@ package io.radicalbit.nsdb.index
 
 import java.nio.file.Path
 
-import org.apache.lucene.store.{FileSwitchDirectory, MMapDirectory, NIOFSDirectory}
-
-import scala.collection.JavaConverters._
+import org.apache.lucene.store.MMapDirectory
 
 /**
   * Trait containing common Lucene [[org.apache.lucene.store.Directory]] custom factory methods.
   */
 trait DirectorySupport {
 
-  /**
-    * extensions for norms, docvaules and term dictionaries
-    */
-  private val PRIMARY_EXTENSIONS = Set("nvd", "dvd", "tim")
-
   def createMmapDirectory(path: Path): MMapDirectory = new MMapDirectory(path)
-
-  /**
-    * Creates an hybrid Lucene Directory subclass that Maps in memory all the files with primaries extensions, all other files are served through NIOFS
-    * @param path the root path
-    * @return the hybrid directory
-    */
-  def createHybridDirectory(path: Path): FileSwitchDirectory =
-    new FileSwitchDirectory(PRIMARY_EXTENSIONS.asJava, new MMapDirectory(path), new NIOFSDirectory(path), true) {
-
-      /**
-        * to avoid listall() call twice
-        */
-      override def listAll(): Array[String] = getPrimaryDir.listAll()
-    }
 
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/FacetCountIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/FacetCountIndex.scala
@@ -25,7 +25,7 @@ import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter
 import org.apache.lucene.facet.{FacetField, FacetResult, FacetsCollector, FacetsConfig}
 import org.apache.lucene.index.IndexWriter
 import org.apache.lucene.search.{Query, Sort}
-import org.apache.lucene.store.BaseDirectory
+import org.apache.lucene.store.Directory
 
 import scala.util.Try
 
@@ -35,7 +35,7 @@ import scala.util.Try
   * @param directory facet index base directory
   * @param taxoDirectory taxonomy base directory
   */
-class FacetCountIndex(override val directory: BaseDirectory, override val taxoDirectory: BaseDirectory)
+class FacetCountIndex(override val directory: Directory, override val taxoDirectory: Directory)
     extends FacetIndex(directory, taxoDirectory) {
 
   override protected[this] val facetNamePrefix = "facet_count_"

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/FacetIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/FacetIndex.scala
@@ -20,17 +20,16 @@ import io.radicalbit.nsdb.common.JSerializable
 import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType}
 import io.radicalbit.nsdb.model.TypedField
 import org.apache.lucene.document._
-import org.apache.lucene.facet.taxonomy.directory.{DirectoryTaxonomyReader, DirectoryTaxonomyWriter}
 import org.apache.lucene.facet._
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager
+import org.apache.lucene.facet.taxonomy.directory.{DirectoryTaxonomyReader, DirectoryTaxonomyWriter}
 import org.apache.lucene.index.IndexWriter
 import org.apache.lucene.search._
-import org.apache.lucene.store.BaseDirectory
+import org.apache.lucene.store.Directory
 
 import scala.util.{Failure, Success, Try}
 
-abstract class FacetIndex(val directory: BaseDirectory, val taxoDirectory: BaseDirectory)
-    extends AbstractStructuredIndex {
+abstract class FacetIndex(val directory: Directory, val taxoDirectory: Directory) extends AbstractStructuredIndex {
 
   private lazy val searchTaxonomyManager: SearcherTaxonomyManager =
     new SearcherTaxonomyManager(directory, taxoDirectory, null)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/FacetSumIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/FacetSumIndex.scala
@@ -19,12 +19,12 @@ package io.radicalbit.nsdb.index
 import io.radicalbit.nsdb.common.JSerializable
 import io.radicalbit.nsdb.common.protocol.Bit
 import org.apache.lucene.document.Field
+import org.apache.lucene.facet._
 import org.apache.lucene.facet.taxonomy._
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter
-import org.apache.lucene.facet._
 import org.apache.lucene.index.IndexWriter
 import org.apache.lucene.search.{Query, Sort}
-import org.apache.lucene.store.BaseDirectory
+import org.apache.lucene.store.Directory
 
 import scala.util.{Failure, Try}
 
@@ -34,7 +34,7 @@ import scala.util.{Failure, Try}
   * @param directory facet index base directory
   * @param taxoDirectory taxonomy base directory
   */
-class FacetSumIndex(override val directory: BaseDirectory, override val taxoDirectory: BaseDirectory)
+class FacetSumIndex(override val directory: Directory, override val taxoDirectory: Directory)
     extends FacetIndex(directory, taxoDirectory) {
 
   override protected[this] val facetNamePrefix = "facet_sum_"

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/SchemaIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/SchemaIndex.scala
@@ -23,7 +23,7 @@ import org.apache.lucene.document.Field.Store
 import org.apache.lucene.document.{Document, Field, StringField}
 import org.apache.lucene.index.{IndexWriter, Term}
 import org.apache.lucene.search.TermQuery
-import org.apache.lucene.store.BaseDirectory
+import org.apache.lucene.store.Directory
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
@@ -32,7 +32,7 @@ import scala.util.{Failure, Success, Try}
   * Index for entry of class [[Schema]].
   * @param directory index base directory.
   */
-class SchemaIndex(override val directory: BaseDirectory) extends SimpleIndex[Schema] {
+class SchemaIndex(override val directory: Directory) extends SimpleIndex[Schema] {
 
   import SchemaIndex._
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/TemporaryIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/TemporaryIndex.scala
@@ -16,11 +16,12 @@
 
 package io.radicalbit.nsdb.index
 
-import org.apache.lucene.store.RAMDirectory
+import java.nio.file.Files
+import java.util.UUID
 
 /**
   * Concrete implementation of [[AbstractStructuredIndex]] which store data in memory.
   */
-class TemporaryIndex extends AbstractStructuredIndex {
-  override lazy val directory = new RAMDirectory()
+class TemporaryIndex extends AbstractStructuredIndex with DirectorySupport {
+  override lazy val directory = createMmapDirectory(Files.createTempDirectory(UUID.randomUUID().toString))
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/TimeSeriesIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/TimeSeriesIndex.scala
@@ -16,11 +16,11 @@
 
 package io.radicalbit.nsdb.index
 
-import org.apache.lucene.store.BaseDirectory
+import org.apache.lucene.store.Directory
 
 /**
   * Concrete implementation of [[AbstractStructuredIndex]] which stores file on disk.
   *
   * @param directory index directory
   */
-class TimeSeriesIndex(override val directory: BaseDirectory) extends AbstractStructuredIndex
+class TimeSeriesIndex(override val directory: Directory) extends AbstractStructuredIndex

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/Index.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/Index.scala
@@ -140,6 +140,10 @@ trait Index[T] {
   }
 
   def count(): Int = this.getSearcher.getIndexReader.numDocs()
+
+  def close(): Unit = {
+    directory.close()
+  }
 }
 
 object Index {

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/Index.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/Index.scala
@@ -20,7 +20,7 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer
 import org.apache.lucene.document.{Document, Field, IntPoint, LongPoint}
 import org.apache.lucene.index.{IndexNotFoundException, IndexWriter, IndexWriterConfig, SimpleMergedSegmentWarmer}
 import org.apache.lucene.search._
-import org.apache.lucene.store.BaseDirectory
+import org.apache.lucene.store.Directory
 import org.apache.lucene.util.InfoStream
 
 import scala.util.{Success, Try}
@@ -30,7 +30,7 @@ trait Index[T] {
   /**
     * @return index base directory.
     */
-  def directory: BaseDirectory
+  def directory: Directory
 
   /**
     * @return index entry identifier.

--- a/nsdb-core/src/test/resources/application.conf
+++ b/nsdb-core/src/test/resources/application.conf
@@ -32,28 +32,32 @@ akka {
 nsdb{
 
   index {
-        base-path= "data/index"
-      }
+    base-path= "data/index"
+  }
 
-      commit-log {
-        enabled = true
-        serializer = "io.radicalbit.nsdb.commit_log.StandardCommitLogSerializer"
-        writer = "io.radicalbit.nsdb.commit_log.RollingCommitLogFileWriter"
-        directory = "target/commit_log"
-        max-size = 50000
-        check-interval = 5 seconds
-      }
+  commit-log {
+    enabled = true
+    serializer = "io.radicalbit.nsdb.commit_log.StandardCommitLogSerializer"
+    writer = "io.radicalbit.nsdb.commit_log.RollingCommitLogFileWriter"
+    directory = "target/commit_log"
+    max-size = 50000
+    check-interval = 5 seconds
+  }
 
-      read-coordinator.timeout = 10 seconds
-      write-coordinator.timeout = 10 seconds
-      namespace-schema.timeout = 10 seconds
-      namespace-data.timeout = 10 seconds
-      publisher.timeout = 10 seconds
-      publisher.scheduler.interval = 5 seconds
-      namespace-data.timeout = 30 seconds
-      nsdb.write.scheduler.interval = 5 seconds
+  read-coordinator.timeout = 10 seconds
+  write-coordinator.timeout = 10 seconds
+  namespace-schema.timeout = 10 seconds
+  namespace-data.timeout = 10 seconds
+  publisher.timeout = 10 seconds
+  publisher.scheduler.interval = 5 seconds
+  namespace-data.timeout = 30 seconds
 
   global.timeout = 30 seconds
+
+  sharding {
+    interval = 1d
+    passivate-after = 1h
+  }
 
   write.scheduler.interval = 5 seconds
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/SchemaIndexTest.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/SchemaIndexTest.scala
@@ -16,14 +16,16 @@
 
 package io.radicalbit.nsdb.index
 
+import java.nio.file.Files
+import java.util.UUID
+
 import io.radicalbit.nsdb.common.protocol.{DimensionFieldType, TagFieldType}
 import io.radicalbit.nsdb.model.{Schema, SchemaField}
-import org.apache.lucene.store.RAMDirectory
 import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
 
 import scala.util.Success
 
-class SchemaIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
+class SchemaIndexTest extends FlatSpec with Matchers with OneInstancePerTest with DirectorySupport {
 
   "SchemaIndex" should "union schemas properly" in {
 
@@ -50,7 +52,7 @@ class SchemaIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
 
   "SchemaIndex" should "write and read properly" in {
 
-    lazy val directory = new RAMDirectory()
+    lazy val directory = createMmapDirectory(Files.createTempDirectory(UUID.randomUUID().toString))
 
     val schemaIndex = new SchemaIndex(directory)
 
@@ -95,7 +97,7 @@ class SchemaIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
       "metric_1",
       Set(SchemaField("field1", DimensionFieldType, INT()), SchemaField("field2", DimensionFieldType, VARCHAR())))
 
-    lazy val directory = new RAMDirectory()
+    lazy val directory = createMmapDirectory(Files.createTempDirectory(UUID.randomUUID().toString))
 
     val schemaIndex = new SchemaIndex(directory)
 
@@ -120,7 +122,7 @@ class SchemaIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
 
   "SchemaIndex" should "drop schema" in {
 
-    lazy val directory = new RAMDirectory()
+    lazy val directory = createMmapDirectory(Files.createTempDirectory(UUID.randomUUID().toString))
 
     val schemaIndex = new SchemaIndex(directory)
 

--- a/nsdb-it/src/test/resources/minicluster.conf
+++ b/nsdb-it/src/test/resources/minicluster.conf
@@ -147,6 +147,7 @@ nsdb {
 
   sharding {
     interval = 5 ms
+    passivate-after = 1h
   }
 
   security {

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/cluster/ReadCoordinatorClusterPassivationSpec.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/cluster/ReadCoordinatorClusterPassivationSpec.scala
@@ -1,0 +1,16 @@
+package io.radicalbit.nsdb.cluster
+
+import io.radicalbit.nsdb.minicluster.{MiniClusterStarter, NsdbMiniCluster}
+
+class ReadCoordinatorClusterPassivationSpec extends ReadCoordinatorClusterSpec {
+
+  override val passivateAfter = java.time.Duration.ofSeconds(10)
+
+  override lazy val minicluster: NsdbMiniCluster = new MiniClusterStarter(nodesNumber, passivateAfter)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    waitPassivation()
+    waitPassivation()
+  }
+}

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/cluster/ReadCoordinatorClusterSpec.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/cluster/ReadCoordinatorClusterSpec.scala
@@ -91,7 +91,6 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
                  10.seconds)
 
     waitIndexing()
-    waitIndexing()
   }
 
   override def afterAll(): Unit = {

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/MiniClusterSpec.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/MiniClusterSpec.scala
@@ -1,4 +1,6 @@
 package io.radicalbit.nsdb.minicluster
+import java.time.Duration
+
 import org.json4s.DefaultFormats
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
@@ -7,6 +9,8 @@ trait MiniClusterSpec extends FunSuite with BeforeAndAfterAll {
   val nodesNumber: Int
 
   implicit val formats = DefaultFormats
+
+  def passivateAfter: Duration = Duration.ofHours(1)
 
   lazy val minicluster: NsdbMiniCluster = new MiniClusterStarter(nodesNumber)
 
@@ -21,5 +25,6 @@ trait MiniClusterSpec extends FunSuite with BeforeAndAfterAll {
   protected lazy val indexingTime: Long =
     minicluster.nodes.head.system.settings.config.getDuration("nsdb.write.scheduler.interval").toMillis
 
-  protected def waitIndexing(): Unit = Thread.sleep(indexingTime + 1000)
+  protected def waitIndexing(): Unit    = Thread.sleep(indexingTime + 1000)
+  protected def waitPassivation(): Unit = Thread.sleep(passivateAfter.toMillis + 1000)
 }

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/MiniClusterStarter.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/MiniClusterStarter.scala
@@ -16,10 +16,14 @@
 
 package io.radicalbit.nsdb.minicluster
 
-class MiniClusterStarter(override val nodesNumber: Int) extends NsdbMiniCluster
+import java.time.Duration
+
+class MiniClusterStarter(override val nodesNumber: Int, override val passivateAfter: Duration = Duration.ofHours(1))
+    extends NsdbMiniCluster
 
 object MiniClusterStarter extends App with NsdbMiniCluster {
-  override protected[this] def nodesNumber = 2
+  override protected[this] def nodesNumber              = 2
+  override protected[this] def passivateAfter: Duration = Duration.ofHours(1)
 
   start()
 }

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NSDbMiniClusterNode.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NSDbMiniClusterNode.scala
@@ -16,10 +16,13 @@
 
 package io.radicalbit.nsdb.minicluster
 
+import java.time.Duration
+
 class NSDbMiniClusterNode(val akkaRemotePort: Int,
                           val httpPort: Int,
                           val uiPort: Int,
                           val grpcPort: Int,
                           val dataDir: String,
-                          val commitLogDir: String)
+                          val commitLogDir: String,
+                          val passivateAfter: Duration = Duration.ofHours(1))
     extends NSDbMiniClusterDefinition {}

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NsdbMiniCluster.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NsdbMiniCluster.scala
@@ -17,6 +17,7 @@
 package io.radicalbit.nsdb.minicluster
 
 import java.io.File
+import java.time.Duration
 import java.util.UUID
 
 import com.typesafe.scalalogging.LazyLogging
@@ -36,6 +37,7 @@ trait NsdbMiniCluster extends LazyLogging {
   protected[this] val clFolder               = s"target/commitLog/$instanceId"
 
   protected[this] def nodesNumber: Int
+  protected[this] def passivateAfter: Duration
 
   lazy val nodes: Set[NSDbMiniClusterNode] =
     (for {
@@ -48,7 +50,8 @@ trait NsdbMiniCluster extends LazyLogging {
         uiPort = startingUiPort + i,
         grpcPort = startingGrpcPort + i,
         dataDir = s"$rootFolder/data${startingAkkaRemotePort + i}",
-        commitLogDir = s"$clFolder$i"
+        commitLogDir = s"$clFolder$i",
+        passivateAfter = passivateAfter
       )).toSet
 
   def start(cleanup: Boolean = false): Unit = {

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NsdbMiniClusterConf.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NsdbMiniClusterConf.scala
@@ -16,6 +16,8 @@
 
 package io.radicalbit.nsdb.minicluster
 
+import java.time.Duration
+
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import io.radicalbit.nsdb.common.NsdbConfig
 
@@ -27,6 +29,7 @@ trait NsdbMiniClusterConf extends NsdbConfig {
   def uiPort: Int
   def dataDir: String
   def commitLogDir: String
+  def passivateAfter: Duration
 
   override def config: Config =
     ConfigFactory
@@ -37,4 +40,5 @@ trait NsdbMiniClusterConf extends NsdbConfig {
       .withValue("nsdb.ui.port", ConfigValueFactory.fromAnyRef(uiPort))
       .withValue("nsdb.index.base-path", ConfigValueFactory.fromAnyRef(dataDir))
       .withValue("nsdb.commit-log.directory", ConfigValueFactory.fromAnyRef(commitLogDir))
+      .withValue("nsdb.sharding.passivate-after", ConfigValueFactory.fromAnyRef(passivateAfter))
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,13 +41,13 @@ object Dependencies {
   }
 
   object cats {
-    lazy val version   = "0.9.0"
+    lazy val version   = "1.6.0"
     lazy val namespace = "org.typelevel"
-    lazy val cats      = namespace %% "cats" % version
+    lazy val cats_core      = namespace %% "cats-core" % version
   }
 
   object spire {
-    lazy val version   = "0.14.1"
+    lazy val version   = "0.16.2"
     lazy val namespace = "org.typelevel"
     lazy val spire     = namespace %% "spire" % version
   }
@@ -116,7 +116,7 @@ object Dependencies {
   }
 
   object lucene {
-    lazy val version     = "7.7.0"
+    lazy val version     = "8.1.1"
     lazy val namespace   = "org.apache.lucene"
     lazy val core        = namespace % "lucene-core" % version
     lazy val queryParser = namespace % "lucene-queryparser" % version
@@ -125,7 +125,7 @@ object Dependencies {
   }
 
   object scalatest {
-    lazy val version   = "3.0.5"
+    lazy val version   = "3.0.7"
     lazy val namespace = "org.scalatest"
     lazy val core      = namespace %% "scalatest" % version
   }
@@ -159,8 +159,6 @@ object Dependencies {
     private lazy val namespace = "com.datamountaineer"
     lazy val kcql              = namespace % "kcql" % version
   }
-
-  lazy val asm = "asm" % "asm" % "3.3.1" % Test //import to use ClosureCleaner in test
 
   object gRPC {
     lazy val version         = scalapb.compiler.Version.grpcJavaVersion
@@ -290,7 +288,7 @@ object Dependencies {
       scalaLang.compiler,
       scopt.scopt,
       asciitable.core,
-      cats.cats,
+      cats.cats_core,
       scala_logging.scala_logging,
       akka.slf4j,
       logback.logback,

--- a/project/PublishSettings.scala
+++ b/project/PublishSettings.scala
@@ -26,9 +26,9 @@ object PublishSettings {
     publishTo := version { v: String =>
       if (v.trim.endsWith("SNAPSHOT"))
         Some(
-          "Artifactory Realm" at "https://tools.radicalbit.io/artifactory/libs-snapshot-local;build.timestamp=" + new java.util.Date().getTime)
+          "Artifactory Realm" at "https://tools.radicalbit.io/artifactory/public-snapshot;build.timestamp=" + new java.util.Date().getTime)
       else
-        Some("Artifactory Realm" at "https://tools.radicalbit.io/artifactory/libs-release-local")
+        Some("Artifactory Realm" at "https://tools.radicalbit.io/artifactory/public-release/")
     }.value,
     credentials += Credentials(Path.userHome / ".artifactory" / ".credentials")
   )

--- a/version.sbt
+++ b/version.sbt
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-version in ThisBuild := "0.7.0-SNAPSHOT"
+version in ThisBuild := "0.8.0-SNAPSHOT"


### PR DESCRIPTION
This PR aims to improve the management of the allocated resources by the indices.

a configuration parameter `passivate-after` of type `Duration` has been added.
The parameter is used inside the actors in order to deallocate all the not needed resources (shard actors, lucene directories)

Some minor fix has been introduced as well in the build and in the modules structure