### PR TITLE
Improve Coordinate Retrieval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot
+    - $HOME/.custom-cache
 script:
-- sbt -jvm-opts .jvmopts-travis clean coverage ++$TRAVIS_SCALA_VERSION test coverageReport coverageAggregate
+- sbt -jvm-opts .jvmopts-travis clean fixCheck coverage ++$TRAVIS_SCALA_VERSION test coverageReport coverageAggregate
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ cache:
     - $HOME/.sbt/boot
     - $HOME/.custom-cache
 script:
-- sbt -jvm-opts .jvmopts-travis clean fixCheck coverage ++$TRAVIS_SCALA_VERSION test coverageReport coverageAggregate
+- sbt -jvm-opts .jvmopts-travis clean coverage ++$TRAVIS_SCALA_VERSION fixCheck test coverageReport coverageAggregate
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -116,8 +116,8 @@ lazy val `nsdb-web-ui` = project
         log.info("skip building ui")
         Def.task {}
       }
-    }.value
-    //(compile in Compile) := ((compile in Compile) dependsOn uiCopyTask).value
+    }.value,
+    (compile in Compile) := ((compile in Compile) dependsOn uiCopyTask).value
   )
 
 lazy val `nsdb-common` = project

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,8 @@ lazy val packageDist   = taskKey[File]("create universal package and move it to 
 lazy val packageDeb    = taskKey[File]("create debian package and move it to package folder")
 lazy val packageRpm    = taskKey[File]("create RPM package and move it to package folder")
 
+addCommandAlias("fix", "all compile:scalafix test:scalafix")
+addCommandAlias("fixCheck", "; compile:scalafix --check ; test:scalafix --check")
 addCommandAlias("dist", "packageDist")
 addCommandAlias("deb", "packageDeb")
 addCommandAlias("rpm", "packageRpm")
@@ -114,8 +116,8 @@ lazy val `nsdb-web-ui` = project
         log.info("skip building ui")
         Def.task {}
       }
-    }.value,
-    (compile in Compile) := ((compile in Compile) dependsOn uiCopyTask).value
+    }.value
+    //(compile in Compile) := ((compile in Compile) dependsOn uiCopyTask).value
   )
 
 lazy val `nsdb-common` = project

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -31,7 +31,8 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.createNodeName
 import io.radicalbit.nsdb.cluster.index.MetricInfo
 import io.radicalbit.nsdb.model.Location
-import io.radicalbit.nsdb.protocol.MessageProtocol.Events.WarmUpCompleted
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.GetDbs
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{DbsGot, WarmUpCompleted}
 import io.radicalbit.nsdb.util.ActorPathLogging
 
 import scala.concurrent.Future
@@ -41,7 +42,7 @@ import scala.concurrent.Future
   * @param cache cluster aware metric's location cache
   */
 class MetadataCoordinator(cache: ActorRef, mediator: ActorRef) extends ActorPathLogging with Stash {
-  val cluster = Cluster(context.system)
+  private val cluster = Cluster(context.system)
 
   implicit val timeout: Timeout = Timeout(
     context.system.settings.config.getDuration("nsdb.metadata-coordinator.timeout", TimeUnit.SECONDS),
@@ -146,6 +147,11 @@ class MetadataCoordinator(cache: ActorRef, mediator: ActorRef) extends ActorPath
       }
 
   def operative: Receive = {
+    case GetDbs =>
+      (cache ? GetDbsFromCache)
+        .mapTo[DbsFromCacheGot]
+        .map(m => DbsGot(m.dbs))
+        .pipeTo(sender())
     case GetLocations(db, namespace, metric) =>
       (cache ? GetLocationsFromCache(db, namespace, metric))
         .mapTo[LocationsCached]

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -31,8 +31,8 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.createNodeName
 import io.radicalbit.nsdb.cluster.index.MetricInfo
 import io.radicalbit.nsdb.model.Location
-import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.{GetDbs, GetNamespaces}
-import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{DbsGot, NamespacesGot, WarmUpCompleted}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.{GetDbs, GetMetrics, GetNamespaces}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{DbsGot, MetricsGot, NamespacesGot, WarmUpCompleted}
 import io.radicalbit.nsdb.util.ActorPathLogging
 
 import scala.concurrent.Future
@@ -156,6 +156,11 @@ class MetadataCoordinator(cache: ActorRef, mediator: ActorRef) extends ActorPath
       (cache ? GetNamespacesFromCache(db))
         .mapTo[NamespacesFromCacheGot]
         .map(m => NamespacesGot(db, m.namespaces))
+        .pipeTo(sender())
+    case GetMetrics(db, namespace) =>
+      (cache ? GetMetricsFromCache(db, namespace))
+        .mapTo[MetricsFromCacheGot]
+        .map(m => MetricsGot(db, namespace, m.metrics))
         .pipeTo(sender())
     case GetLocations(db, namespace, metric) =>
       (cache ? GetLocationsFromCache(db, namespace, metric))

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -31,8 +31,8 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.createNodeName
 import io.radicalbit.nsdb.cluster.index.MetricInfo
 import io.radicalbit.nsdb.model.Location
-import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.GetDbs
-import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{DbsGot, WarmUpCompleted}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.{GetDbs, GetNamespaces}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{DbsGot, NamespacesGot, WarmUpCompleted}
 import io.radicalbit.nsdb.util.ActorPathLogging
 
 import scala.concurrent.Future
@@ -151,6 +151,11 @@ class MetadataCoordinator(cache: ActorRef, mediator: ActorRef) extends ActorPath
       (cache ? GetDbsFromCache)
         .mapTo[DbsFromCacheGot]
         .map(m => DbsGot(m.dbs))
+        .pipeTo(sender())
+    case GetNamespaces(db) =>
+      (cache ? GetNamespacesFromCache(db))
+        .mapTo[NamespacesFromCacheGot]
+        .map(m => NamespacesGot(db, m.namespaces))
         .pipeTo(sender())
     case GetLocations(db, namespace, metric) =>
       (cache ? GetLocationsFromCache(db, namespace, metric))

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -174,12 +174,8 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
       metadataCoordinator forward GetDbs
     case msg @ GetNamespaces(_) =>
       metadataCoordinator forward msg
-    case msg @ GetMetrics(db, namespace) =>
-      Future
-        .sequence(metricsDataActors.values.toSeq.map(actor => (actor ? msg).mapTo[MetricsGot].map(_.metrics)))
-        .map(_.flatten.toSet)
-        .map(metrics => MetricsGot(db, namespace, metrics))
-        .pipeTo(sender)
+    case msg @ GetMetrics(_, _) =>
+      metadataCoordinator forward msg
     case msg: GetSchema =>
       schemaCoordinator forward msg
     case ExecuteStatement(statement) =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -170,12 +170,8 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
       sender() ! MetricsDataActorSubscribed(actor, nodeName)
     case GetConnectedDataNodes =>
       sender ! ConnectedDataNodesGot(metricsDataActors.keys.toSeq)
-    case msg @ GetDbs =>
-      Future
-        .sequence(metricsDataActors.values.toSeq.map(actor => (actor ? msg).mapTo[DbsGot].map(_.dbs)))
-        .map(_.flatten.toSet)
-        .map(dbs => DbsGot(dbs))
-        .pipeTo(sender)
+    case GetDbs =>
+      metadataCoordinator forward GetDbs
     case msg @ GetNamespaces(db) =>
       Future
         .sequence(metricsDataActors.values.toSeq.map(actor => (actor ? msg).mapTo[NamespacesGot].map(_.namespaces)))

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -172,12 +172,8 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
       sender ! ConnectedDataNodesGot(metricsDataActors.keys.toSeq)
     case GetDbs =>
       metadataCoordinator forward GetDbs
-    case msg @ GetNamespaces(db) =>
-      Future
-        .sequence(metricsDataActors.values.toSeq.map(actor => (actor ? msg).mapTo[NamespacesGot].map(_.namespaces)))
-        .map(_.flatten.toSet)
-        .map(namespaces => NamespacesGot(db, namespaces))
-        .pipeTo(sender)
+    case msg @ GetNamespaces(_) =>
+      metadataCoordinator forward msg
     case msg @ GetMetrics(db, namespace) =>
       Future
         .sequence(metricsDataActors.values.toSeq.map(actor => (actor ? msg).mapTo[MetricsGot].map(_.metrics)))

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -144,7 +144,7 @@ class ReplicatedMetadataCacheSpec
           expectMsg(LocationsCached("db", "namespace", metric, Seq(location1, location2)))
         }
         awaitAssert{
-          replicatedCache ! GetDbsFromCache()
+          replicatedCache ! GetDbsFromCache
           expectMsg(DbsFromCacheGot(Set("db")))
         }
       }
@@ -185,7 +185,7 @@ class ReplicatedMetadataCacheSpec
           expectMsg(LocationsCached("db1", "namespace", metric, Seq(location2)))
         }
         awaitAssert{
-          replicatedCache ! GetDbsFromCache()
+          replicatedCache ! GetDbsFromCache
           expectMsg(DbsFromCacheGot(Set("db", "db1")))
         }
       }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/FakeMetadataCache.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/FakeMetadataCache.scala
@@ -20,6 +20,7 @@ import akka.actor.{Actor, Props}
 import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache._
 import io.radicalbit.nsdb.cluster.coordinator.FakeMetadataCache.{DeleteAll, DeleteDone}
 import io.radicalbit.nsdb.cluster.index.MetricInfo
+import io.radicalbit.nsdb.common.protocol.Coordinates
 import io.radicalbit.nsdb.model.Location
 
 import scala.collection.mutable
@@ -30,17 +31,21 @@ class FakeMetadataCache extends Actor {
 
   val metricInfo: mutable.Map[MetricInfoCacheKey, MetricInfo] = mutable.Map.empty
 
-  val dbsNamespaces: mutable.Set[(String, String)] = mutable.Set.empty
+  val coordinates: mutable.Set[Coordinates] = mutable.Set.empty
 
   def receive: Receive = {
     case GetDbsFromCache =>
-      sender ! DbsFromCacheGot(dbsNamespaces.map(_._1).toSet)
+      sender ! DbsFromCacheGot(coordinates.map(_.db).toSet)
     case GetNamespacesFromCache(db) =>
-      sender ! NamespacesFromCacheGot(db, dbsNamespaces.filter(_._1 == db).map(_._2).toSet)
+      sender ! NamespacesFromCacheGot(db, coordinates.filter(c => c.db == db).map(_.namespace).toSet)
+    case GetMetricsFromCache(db, namespace) =>
+      sender ! MetricsFromCacheGot(db,
+                                   namespace,
+                                   coordinates.filter(c => c.db == db && c.namespace == namespace).map(_.metric).toSet)
     case PutLocationInCache(db, namespace, metric, from, to, value) =>
       val key = LocationWithNodeKey(db, namespace, metric, value.node, from: Long, to: Long)
       locations.put(key, value)
-      dbsNamespaces += ((db, namespace))
+      coordinates += Coordinates(db, namespace, metric)
       sender ! LocationCached(db, namespace, metric, from, to, value)
     case GetLocationsFromCache(db, namespace, metric) =>
       val key                 = MetricLocationsCacheKey(db, namespace, metric)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/FakeMetadataCache.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/FakeMetadataCache.scala
@@ -30,15 +30,17 @@ class FakeMetadataCache extends Actor {
 
   val metricInfo: mutable.Map[MetricInfoCacheKey, MetricInfo] = mutable.Map.empty
 
-  val dbs: mutable.Set[String] = mutable.Set.empty
+  val dbsNamespaces: mutable.Set[(String, String)] = mutable.Set.empty
 
   def receive: Receive = {
     case GetDbsFromCache =>
-      sender ! DbsFromCacheGot(dbs.toSet)
+      sender ! DbsFromCacheGot(dbsNamespaces.map(_._1).toSet)
+    case GetNamespacesFromCache(db) =>
+      sender ! NamespacesFromCacheGot(db, dbsNamespaces.filter(_._1 == db).map(_._2).toSet)
     case PutLocationInCache(db, namespace, metric, from, to, value) =>
       val key = LocationWithNodeKey(db, namespace, metric, value.node, from: Long, to: Long)
       locations.put(key, value)
-      dbs += db
+      dbsNamespaces += ((db, namespace))
       sender ! LocationCached(db, namespace, metric, from, to, value)
     case GetLocationsFromCache(db, namespace, metric) =>
       val key                 = MetricLocationsCacheKey(db, namespace, metric)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/FakeMetadataCache.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/FakeMetadataCache.scala
@@ -30,10 +30,15 @@ class FakeMetadataCache extends Actor {
 
   val metricInfo: mutable.Map[MetricInfoCacheKey, MetricInfo] = mutable.Map.empty
 
+  val dbs: mutable.Set[String] = mutable.Set.empty
+
   def receive: Receive = {
+    case GetDbsFromCache =>
+      sender ! DbsFromCacheGot(dbs.toSet)
     case PutLocationInCache(db, namespace, metric, from, to, value) =>
       val key = LocationWithNodeKey(db, namespace, metric, value.node, from: Long, to: Long)
       locations.put(key, value)
+      dbs += db
       sender ! LocationCached(db, namespace, metric, from, to, value)
     case GetLocationsFromCache(db, namespace, metric) =>
       val key                 = MetricLocationsCacheKey(db, namespace, metric)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/SchemaCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/SchemaCoordinatorSpec.scala
@@ -16,12 +16,11 @@
 
 package io.radicalbit.nsdb.cluster.coordinator
 
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import akka.actor.{ActorSystem, Props}
 import akka.cluster.pubsub.DistributedPubSubMediator.Publish
 import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
-import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import io.radicalbit.nsdb.cluster.coordinator.SchemaCoordinator.commands.WarmUpSchemas
 import io.radicalbit.nsdb.common.protocol._
 import io.radicalbit.nsdb.index._

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
@@ -134,7 +134,7 @@ class WriteCoordinatorErrorsSpec
 
       compensationMessage.action.shouldBe(RejectedEntryAction(record1))
 
-      val externalResponse = awaitAssert {
+      awaitAssert {
         callingProbe.expectMsgType[RecordRejected]
       }
     }
@@ -174,7 +174,7 @@ class WriteCoordinatorErrorsSpec
 
       rejectionRequestNode2.action.shouldBe(RejectedEntryAction(record2))
 
-      val externalResponse = awaitAssert {
+      awaitAssert {
         callingProbe.expectMsgType[RecordRejected]
       }
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/RollingCommitLogFileWriterSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/RollingCommitLogFileWriterSpec.scala
@@ -22,10 +22,10 @@ import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
-import io.radicalbit.nsdb.commit_log.CommitLogWriterActor.{CommitLogBitEntry, RejectedEntryAction, WriteToCommitLog}
+import io.radicalbit.nsdb.commit_log.CommitLogWriterActor.{RejectedEntryAction, WriteToCommitLog}
 import io.radicalbit.nsdb.commit_log.RollingCommitLogFileWriter.ForceRolling
 import io.radicalbit.nsdb.model.Location
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.{BeforeAndAfter, Matchers, WordSpecLike}
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -81,7 +81,7 @@ class RollingCommitLogFileWriterSpec
         unbalancedFileOS.flush()
         unbalancedFileOS.close()
 
-        val rolling = system.actorOf(RollingCommitLogFileWriter.props(db, namespace, metric))
+        system.actorOf(RollingCommitLogFileWriter.props(db, namespace, metric))
 
         Thread.sleep(interval.toMillis + 1000)
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/FacetIndexTest.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/FacetIndexTest.scala
@@ -217,8 +217,6 @@ class FacetIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
     implicit val writer     = facetIndexes.newIndexWriter
     implicit val taxoWriter = facetIndexes.newDirectoryTaxonomyWriter
 
-    var groups = Map.empty[String, Int]
-
     (1 to 100).foreach { i =>
       val factor = i / 4
       val tag    = s"tag_$factor"
@@ -322,8 +320,6 @@ class FacetIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
     implicit val writer     = facetIndexes.newIndexWriter
     implicit val taxoWriter = facetIndexes.newDirectoryTaxonomyWriter
 
-    var groups = Map.empty[String, Int]
-
     (1 to 100).foreach { i =>
       val factor: Double = 1.2d
       val tag            = s"tag_${i / 10}"
@@ -343,13 +339,12 @@ class FacetIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
     val res = facetIndexes.facetSumIndex
       .result(LongPoint.newRangeQuery("timestamp", 0, 50), "tag", None, None, VARCHAR(), Some(DECIMAL()))
     res.size shouldBe 6
-    res.foreach {
-      case bit =>
-        bit.tags.headOption match {
-          case Some(("tag", "tag_0"))   => Math.abs(bit.value.asInstanceOf[Double] - 10.8d) should be < 1e-7
-          case Some(("tag", "tag_5"))   => Math.abs(bit.value.asInstanceOf[Double] - 1.2d) should be < 1e-7
-          case Some(("tag", v: String)) => Math.abs(bit.value.asInstanceOf[Double] - 12.0d) should be < 1e-7
-        }
+    res.foreach { bit =>
+      bit.tags.headOption match {
+        case Some(("tag", "tag_0"))   => Math.abs(bit.value.asInstanceOf[Double] - 10.8d) should be < 1e-7
+        case Some(("tag", "tag_5"))   => Math.abs(bit.value.asInstanceOf[Double] - 1.2d) should be < 1e-7
+        case Some(("tag", v: String)) => Math.abs(bit.value.asInstanceOf[Double] - 12.0d) should be < 1e-7
+      }
     }
   }
 }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeSeriesIndexTest.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeSeriesIndexTest.scala
@@ -21,11 +21,10 @@ import java.util.UUID
 
 import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType, TagFieldType}
 import io.radicalbit.nsdb.model.{Schema, SchemaField}
-import io.radicalbit.nsdb.statement.StatementParser.InternalMaxAggregation
 import org.apache.lucene.document.LongPoint
 import org.apache.lucene.index.Term
 import org.apache.lucene.search._
-import org.apache.lucene.store.{MMapDirectory, RAMDirectory}
+import org.apache.lucene.store.MMapDirectory
 import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
 
 class TimeSeriesIndexTest extends FlatSpec with Matchers with OneInstancePerTest {


### PR DESCRIPTION
This Pr Improves the design of the method that retrieves the NSDb coordinates.
- getDbs
- getNamespaces given a Db
- getMetrics given a Db and a Namespace

Basically, a dedicated distributed cache entry has been provided and used to retrieve the coordinates instead of relying on the children actors