### PR TITLE
Add Retention In Init JVM API

### DIFF
--- a/docs/JVM_API_doc.md
+++ b/docs/JVM_API_doc.md
@@ -13,8 +13,13 @@ In both cases, communication to NSDb cluster is handled using a gRPC Client inst
 
 ## Init API
 Before writing into a metric, NSDb provides an api that makes possible to set some metric parameter in order to optimize write or read performance.
-The Init api allows the user to set a custom shard interval for a metric. If this api is not called, the default shard interval will be used for the metric.
-The shard interval is expressed using the [Java Duration](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html) convention (23 seconds, 23 s, 24h etc).
+The Init api allows the user to set the following custom parameters for a metric
+
+- shard interval: the time interval that determines the shard duration.
+- retention: the time interval in which data are kept into the indices.
+
+If this api is not called, the default shard interval and an infinite retention will be used for the metric.
+The shard interval and the retention are expressed using the [Java Duration](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html) convention (e.g. 23 seconds, 23 s, 24h etc).
 This operation is allowed only before the first bit is written. Otherwise an error message will be returned  
 
 **Example**
@@ -24,12 +29,14 @@ public class NSDBInitMetric {
     public static void main(String[] args) throws Exception {
         NSDB nsdb = NSDB.connect("127.0.0.1", 7817).get();
 
-        NSDB.BitInfo bitInfo = nsdb.db("root")
+        NSDB.BitInfo metricInfo = nsdb.db("root")
                 .namespace("registry")
-                .bit("people").shardInterval("2d");
+                .bit("people")
+                .shardInterval("2d")
+                .retention("2d");
 
 
-        InitMetricResult result = nsdb.initMetric(bitInfo).get();
+        InitMetricResult result = nsdb.initMetric(metricInfo).get();
         System.out.println("IsSuccessful = " + result.isCompletedSuccessfully());
         System.out.println("errors = " + result.getErrorMsg());
     }

--- a/nsdb-cli/src/main/scala/io/radicalbit/nsdb/cli/console/NsdbILoop.scala
+++ b/nsdb-cli/src/main/scala/io/radicalbit/nsdb/cli/console/NsdbILoop.scala
@@ -279,7 +279,7 @@ class NsdbILoop(host: Option[String],
     case DescribeMetric(_, namespace, metric) =>
       processCommandResponse[CommandStatementExecuted](
         clientGrpc
-          .describeMetrics(GrpcDescribeMetric(db, namespace, metric))
+          .describeMetric(GrpcDescribeMetric(db, namespace, metric))
           .map(toInternalCommandResponse[GrpcDescribeMetricResponse]),
         tableBuilder.tableFor,
         lineToRecord

--- a/nsdb-cli/src/main/scala/io/radicalbit/nsdb/cli/console/NsdbILoop.scala
+++ b/nsdb-cli/src/main/scala/io/radicalbit/nsdb/cli/console/NsdbILoop.scala
@@ -22,6 +22,7 @@ import com.typesafe.scalalogging.LazyLogging
 import io.radicalbit.nsdb.cli.table.ASCIITableBuilder
 import io.radicalbit.nsdb.client.rpc.GRPCClient
 import io.radicalbit.nsdb.common.JSerializable
+import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.{CommandStatementExecuted, _}
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.rpc.health.HealthCheckResponse
@@ -34,7 +35,7 @@ import io.radicalbit.nsdb.rpc.requestCommand.{
 import io.radicalbit.nsdb.rpc.requestSQL.SQLRequestStatement
 import io.radicalbit.nsdb.rpc.responseCommand.{
   Namespaces,
-  MetricSchemaRetrieved => GrpcMetricSchemaRetrieved,
+  DescribeMetricResponse => GrpcDescribeMetricResponse,
   MetricsGot => GrpcMetricsGot
 }
 import io.radicalbit.nsdb.rpc.responseSQL.SQLStatementResponse
@@ -167,8 +168,8 @@ class NsdbILoop(host: Option[String],
           ))
     }
 
-  private def fieldClassTypeFor(field: GrpcMetricSchemaRetrieved.MetricField): FieldClassType = {
-    import GrpcMetricSchemaRetrieved.MetricField.FieldClassType._
+  private def fieldClassTypeFor(field: GrpcDescribeMetricResponse.MetricField): FieldClassType = {
+    import GrpcDescribeMetricResponse.MetricField.FieldClassType._
 
     field.fieldClassType match {
       case DIMENSION => DimensionFieldType
@@ -182,7 +183,7 @@ class NsdbILoop(host: Option[String],
     * Manages server responses from [[CommandStatement]] client requests
     * Transform gRPC protocol depending messages into client managed ones.
     *
-    * @param gRpcResponse server response oneOf [[GrpcMetricsGot]], [[GrpcMetricSchemaRetrieved]],
+    * @param gRpcResponse server response oneOf [[GrpcMetricsGot]], [[GrpcDescribeMetricResponse]],
     * @tparam T type parameter of gRpcResponse
     * @return internal representation on gRPC response
     */
@@ -190,19 +191,21 @@ class NsdbILoop(host: Option[String],
     gRpcResponse match {
       case r: GrpcMetricsGot if r.completedSuccessfully =>
         NamespaceMetricsListRetrieved(r.db, r.namespace, r.metrics.toList)
-      case r: GrpcMetricSchemaRetrieved if r.completedSuccessfully =>
-        MetricSchemaRetrieved(
+      case r: GrpcDescribeMetricResponse if r.completedSuccessfully =>
+        DescribeMetricResponse(
           r.db,
           r.namespace,
           r.metric,
-          r.fields.map(field => MetricField(field.name, fieldClassTypeFor(field), field.indexType)).toList)
+          r.fields.map(field => MetricField(field.name, fieldClassTypeFor(field), field.indexType)).toList,
+          metricInfo = r.metricInfo.map(mi => MetricInfo(r.metric, mi.shardInterval, mi.retention))
+        )
       case r: Namespaces if r.completedSuccessfully =>
         NamespacesListRetrieved(r.db, r.namespaces)
       case r: Namespaces =>
         CommandStatementExecutedWithFailure(r.errors)
       case r: GrpcMetricsGot =>
         CommandStatementExecutedWithFailure(r.errors)
-      case r: GrpcMetricSchemaRetrieved =>
+      case r: GrpcDescribeMetricResponse =>
         CommandStatementExecutedWithFailure(r.errors)
     }
 
@@ -277,7 +280,7 @@ class NsdbILoop(host: Option[String],
       processCommandResponse[CommandStatementExecuted](
         clientGrpc
           .describeMetrics(GrpcDescribeMetric(db, namespace, metric))
-          .map(toInternalCommandResponse[GrpcMetricSchemaRetrieved]),
+          .map(toInternalCommandResponse[GrpcDescribeMetricResponse]),
         tableBuilder.tableFor,
         lineToRecord
       )

--- a/nsdb-cli/src/main/scala/io/radicalbit/nsdb/cli/table/ASCIITableBuilder.scala
+++ b/nsdb-cli/src/main/scala/io/radicalbit/nsdb/cli/table/ASCIITableBuilder.scala
@@ -121,7 +121,7 @@ class ASCIITableBuilder(tableMaxWidth: Int) extends LazyLogging {
     commandResult match {
       case res: NamespaceMetricsListRetrieved =>
         Try(render(List("Metric Name"), res.metrics.map(m => List(m))))
-      case res: MetricSchemaRetrieved =>
+      case res: DescribeMetricResponse =>
         Try(
           render(List("Field Name", "Type", "Field Class Type"),
                  res.fields.map(x =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
@@ -22,7 +22,7 @@ import akka.actor.{Actor, ActorLogging, ActorRef}
 import akka.cluster.ddata._
 import akka.pattern.{ask, pipe}
 import akka.util.Timeout
-import io.radicalbit.nsdb.cluster.index.MetricInfo
+import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.Coordinates
 import io.radicalbit.nsdb.model.Location
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -27,8 +27,9 @@ import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache._
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands._
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.createNodeName
-import io.radicalbit.nsdb.cluster.index.{MetricInfo, MetricInfoIndex}
+import io.radicalbit.nsdb.cluster.index.MetricInfoIndex
 import io.radicalbit.nsdb.cluster.util.FileUtils
+import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.Coordinates
 import io.radicalbit.nsdb.index.DirectorySupport
 import io.radicalbit.nsdb.model.Location

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndex.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndex.scala
@@ -16,6 +16,7 @@
 
 package io.radicalbit.nsdb.cluster.index
 
+import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.index.SimpleIndex
 import io.radicalbit.nsdb.index.lucene.Index._
 import io.radicalbit.nsdb.statement.StatementParser.SimpleField
@@ -27,13 +28,6 @@ import org.apache.lucene.store.Directory
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
-
-/**
-  * Metric Info.
-  * @param metric the metric.
-  * @param shardInterval shard interval for the metric in milliseconds
-  */
-case class MetricInfo(metric: String, shardInterval: Long)
 
 /**
   * Index for storing metric info (shard interval).
@@ -74,8 +68,6 @@ class MetricInfoIndex(override val directory: Directory) extends SimpleIndex[Met
   def getMetricInfo(metric: String): Option[MetricInfo] = {
     val results = handleNoIndexResults(Try {
       val queryTerm = new TermQuery(new Term(_keyField, metric))
-
-      implicit val searcher: IndexSearcher = getSearcher
 
       query(queryTerm, Seq.empty, Integer.MAX_VALUE, None)(identity)
     })

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -11,7 +11,7 @@ import com.typesafe.config.ConfigFactory
 import io.radicalbit.nsdb.cluster.actor.DatabaseActorsGuardian.{GetMetadataCache, GetSchemaCache}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands._
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
-import io.radicalbit.nsdb.cluster.index.MetricInfo
+import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.rtsae.STMultiNodeSpec
 
@@ -145,7 +145,7 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
 
     "add metric info from different nodes" in within(10.seconds) {
 
-      val metricInfo = MetricInfo("metric", 100)
+      val metricInfo = MetricInfo("metric", 100, 30)
 
       runOn(node1) {
         val selfMember = cluster.selfMember

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -9,7 +9,7 @@ import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec}
 import akka.testkit.ImplicitSender
 import com.typesafe.config.ConfigFactory
 import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache._
-import io.radicalbit.nsdb.cluster.index.MetricInfo
+import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.rtsae.STMultiNodeSpec
 import org.json4s.DefaultFormats

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -25,7 +25,7 @@ import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands._
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.coordinator.mockedActors.LocalMetadataCache
-import io.radicalbit.nsdb.cluster.index.MetricInfo
+import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.model.Location
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
@@ -18,7 +18,7 @@ package io.radicalbit.nsdb.cluster.coordinator.mockedActors
 
 import akka.actor.{Actor, Props}
 import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache._
-import io.radicalbit.nsdb.cluster.index.MetricInfo
+import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.Coordinates
 import io.radicalbit.nsdb.model.Location
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndexTest.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndexTest.scala
@@ -19,6 +19,7 @@ package io.radicalbit.nsdb.cluster.index
 import java.nio.file.Files
 import java.util.UUID
 
+import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.index.DirectorySupport
 import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
 

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/model/MetricInfo.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/model/MetricInfo.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.common.model
+
+/**
+  * Metric Info.
+  *
+  * @param metric        the metric.
+  * @param shardInterval shard interval for the metric in milliseconds.
+  * @param retention     period in which data is stored for the metric, 0 means infinite.
+  */
+case class MetricInfo(metric: String, shardInterval: Long, retention: Long = 0)

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/EndpointProtocol.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/EndpointProtocol.scala
@@ -16,6 +16,7 @@
 
 package io.radicalbit.nsdb.common.protocol
 
+import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.statement.{CommandStatement, SQLStatement}
 
 /**
@@ -64,7 +65,8 @@ case class SQLStatementExecuted(db: String, namespace: String, metric: String, r
 case class SQLStatementFailed(db: String, namespace: String, metric: String, reason: String) extends SQLStatementResult
 
 /**
-  * Describes a metric field. See [[MetricSchemaRetrieved]].
+  * Describes a metric field. See [[DescribeMetricResponse]].
+  *
   * @param name field name.
   * @param `type` field type (e.g. VARCHAR, INT, BIGINT, ecc.).
   */
@@ -76,14 +78,18 @@ case class MetricField(name: String, fieldClassType: FieldClassType, `type`: Str
   *
   * - [[NamespaceMetricsListRetrieved]] for show metrics command.
   *
-  * - [[MetricSchemaRetrieved]] for describe metric command.
+  * - [[DescribeMetricResponse]] for describe metric command.
   *
   * - [[NamespacesListRetrieved]] for show namespaces command.
   */
 sealed trait CommandStatementExecuted extends EndpointOutputProtocol
 case class NamespaceMetricsListRetrieved(db: String, namespace: String, metrics: List[String])
     extends CommandStatementExecuted
-case class MetricSchemaRetrieved(db: String, namespace: String, metric: String, fields: List[MetricField])
+case class DescribeMetricResponse(db: String,
+                                  namespace: String,
+                                  metric: String,
+                                  fields: List[MetricField],
+                                  metricInfo: Option[MetricInfo])
     extends CommandStatementExecuted
 case class NamespacesListRetrieved(db: String, namespaces: Seq[String]) extends CommandStatementExecuted
 

--- a/nsdb-java-api/src/main/java/NSDBInitMetric.java
+++ b/nsdb-java-api/src/main/java/NSDBInitMetric.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import io.radicalbit.nsdb.api.java.DescribeMetricResult;
 import io.radicalbit.nsdb.api.java.InitMetricResult;
 import io.radicalbit.nsdb.api.java.NSDB;
 
@@ -35,5 +36,12 @@ public class NSDBInitMetric {
         InitMetricResult result = nsdb.initMetric(metricInfo).get();
         System.out.println("IsSuccessful = " + result.isCompletedSuccessfully());
         System.out.println("errors = " + result.getErrorMsg());
+
+        NSDB.Bit bit = nsdb.db("root")
+                .namespace("registry")
+                .bit("people");
+
+        DescribeMetricResult describeMetricResult = nsdb.describe(bit).get();
+        System.out.println("describeMetricResult = " + describeMetricResult);
     }
 }

--- a/nsdb-java-api/src/main/java/NSDBInitMetric.java
+++ b/nsdb-java-api/src/main/java/NSDBInitMetric.java
@@ -25,12 +25,14 @@ public class NSDBInitMetric {
     public static void main(String[] args) throws Exception {
         NSDB nsdb = NSDB.connect("127.0.0.1", 7817).get();
 
-        NSDB.BitInfo bitInfo = nsdb.db("root")
+        NSDB.MetricInfo metricInfo = nsdb.db("root")
                 .namespace("registry")
-                .bit("people").shardInterval("2d");
+                .bit("people")
+                .shardInterval("2d")
+                .retention("1d");
 
 
-        InitMetricResult result = nsdb.initMetric(bitInfo).get();
+        InitMetricResult result = nsdb.initMetric(metricInfo).get();
         System.out.println("IsSuccessful = " + result.isCompletedSuccessfully());
         System.out.println("errors = " + result.getErrorMsg());
     }

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/DescribeMetricResult.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/DescribeMetricResult.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.api.java;
+
+import io.radicalbit.nsdb.rpc.responseCommand.DescribeMetricResponse;
+import scala.compat.java8.OptionConverters;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+/**
+ * Class that models the describe metric response.
+ */
+public class DescribeMetricResult {
+
+    private String db;
+    private String namespace;
+    private String metric;
+    private List<SchemaField> fields;
+    private MetricInfoResult metricInfo;
+    private boolean completedSuccessfully;
+    private String errors;
+
+
+    /**
+     * friendly Constructor that builds the object from the Grpc raw result
+     * @param describeMetricResponse the Grpc result
+     */
+    DescribeMetricResult(DescribeMetricResponse describeMetricResponse) {
+        this.db = describeMetricResponse.db();
+        this.namespace = describeMetricResponse.namespace();
+        this.metric = describeMetricResponse.metric();
+
+        this.fields = scala.collection.JavaConversions.seqAsJavaList(describeMetricResponse.fields()).stream().map(f ->  new SchemaField(f.name(), f.fieldClassType().name())).collect(Collectors.toList());
+        this.metricInfo = OptionConverters.toJava(describeMetricResponse.metricInfo()).map(mi -> new MetricInfoResult(this.metric, mi.shardInterval(), mi.retention())).orElse(new MetricInfoResult(this.metric, 0L, 0L));
+
+        this.completedSuccessfully = describeMetricResponse.completedSuccessfully();
+        this.errors = describeMetricResponse.errors();
+    }
+
+    public String getDb() {
+        return db;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getMetric() {
+        return metric;
+    }
+
+    public List<SchemaField> getFields() {
+        return fields;
+    }
+
+    public MetricInfoResult getMetricInfo() {
+        return metricInfo;
+    }
+
+    public boolean isCompletedSuccessfully() {
+        return completedSuccessfully;
+    }
+
+    public String getErrors() {
+        return errors;
+    }
+
+    @Override
+    public String toString() {
+        return "DescribeMetricResult{" +
+                "db='" + db + '\'' +
+                ", namespace='" + namespace + '\'' +
+                ", metric='" + metric + '\'' +
+                ", fields=" + fields +
+                ", metricInfo=" + metricInfo +
+                ", completedSuccessfully=" + completedSuccessfully +
+                ", errors='" + errors + '\'' +
+                '}';
+    }
+}

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/MetricInfoResult.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/MetricInfoResult.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.api.java;
+
+import java.time.Duration;
+
+/**
+ * Models a MetricInfo result contained in the describe metric response
+ *
+ * see {@link io.radicalbit.nsdb.api.java.DescribeMetricResult} for more details.
+ */
+public class MetricInfoResult {
+
+    private String metric;
+    private Duration shardInterval;
+    private Duration retention;
+
+    public MetricInfoResult(String metric, Long shardInterval, Long retention) {
+        this.metric = metric;
+        this.shardInterval = Duration.ofMillis(shardInterval);
+        this.retention = Duration.ofMillis(retention);
+    }
+
+    public String getMetric() {
+        return metric;
+    }
+
+    public Duration getShardInterval() {
+        return shardInterval;
+    }
+
+    public Duration getRetention() {
+        return retention;
+    }
+
+    @Override
+    public String toString() {
+        return "MetricInfoResult{" +
+                "metric='" + metric + '\'' +
+                ", shardInterval=" + shardInterval +
+                ", retention=" + retention +
+                '}';
+    }
+}

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/NSDB.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/NSDB.java
@@ -21,7 +21,6 @@ import io.radicalbit.nsdb.rpc.common.Dimension;
 import io.radicalbit.nsdb.rpc.common.Tag;
 import io.radicalbit.nsdb.rpc.health.HealthCheckResponse;
 import io.radicalbit.nsdb.rpc.init.InitMetricRequest;
-import io.radicalbit.nsdb.rpc.init.InitMetricResponse;
 import io.radicalbit.nsdb.rpc.request.RPCInsert;
 import io.radicalbit.nsdb.rpc.requestSQL.SQLRequestStatement;
 
@@ -321,28 +320,58 @@ public class NSDB {
         }
 
         /**
-         * Builds a BitInfo from a Bit by specifying the shardinterval
+         * Builds a MetricInfo from a Bit by specifying the shardinterval
          * @param interval shard interval according to the Duration semantic (1d, 2h, 1m etc.)
-         * @return the BitInfo with the given shard interval
+         * @return the MetricInfo with the given shard interval
          */
-        public BitInfo shardInterval(String interval) {
-            return new BitInfo(db, namespace, metric, interval);
+        public MetricInfo shardInterval(String interval) {
+            return new MetricInfo(db, namespace, metric, interval, "");
+        }
+
+        /**
+         * Builds a MetricInfo from a Bit by specifying the retention
+         * @param retention metric retention according to the Duration semantic (1d, 2h, 1m etc.)
+         * @return the MetricInfo with the given shard interval
+         */
+        public MetricInfo retention(String retention) {
+            return new MetricInfo(db, namespace, metric, "", retention);
         }
 
     }
 
-    public static class BitInfo {
+    public static class MetricInfo {
 
         private String db;
         private String namespace;
         private String metric;
         private String shardInterval;
+        private String retention;
 
-        private BitInfo(String db, String namespace, String metric, String shardInterval) {
+        private MetricInfo(String db, String namespace, String metric, String shardInterval, String retention) {
             this.db = db;
             this.namespace = namespace;
             this.metric = metric;
             this.shardInterval = shardInterval;
+        }
+
+        /**
+         * Adds a shard interval the existing instance.
+         * @param interval shard interval according to the Duration semantic (1d, 2h, 1m etc.)
+         * @return the MetricInfo with the given shard interval
+         */
+        public MetricInfo shardInterval(String interval) {
+            this.shardInterval = interval;
+            return this;
+        }
+
+        /**
+         * Adds a retention to the existing instance.
+         * @param retention metric retention according to the Duration semantic (1d, 2h, 1m etc.)
+         * @return the MetricInfo with the given shard interval
+         */
+        public MetricInfo retention(String retention) {
+            this.retention = retention;
+            return this;
         }
 
     }
@@ -416,9 +445,9 @@ public class NSDB {
     }
 
 
-    public CompletableFuture<InitMetricResult> initMetric(BitInfo bitInfo) {
+    public CompletableFuture<InitMetricResult> initMetric(MetricInfo metricInfo) {
         return toJava(client.initMetric(
-                new InitMetricRequest(bitInfo.db, bitInfo.namespace, bitInfo.metric, bitInfo.shardInterval))).toCompletableFuture().thenApply(InitMetricResult::new);
+                new InitMetricRequest(metricInfo.db, metricInfo.namespace, metricInfo.metric, metricInfo.shardInterval, metricInfo.retention))).toCompletableFuture().thenApply(InitMetricResult::new);
     }
 
 

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/NSDB.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/NSDB.java
@@ -22,6 +22,7 @@ import io.radicalbit.nsdb.rpc.common.Tag;
 import io.radicalbit.nsdb.rpc.health.HealthCheckResponse;
 import io.radicalbit.nsdb.rpc.init.InitMetricRequest;
 import io.radicalbit.nsdb.rpc.request.RPCInsert;
+import io.radicalbit.nsdb.rpc.requestCommand.DescribeMetric;
 import io.radicalbit.nsdb.rpc.requestSQL.SQLRequestStatement;
 
 import java.util.HashMap;
@@ -448,6 +449,11 @@ public class NSDB {
     public CompletableFuture<InitMetricResult> initMetric(MetricInfo metricInfo) {
         return toJava(client.initMetric(
                 new InitMetricRequest(metricInfo.db, metricInfo.namespace, metricInfo.metric, metricInfo.shardInterval, metricInfo.retention))).toCompletableFuture().thenApply(InitMetricResult::new);
+    }
+
+    public CompletableFuture<DescribeMetricResult> describe(Bit bit) {
+        return toJava(client.describeMetric(
+                new DescribeMetric(bit.db, bit.namespace, bit.metric))).toCompletableFuture().thenApply(DescribeMetricResult::new);
     }
 
 

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/SchemaField.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/SchemaField.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.api.java;
+
+/**
+ * Models a Schema field contained in the describe metric response
+ *
+ * see {@link io.radicalbit.nsdb.api.java.DescribeMetricResult} for more details.
+ */
+public class SchemaField {
+
+    private String name;
+    private String fieldType;
+
+    public SchemaField(String name, String fieldType) {
+        this.name = name;
+        this.fieldType = fieldType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getFieldType() {
+        return fieldType;
+    }
+
+    @Override
+    public String toString() {
+        return "SchemaField{" +
+                "name='" + name + '\'' +
+                ", fieldType='" + fieldType + '\'' +
+                '}';
+    }
+}

--- a/nsdb-rpc/src/main/protobuf/init.proto
+++ b/nsdb-rpc/src/main/protobuf/init.proto
@@ -23,6 +23,7 @@ message InitMetricRequest {
   string namespace = 2;
   string metric = 3;
   string shardInterval = 4;
+  string retention = 5;
 }
 
 message InitMetricResponse {

--- a/nsdb-rpc/src/main/protobuf/responseCommand.proto
+++ b/nsdb-rpc/src/main/protobuf/responseCommand.proto
@@ -26,7 +26,7 @@ message MetricsGot{
     string errors = 5;
 }
 
-message MetricSchemaRetrieved{
+message DescribeMetricResponse{
     message MetricField{
         string name = 1;
         enum FieldClassType {
@@ -38,12 +38,17 @@ message MetricSchemaRetrieved{
         FieldClassType fieldClassType = 2;
         string indexType = 3;
     }
+    message MetricInfo{
+     int64 shardInterval = 1;
+     int64 retention = 2;
+    }
     string db = 1;
     string namespace = 2;
     string metric = 3;
     repeated MetricField fields = 4;
-    bool completedSuccessfully = 5;
-    string errors = 6;
+    MetricInfo metricInfo = 5;
+    bool completedSuccessfully = 6;
+    string errors = 7;
 }
 
 message Namespaces{

--- a/nsdb-rpc/src/main/protobuf/service.proto
+++ b/nsdb-rpc/src/main/protobuf/service.proto
@@ -34,5 +34,5 @@ service NSDBServiceSQL {
 service NSDBServiceCommand {
     rpc showNamespaces (io.radicalbit.nsdb.rpc.ShowNamespaces) returns (io.radicalbit.nsdb.rpc.Namespaces) {}
     rpc showMetrics (io.radicalbit.nsdb.rpc.ShowMetrics) returns (io.radicalbit.nsdb.rpc.MetricsGot) {}
-    rpc describeMetric (io.radicalbit.nsdb.rpc.DescribeMetric) returns (io.radicalbit.nsdb.rpc.MetricSchemaRetrieved) {}
+    rpc describeMetric (io.radicalbit.nsdb.rpc.DescribeMetric) returns (io.radicalbit.nsdb.rpc.DescribeMetricResponse) {}
 }

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/client/rpc/GRPCClient.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/client/rpc/GRPCClient.scala
@@ -25,7 +25,7 @@ import io.radicalbit.nsdb.rpc.request.RPCInsert
 import io.radicalbit.nsdb.rpc.requestCommand.{DescribeMetric, ShowMetrics, ShowNamespaces}
 import io.radicalbit.nsdb.rpc.requestSQL.SQLRequestStatement
 import io.radicalbit.nsdb.rpc.response.RPCInsertResult
-import io.radicalbit.nsdb.rpc.responseCommand.{MetricSchemaRetrieved, MetricsGot, Namespaces}
+import io.radicalbit.nsdb.rpc.responseCommand.{DescribeMetricResponse, MetricsGot, Namespaces}
 import io.radicalbit.nsdb.rpc.responseSQL.SQLStatementResponse
 import io.radicalbit.nsdb.rpc.service.{NSDBServiceCommandGrpc, NSDBServiceSQLGrpc}
 import org.slf4j.LoggerFactory
@@ -89,7 +89,7 @@ class GRPCClient(host: String, port: Int) {
     stubCommand.showMetrics(request)
   }
 
-  def describeMetrics(request: DescribeMetric): Future[MetricSchemaRetrieved] = {
+  def describeMetrics(request: DescribeMetric): Future[DescribeMetricResponse] = {
     log.debug("Preparing of command describe metric for namespace: {} ", request.namespace)
     stubCommand.describeMetric(request)
   }

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/client/rpc/GRPCClient.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/client/rpc/GRPCClient.scala
@@ -89,7 +89,7 @@ class GRPCClient(host: String, port: Int) {
     stubCommand.showMetrics(request)
   }
 
-  def describeMetrics(request: DescribeMetric): Future[DescribeMetricResponse] = {
+  def describeMetric(request: DescribeMetric): Future[DescribeMetricResponse] = {
     log.debug("Preparing of command describe metric for namespace: {} ", request.namespace)
     stubCommand.describeMetric(request)
   }

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDBDescribe.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDBDescribe.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.api.scala
+
+import io.radicalbit.nsdb.rpc.requestCommand.DescribeMetric
+import io.radicalbit.nsdb.rpc.responseCommand.DescribeMetricResponse
+
+import scala.concurrent.Future
+
+/**
+  * Auxiliary class to add the describe API
+  * @param nsdb the api object representing the nsdb connection.
+  */
+class NSDBDescribe(nsdb: NSDB) {
+
+  def describe(bit: Bit): Future[DescribeMetricResponse] = {
+    nsdb.client.describeMetric(DescribeMetric(bit.db, bit.namespace, bit.metric))
+  }
+
+}

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDBMetricInfo.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDBMetricInfo.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.api.scala
+
+import io.radicalbit.nsdb.rpc.init.{InitMetricRequest, InitMetricResponse}
+
+import scala.concurrent.Future
+
+/**
+  * Auxiliary case class useful to define a init metric request.
+  * @param db the db.
+  * @param namespace the namespace.
+  * @param metric the metric.
+  * @param shardInterval the shard interval to be used to the init metric request.
+  * @param retention the retention to be used to the init metric request.
+  */
+case class MetricInfo protected (db: String,
+                                 namespace: String,
+                                 metric: String,
+                                 shardInterval: Option[String],
+                                 retention: Option[String]) {
+
+  /**
+    * Adds a Long timestamp to the bit.
+    * @param v the timestamp.
+    * @return a new instance with `v` as a timestamp.
+    */
+  def shardInterval(v: String): MetricInfo = copy(shardInterval = Some(v))
+
+  /**
+    * Adds a Long timestamp to the bit.
+    * @param v the timestamp.
+    * @return a new instance with `v` as a timestamp.
+    */
+  def retention(v: String): MetricInfo = copy(retention = Some(v))
+
+}
+
+class NSDBMetricInfo(nsdb: NSDB) {
+
+  /**
+    * Init a bit by providing all the auxiliary information inside the [[MetricInfo]]
+    * @param metricInfo the [[MetricInfo]] to be written.
+    * @return a Future of the result of the operation. See [[InitMetricResponse]]
+    */
+  def init(metricInfo: MetricInfo): Future[InitMetricResponse] =
+    nsdb.client.initMetric(
+      InitMetricRequest(metricInfo.db,
+                        metricInfo.namespace,
+                        metricInfo.metric,
+                        metricInfo.shardInterval.getOrElse(""),
+                        metricInfo.retention.getOrElse("")))
+
+}

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
@@ -16,7 +16,7 @@
 
 package io.radicalbit.nsdb.api.scala.example
 
-import io.radicalbit.nsdb.api.scala.NSDB
+import io.radicalbit.nsdb.api.scala._
 import io.radicalbit.nsdb.rpc.init.InitMetricResponse
 import io.radicalbit.nsdb.rpc.response.RPCInsertResult
 import io.radicalbit.nsdb.rpc.responseSQL.SQLStatementResponse
@@ -71,7 +71,7 @@ object NSDBMainRead extends App {
   */
 object NSDBInitRead extends App {
 
-  val nsdb = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817)(ExecutionContext.global), 10.seconds)
+  val nsdb: NSDB = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817)(ExecutionContext.global), 10.seconds)
 
   val init = nsdb
     .db("root")
@@ -83,4 +83,12 @@ object NSDBInitRead extends App {
   val readRes: Future[InitMetricResponse] = nsdb.init(init)
 
   println(Await.result(readRes, 10.seconds))
+
+  val metricToDescribe = nsdb
+    .db("root")
+    .namespace("registry")
+    .metric("people")
+
+  val describeRes = nsdb.describe(metricToDescribe)
+  println(Await.result(describeRes, 10.seconds))
 }

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
@@ -78,6 +78,7 @@ object NSDBInitRead extends App {
     .namespace("registry")
     .metric("people")
     .shardInterval("2d")
+    .retention("1d")
 
   val readRes: Future[InitMetricResponse] = nsdb.init(init)
 


### PR DESCRIPTION
This PR has the purpose to add `retention` as a possible configuration of a metric in the Init Metric API.
The retention must be set as an interval.
```
NSDB.BitInfo metricInfo = nsdb.db("root")
                .namespace("registry")
                .bit("people")
                .shardInterval("2d")
                .retention("2d");
```

Also, the info response (if present for the specified metric) has been added to the describe metric api.