### PR TITLE
Feature/remove outdated locations

### DIFF
--- a/nsdb-cli/src/main/scala/io/radicalbit/nsdb/cli/console/NsdbILoop.scala
+++ b/nsdb-cli/src/main/scala/io/radicalbit/nsdb/cli/console/NsdbILoop.scala
@@ -197,7 +197,7 @@ class NsdbILoop(host: Option[String],
           r.namespace,
           r.metric,
           r.fields.map(field => MetricField(field.name, fieldClassTypeFor(field), field.indexType)).toList,
-          metricInfo = r.metricInfo.map(mi => MetricInfo(r.metric, mi.shardInterval, mi.retention))
+          metricInfo = r.metricInfo.map(mi => MetricInfo(r.db, r.namespace, r.metric, mi.shardInterval, mi.retention))
         )
       case r: Namespaces if r.completedSuccessfully =>
         NamespacesListRetrieved(r.db, r.namespaces)

--- a/nsdb-cluster/src/main/resources/cluster.conf
+++ b/nsdb-cluster/src/main/resources/cluster.conf
@@ -191,6 +191,9 @@ nsdb {
 
   write.scheduler.interval = 15 seconds
 
+  retention.check.interval = 30 seconds
+  retention.check.interval = ${?RETENTION_CHECK_INTERVAL}
+
   stream.timeout = 30 seconds
   stream.timeout = ${?STREAM_TIMEOUT}
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
@@ -151,11 +151,11 @@ class GrpcEndpoint(readCoordinator: ActorRef, writeCoordinator: ActorRef, metada
 
       Try { Duration(request.shardInterval).toMillis } match {
         case Success(interval) =>
-          (metadataCoordinator ? PutMetricInfo(request.db, request.namespace, MetricInfo(request.metric, interval)))
+          (metadataCoordinator ? PutMetricInfo(MetricInfo(request.db, request.namespace, request.metric, interval)))
             .map {
-              case MetricInfoPut(_, _, _) =>
+              case MetricInfoPut(_) =>
                 InitMetricResponse(request.db, request.namespace, request.metric, completedSuccessfully = true)
-              case MetricInfoFailed(_, _, _, message) =>
+              case MetricInfoFailed(_, message) =>
                 InitMetricResponse(request.db,
                                    request.namespace,
                                    request.metric,
@@ -230,7 +230,7 @@ class GrpcEndpoint(readCoordinator: ActorRef, writeCoordinator: ActorRef, metada
             metadataCoordinator ? GetMetricInfo(db = request.db, namespace = request.namespace, metric = request.metric)
           ))
         .map {
-          case SchemaGot(db, namespace, metric, schema) :: MetricInfoGot(_, _, metricInfoOpt) :: Nil =>
+          case SchemaGot(db, namespace, metric, schema) :: MetricInfoGot(_, _, _, metricInfoOpt) :: Nil =>
             GrpcDescribeMetricResponse(
               db,
               namespace,

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndex.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndex.scala
@@ -60,6 +60,8 @@ class MetricInfoIndex(override val directory: Directory) extends SimpleIndex[Met
   override def toRecord(document: Document, fields: Seq[SimpleField]): MetricInfo = {
     val fields = document.getFields.asScala.map(f => f.name() -> f).toMap
     MetricInfo(
+      "notPresent",
+      "notPresent",
       document.get(_keyField),
       fields("shardInterval").numericValue().longValue()
     )

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -39,6 +39,7 @@ object MetadataSpec extends MultiNodeConfig {
     |  publisher.timeout = 10 seconds
     |  publisher.scheduler.interval = 5 seconds
     |  write.scheduler.interval = 15 seconds
+    |  retention.check.interval = 1 seconds
     |
     |  sharding {
     |    interval = 1d

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -145,7 +145,7 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
 
     "add metric info from different nodes" in within(10.seconds) {
 
-      val metricInfo = MetricInfo("metric", 100, 30)
+      val metricInfo = MetricInfo("db", "namespace","metric", 100, 30)
 
       runOn(node1) {
         val selfMember = cluster.selfMember
@@ -154,8 +154,8 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
         val metadataCoordinator = system.actorSelection(s"user/guardian_$nodeName/metadata-coordinator_$nodeName")
 
         awaitAssert {
-          metadataCoordinator ! PutMetricInfo("db", "namespace", metricInfo)
-          expectMsg(MetricInfoPut("db", "namespace", metricInfo))
+          metadataCoordinator ! PutMetricInfo(metricInfo)
+          expectMsg(MetricInfoPut(metricInfo))
         }
       }
 

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -10,7 +10,6 @@ import akka.testkit.ImplicitSender
 import com.typesafe.config.ConfigFactory
 import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache._
 import io.radicalbit.nsdb.common.model.MetricInfo
-import io.radicalbit.nsdb.common.protocol.Coordinates
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.rtsae.STMultiNodeSpec
 
@@ -402,7 +401,7 @@ class ReplicatedMetadataCacheSpec
         }
 
         replicatedCache ! EvictLocation("db", "namespace", Location(metric, "node1", 0, 1))
-        expectMsg(LocationEvicted("db", "namespace", metric, "node1", 0, 1))
+        expectMsg(Right(LocationEvicted("db", "namespace", Location(metric, "node1", 0, 1))))
       }
 
       runOn(node1) {

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -151,11 +151,11 @@ class ReplicatedMetadataCacheSpec
 
       enterBarrier("after-add-location")
 
-      val metricInfoValue = MetricInfo(metric, 100)
+      val metricInfoValue = MetricInfo("db", "namespace",metric, 100)
 
       runOn(node2) {
         awaitAssert {
-          replicatedCache ! PutMetricInfoInCache("db", "namespace", metric, metricInfoValue)
+          replicatedCache ! PutMetricInfoInCache(metricInfoValue)
           expectMsg(MetricInfoCached("db", "namespace", metric, Some(metricInfoValue)))
         }
       }
@@ -168,7 +168,7 @@ class ReplicatedMetadataCacheSpec
 
         awaitAssert {
           replicatedCache ! GetAllMetricInfo
-          expectMsg(AllMetricInfoGot(Set((Coordinates("db", "namespace", metric), metricInfoValue))))
+          expectMsg(AllMetricInfoGot(Set(metricInfoValue)))
         }
       }
       enterBarrier("after-add-metric-info")
@@ -328,14 +328,14 @@ class ReplicatedMetadataCacheSpec
       val metric   = "metric2"
       val location = Location(metric, "node1", _: Long, _: Long)
 
-      val metricInfoValue = MetricInfo(_: String, 100)
+      val metricInfoValue = MetricInfo("db", "namespace", _: String, 100)
 
       runOn(node1) {
         for (i ← 10 to 20) {
           replicatedCache ! PutLocationInCache("db", "namespace", metric, i - 1, i, location(i - 1, i))
           expectMsg(LocationCached("db", "namespace", metric, i - 1, i, location(i - 1, i)))
 
-          replicatedCache ! PutMetricInfoInCache("db", "namespace", s"metric_$i", metricInfoValue(s"metric_$i"))
+          replicatedCache ! PutMetricInfoInCache(metricInfoValue(s"metric_$i"))
           expectMsg(MetricInfoCached("db", "namespace", s"metric_$i", Some(metricInfoValue(s"metric_$i"))))
         }
       }
@@ -362,11 +362,11 @@ class ReplicatedMetadataCacheSpec
     "do not allow insertion of an already present metric info" in within(5.seconds) {
       val metric          = "metricInfo"
       val metricInfoKey   = MetricInfoCacheKey("db", "namespace", metric)
-      val metricInfoValue = MetricInfo(metric, 100)
+      val metricInfoValue = MetricInfo("db", "namespace",metric, 100)
 
       runOn(node2) {
         awaitAssert {
-          replicatedCache ! PutMetricInfoInCache("db", "namespace", metric, metricInfoValue)
+          replicatedCache ! PutMetricInfoInCache(metricInfoValue)
           expectMsg(MetricInfoCached("db", "namespace", metric, Some(metricInfoValue)))
         }
       }
@@ -380,7 +380,7 @@ class ReplicatedMetadataCacheSpec
 
       runOn(node2) {
         awaitAssert {
-          replicatedCache ! PutMetricInfoInCache("db", "namespace", metric, metricInfoValue)
+          replicatedCache ! PutMetricInfoInCache(metricInfoValue)
           expectMsg(MetricInfoAlreadyExisting(metricInfoKey, metricInfoValue))
         }
       }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -12,7 +12,6 @@ import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache._
 import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.rtsae.STMultiNodeSpec
-import org.json4s.DefaultFormats
 
 import scala.concurrent.duration._
 
@@ -70,12 +69,10 @@ class ReplicatedMetadataCacheSpec
 
   import ReplicatedMetadataCacheSpec._
 
-  implicit val formats = DefaultFormats
+  override def initialParticipants: Int = roles.size
 
-  override def initialParticipants = roles.size
-
-  val cluster         = Cluster(system)
-  val replicatedCache = system.actorOf(Props[ReplicatedMetadataCache])
+  private val cluster         = Cluster(system)
+  private val replicatedCache = system.actorOf(Props[ReplicatedMetadataCache])
 
   def join(from: RoleName, to: RoleName): Unit = {
     runOn(from) {
@@ -385,9 +382,7 @@ class ReplicatedMetadataCacheSpec
 
     "replicate evicted entry" in within(5.seconds) {
       val metric    = "metric3"
-      val key       = LocationCacheKey("db", "namespace", metric, 0, 1)
       val location  = Location(metric, "node1", 0, 1)
-      val metricKey = MetricLocationsCacheKey("db", "namespace", metric)
 
       runOn(node1) {
         replicatedCache ! PutLocationInCache("db", "namespace", metric, 0, 1, location)

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -10,6 +10,7 @@ import akka.testkit.ImplicitSender
 import com.typesafe.config.ConfigFactory
 import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache._
 import io.radicalbit.nsdb.common.model.MetricInfo
+import io.radicalbit.nsdb.common.protocol.Coordinates
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.rtsae.STMultiNodeSpec
 
@@ -163,6 +164,11 @@ class ReplicatedMetadataCacheSpec
         awaitAssert {
           replicatedCache ! GetMetricInfoFromCache("db", "namespace", metric)
           expectMsg(MetricInfoCached("db", "namespace", metric, Some(metricInfoValue)))
+        }
+
+        awaitAssert {
+          replicatedCache ! GetAllMetricInfo
+          expectMsg(AllMetricInfoGot(Set((Coordinates("db", "namespace", metric), metricInfoValue))))
         }
       }
       enterBarrier("after-add-metric-info")

--- a/nsdb-cluster/src/test/resources/application.conf
+++ b/nsdb-cluster/src/test/resources/application.conf
@@ -71,5 +71,7 @@ nsdb {
 
   write.scheduler.interval = 5 seconds
 
+  retention.check.interval = 1 seconds
+
   stream.timeout = 30 seconds
 }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -201,9 +201,9 @@ class MetadataCoordinatorSpec
 
     "retrieve correct write Location for a initialized metric with a different shard interval" in {
 
-      val metricInfo = MetricInfo(metric, 100)
+      val metricInfo = MetricInfo(db, namespace, metric, 100)
 
-      probe.send(metadataCoordinator, PutMetricInfo(db, namespace, metricInfo))
+      probe.send(metadataCoordinator, PutMetricInfo(metricInfo))
       awaitAssert {
         probe.expectMsgType[MetricInfoPut]
       }.metricInfo shouldBe metricInfo
@@ -255,14 +255,14 @@ class MetadataCoordinatorSpec
 
     "retrieve metric infos" in {
 
-      val metricInfo = MetricInfo(metric, 100)
+      val metricInfo = MetricInfo(db, namespace, metric, 100)
 
       probe.send(metadataCoordinator, GetMetricInfo(db, namespace, metric))
       awaitAssert {
         probe.expectMsgType[MetricInfoGot]
       }.metricInfo.isEmpty shouldBe true
 
-      probe.send(metadataCoordinator, PutMetricInfo(db, namespace, metricInfo))
+      probe.send(metadataCoordinator, PutMetricInfo(metricInfo))
       awaitAssert {
         probe.expectMsgType[MetricInfoPut]
       }.metricInfo shouldBe metricInfo
@@ -275,9 +275,9 @@ class MetadataCoordinatorSpec
 
     "not allow to insert a metric info already inserted" in {
 
-      val metricInfo = MetricInfo(metric, 100)
+      val metricInfo = MetricInfo(db, namespace, metric, 100)
 
-      probe.send(metadataCoordinator, PutMetricInfo(db, namespace, metricInfo))
+      probe.send(metadataCoordinator, PutMetricInfo(metricInfo))
       awaitAssert {
         probe.expectMsgType[MetricInfoPut]
       }.metricInfo shouldBe metricInfo
@@ -287,7 +287,7 @@ class MetadataCoordinatorSpec
         probe.expectMsgType[MetricInfoGot]
       }.metricInfo shouldBe Some(metricInfo)
 
-      probe.send(metadataCoordinator, PutMetricInfo(db, namespace, metricInfo))
+      probe.send(metadataCoordinator, PutMetricInfo(metricInfo))
       awaitAssert {
         probe.expectMsgType[MetricInfoFailed]
       }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
@@ -76,9 +76,14 @@ class LocalMetadataCache extends Actor {
           metricInfo.put(key, info)
           sender ! MetricInfoCached(db, namespace, metric, Some(info))
       }
+    case EvictLocation(db, namespace, location) =>
+      locations -= LocationWithNodeKey(db, namespace, location.metric, location.node, location.from, location.to)
+      sender ! Right(LocationEvicted(db, namespace, location))
     case GetMetricInfoFromCache(db, namespace, metric) =>
       val key = MetricInfoCacheKey(db, namespace, metric)
       sender ! MetricInfoCached(db, namespace, metric, metricInfo.get(key))
+    case GetAllMetricInfo =>
+      sender() ! AllMetricInfoGot(metricInfo.values.toSet)
   }
 }
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
@@ -67,14 +67,14 @@ class LocalMetadataCache extends Actor {
       metricInfo.clear()
       coordinates.clear()
       sender() ! DeleteDone
-    case PutMetricInfoInCache(db, namespace, metric, value) =>
+    case PutMetricInfoInCache(info @ MetricInfo(db, namespace, metric, _, _)) =>
       val key = MetricInfoCacheKey(db, namespace, metric)
       metricInfo.get(key) match {
         case Some(v) =>
           sender ! MetricInfoAlreadyExisting(key, v)
         case None =>
-          metricInfo.put(key, value)
-          sender ! MetricInfoCached(db, namespace, metric, Some(value))
+          metricInfo.put(key, info)
+          sender ! MetricInfoCached(db, namespace, metric, Some(info))
       }
     case GetMetricInfoFromCache(db, namespace, metric) =>
       val key = MetricInfoCacheKey(db, namespace, metric)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
@@ -95,17 +95,17 @@ class LocalMetadataCoordinator(cache: ActorRef) extends Actor {
     case GetMetricInfo(db, namespace, metric) =>
       (cache ? GetMetricInfoFromCache(db, namespace, metric))
         .map {
-          case MetricInfoCached(_, _, _, value) => MetricInfoGot(db, namespace, value)
+          case MetricInfoCached(_, _, _, value) => MetricInfoGot(db, namespace, metric, value)
         }
         .pipeTo(sender)
-    case PutMetricInfo(db, namespace, metricInfo) =>
-      (cache ? PutMetricInfoInCache(db, namespace, metricInfo.metric, metricInfo))
+    case PutMetricInfo(metricInfo) =>
+      (cache ? PutMetricInfoInCache(metricInfo))
         .map {
           case MetricInfoCached(_, _, _, Some(_)) =>
-            MetricInfoPut(db, namespace, metricInfo)
+            MetricInfoPut(metricInfo)
           case MetricInfoAlreadyExisting(_, _) =>
-            MetricInfoFailed(db, namespace, metricInfo, "metric info already exist")
-          case e => MetricInfoFailed(db, namespace, metricInfo, s"Unknown response from cache $e")
+            MetricInfoFailed(metricInfo, "metric info already exist")
+          case e => MetricInfoFailed(metricInfo, s"Unknown response from cache $e")
         }
         .pipeTo(sender)
   }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndexTest.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndexTest.scala
@@ -34,7 +34,7 @@ class MetricInfoIndexTest extends FlatSpec with Matchers with OneInstancePerTest
     val writer = metricInfoIndex.getWriter
 
     (0 to 100).foreach { i =>
-      val testData = MetricInfo(s"metric_$i", i)
+      val testData = MetricInfo("db", "namespace", s"metric_$i", i)
       metricInfoIndex.write(testData)(writer)
     }
     writer.close()
@@ -47,7 +47,7 @@ class MetricInfoIndexTest extends FlatSpec with Matchers with OneInstancePerTest
     val firstMetricInfo = metricInfoIndex.getMetricInfo("metric_0")
 
     firstMetricInfo shouldBe Some(
-      MetricInfo(s"metric_0", 0)
+      MetricInfo("notPresent", "notPresent", s"metric_0", 0)
     )
   }
 
@@ -60,13 +60,13 @@ class MetricInfoIndexTest extends FlatSpec with Matchers with OneInstancePerTest
     val writer = metricInfoIndex.getWriter
 
     (0 to 100).foreach { i =>
-      val testData = MetricInfo(s"metric_$i", i)
+      val testData = MetricInfo("db", "namespace", s"metric_$i", i)
       metricInfoIndex.write(testData)(writer)
     }
     writer.close()
     metricInfoIndex.refresh()
 
-    val firstExpected = MetricInfo(s"metric_0", 0)
+    val firstExpected = MetricInfo("notPresent", "notPresent", s"metric_0", 0)
     metricInfoIndex.getMetricInfo("metric_0") shouldBe Some(
       firstExpected
     )

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/model/MetricInfo.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/model/MetricInfo.scala
@@ -19,8 +19,10 @@ package io.radicalbit.nsdb.common.model
 /**
   * Metric Info.
   *
+  * @param db the db.
+  * @param namespace the namespace.
   * @param metric        the metric.
   * @param shardInterval shard interval for the metric in milliseconds.
   * @param retention     period in which data is stored for the metric, 0 means infinite.
   */
-case class MetricInfo(metric: String, shardInterval: Long, retention: Long = 0)
+case class MetricInfo(db: String, namespace: String, metric: String, shardInterval: Long, retention: Long = 0)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/TimeRangeExtractor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/TimeRangeExtractor.scala
@@ -16,6 +16,7 @@
 
 package io.radicalbit.nsdb.statement
 
+import io.radicalbit.nsdb.common.protocol.Coordinates
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.model.{Location, TimeRange}
 import spire.implicits._
@@ -108,5 +109,20 @@ object TimeRangeExtractor {
           computeRangeForInterval(upperBound, lowerBound, rangeLength, Seq.empty)
         }
     }
+  }
+
+  /**
+    * Filters a sequence of [[Location]] given a threshold.
+    * Locations that are older that the threshold are returned.
+    * @param locations the location with coordinates to evict.
+    * @param threshold the lowest timestamp to keep.
+    * @return the location that must be completely evicted, and the locations that must be partially evicted.
+    */
+  def getLocationsToEvict(locations: Seq[Location], threshold: Long): (Seq[Location], Seq[Location]) = {
+    (locations.filter { l =>
+      l.to < threshold
+    }, locations.filter { l =>
+      l.from <= threshold && l.to >= threshold
+    })
   }
 }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeExtractorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeExtractorSpec.scala
@@ -16,6 +16,7 @@
 
 package io.radicalbit.nsdb.statement
 
+import io.radicalbit.nsdb.common.protocol.Coordinates
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.model.{Location, TimeRange}
 import org.scalatest.{Matchers, WordSpec}
@@ -268,6 +269,26 @@ class TimeRangeExtractorSpec extends WordSpec with Matchers {
           TimeRange(71, 74, true, true)
         )
       }
+    }
+
+    "executing getLocationsToEvict" should {
+
+      "filter locations given a threshold" in {
+        val locationSequence = Seq(
+          Location("metric", "node", 0, 5),
+          Location("metric", "node", 6, 10),
+          Location("metric", "node", 11, 15),
+          Location("metric", "node", 16, 20),
+          Location("metric", "node", 21, 25)
+        )
+
+        TimeRangeExtractor.getLocationsToEvict(locationSequence, 15) shouldBe (
+          Seq(Location("metric", "node", 0, 5), Location("metric", "node", 6, 10)),
+          Seq(Location("metric", "node", 11, 15))
+        )
+
+      }
+
     }
   }
 

--- a/nsdb-it/src/test/resources/minicluster.conf
+++ b/nsdb-it/src/test/resources/minicluster.conf
@@ -191,6 +191,7 @@ nsdb {
   publisher.scheduler.interval = 5 seconds
 
   write.scheduler.interval = 5 seconds
+  retention.check.interval = 30 seconds
 
   stream.timeout = 30 seconds
   stream.timeout = ${?STREAM_TIMEOUT}


### PR DESCRIPTION
This PR introduces Retention implementation.

A check of all the available locations is performed periodically and all the locations that are completely outdated (beyond the retention period) will be removed from the cache and no longer considered when a query is executed.
