### PR TITLE
[Retention] Delete records inside partially outdated locations

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
@@ -70,6 +70,7 @@ class NodeActorsGuardian(metadataCache: ActorRef, schemaCache: ActorRef) extends
     context.actorOf(
       MetadataCoordinator
         .props(metadataCache, schemaCoordinator, mediator)
+        .withDispatcher("akka.actor.control-aware-dispatcher")
         .withDeploy(Deploy(scope = RemoteScope(selfMember.address))),
       name = s"metadata-coordinator_$nodeName"
     )

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
@@ -61,7 +61,7 @@ class NodeActorsGuardian(metadataCache: ActorRef, schemaCache: ActorRef) extends
 
   private val schemaCoordinator = context.actorOf(
     SchemaCoordinator
-      .props(indexBasePath, schemaCache)
+      .props(schemaCache)
       .withDeploy(Deploy(scope = RemoteScope(selfMember.address))),
     s"schema-coordinator_$nodeName"
   )

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
@@ -68,8 +68,11 @@ class NodeActorsGuardian(metadataCache: ActorRef, schemaCache: ActorRef) extends
 
   private val metadataCoordinator =
     context.actorOf(
-      MetadataCoordinator.props(metadataCache, mediator).withDeploy(Deploy(scope = RemoteScope(selfMember.address))),
-      name = s"metadata-coordinator_$nodeName")
+      MetadataCoordinator
+        .props(metadataCache, schemaCoordinator, mediator)
+        .withDeploy(Deploy(scope = RemoteScope(selfMember.address))),
+      name = s"metadata-coordinator_$nodeName"
+    )
 
   private val readCoordinator =
     context.actorOf(

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -125,6 +125,11 @@ class MetadataCoordinator(cache: ActorRef, mediator: ActorRef)
 
   override def preStart(): Unit = {
     mediator ! Subscribe(COORDINATORS_TOPIC, self)
+
+    val interval = FiniteDuration(
+      context.system.settings.config.getDuration("nsdb.publisher.scheduler.interval", TimeUnit.SECONDS),
+      TimeUnit.SECONDS)
+
   }
 
   override def receive: Receive = {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/SchemaCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/SchemaCoordinator.scala
@@ -44,12 +44,8 @@ import scala.util.{Failure, Success}
   * Actor responsible for dispatching read and write schema operations to che proper schema actor.
   * It performs write/update/deletion in distributed cache
   *
-  * @param basePath indexes' base path.
   */
-class SchemaCoordinator(basePath: String, schemaCache: ActorRef)
-    extends ActorPathLogging
-    with Stash
-    with DirectorySupport {
+class SchemaCoordinator(schemaCache: ActorRef) extends ActorPathLogging with Stash with DirectorySupport {
 
   implicit val timeout: Timeout = Timeout(
     context.system.settings.config.getDuration("nsdb.namespace-schema.timeout", TimeUnit.SECONDS),
@@ -199,8 +195,8 @@ class SchemaCoordinator(basePath: String, schemaCache: ActorRef)
 
 object SchemaCoordinator {
 
-  def props(basePath: String, schemaCache: ActorRef): Props =
-    Props(new SchemaCoordinator(basePath, schemaCache))
+  def props(schemaCache: ActorRef): Props =
+    Props(new SchemaCoordinator(schemaCache))
 
   object events {
     case class NamespaceSchemaDeleted(db: String, namespace: String)

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -166,8 +166,8 @@ class ReplicatedMetadataCacheSpec
         }
 
         awaitAssert {
-          replicatedCache ! GetAllMetricInfo
-          expectMsg(AllMetricInfoGot(Set(metricInfoValue)))
+          replicatedCache ! GetAllMetricInfoWithRetention
+          expectMsg(AllMetricInfoWithRetentionGot(Set()))
         }
       }
       enterBarrier("after-add-metric-info")

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
@@ -110,7 +110,7 @@ abstract class AbstractReadCoordinatorSpec
   val db        = "db"
   val namespace = "registry"
   val schemaCoordinator =
-    system.actorOf(SchemaCoordinator.props(basePath, system.actorOf(Props[FakeSchemaCache])), "schemacoordinator")
+    system.actorOf(SchemaCoordinator.props(system.actorOf(Props[FakeSchemaCache])), "schemacoordinator")
   val metadataCoordinator =
     system.actorOf(LocalMetadataCoordinator.props(system.actorOf(Props[LocalMetadataCache])), "metadatacoordinator")
   val writeCoordinator =
@@ -124,9 +124,6 @@ abstract class AbstractReadCoordinatorSpec
   override def beforeAll = {
     import scala.concurrent.duration._
     implicit val timeout = Timeout(5.second)
-
-//    schemaCoordinator ! WarmUpSchemas(List.empty)
-//    readCoordinatorActor ! WarmUpCompleted
 
     Await.result(readCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "node1"), 10 seconds)
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
@@ -94,7 +94,7 @@ abstract class AbstractReadCoordinatorSpec
         "ReadCoordinatorSpec",
         ConfigFactory
           .load()
-          .withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(2553))
+          .withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(2653))
           .withValue("akka.actor.provider", ConfigValueFactory.fromAnyRef("local"))
           .withValue("nsdb.sharding.interval", ConfigValueFactory.fromAnyRef("5s"))
       ))

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
@@ -16,7 +16,7 @@
 
 package io.radicalbit.nsdb.cluster.coordinator
 
-import akka.actor.{ActorSystem, Props}
+import akka.actor.{Actor, ActorSystem, Props}
 import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
@@ -28,7 +28,6 @@ import io.radicalbit.nsdb.cluster.coordinator.mockedActors.{LocalMetadataCache, 
 import io.radicalbit.nsdb.common.protocol._
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
-import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import org.scalatest._
 
 import scala.concurrent.Await
@@ -110,13 +109,11 @@ abstract class AbstractReadCoordinatorSpec
   val db        = "db"
   val namespace = "registry"
   val schemaCoordinator =
-    system.actorOf(SchemaCoordinator.props(system.actorOf(Props[FakeSchemaCache])), "schemacoordinator")
+    system.actorOf(SchemaCoordinator.props(system.actorOf(Props[FakeSchemaCache])), "schema-coordinator")
   val metadataCoordinator =
-    system.actorOf(LocalMetadataCoordinator.props(system.actorOf(Props[LocalMetadataCache])), "metadatacoordinator")
-  val writeCoordinator =
-    system.actorOf(WriteCoordinator.props(metadataCoordinator, schemaCoordinator, system.actorOf(Props.empty)))
+    system.actorOf(LocalMetadataCoordinator.props(system.actorOf(Props[LocalMetadataCache])), "metadata-coordinator")
   val metricsDataActor =
-    system.actorOf(MetricsDataActor.props(basePath, "node1", writeCoordinator))
+    system.actorOf(MetricsDataActor.props(basePath, "node1", Actor.noSender))
   val readCoordinatorActor = system actorOf ReadCoordinator.props(metadataCoordinator,
                                                                   schemaCoordinator,
                                                                   system.actorOf(Props.empty))

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
@@ -196,7 +196,7 @@ abstract class AbstractReadCoordinatorSpec
                    10 seconds)
     })
 
-    expectNoMessage(interval)
-    expectNoMessage(interval)
+    expectNoMessage(indexingInterval)
+    expectNoMessage(indexingInterval)
   }
 }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -46,6 +46,7 @@ class MetadataCoordinatorSpec
         ConfigFactory
           .load()
           .withValue("akka.actor.provider", ConfigValueFactory.fromAnyRef("cluster"))
+          .withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(2652))
           .withValue("nsdb.sharding.interval", ConfigValueFactory.fromAnyRef("60s"))
       ))
     with ImplicitSender

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -51,7 +51,7 @@ class MetadataCoordinatorSpec
 
   val probe               = TestProbe()
   val metadataCache       = system.actorOf(LocalMetadataCache.props)
-  val metadataCoordinator = system.actorOf(MetadataCoordinator.props(metadataCache, probe.ref))
+  val metadataCoordinator = system.actorOf(MetadataCoordinator.props(metadataCache, probe.ref, probe.ref))
 
   val db        = "testDb"
   val namespace = "testNamespace"

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
@@ -105,7 +105,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                      10 seconds)
       })
 
-    expectNoMessage(interval)
+    expectNoMessage(indexingInterval)
   }
 
   "ReadCoordinator" when {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.coordinator
+
+import akka.actor.{Actor, ActorSystem, Props}
+import akka.cluster.Cluster
+import akka.pattern.ask
+import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import akka.util.Timeout
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import io.radicalbit.nsdb.cluster.actor.MetricsDataActor
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.PutMetricInfo
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.MetricInfoPut
+import io.radicalbit.nsdb.cluster.coordinator.mockedActors.{FakeCommitLogCoordinator, LocalMetadataCache}
+import io.radicalbit.nsdb.cluster.createNodeName
+import io.radicalbit.nsdb.common.model.MetricInfo
+import io.radicalbit.nsdb.common.protocol._
+import io.radicalbit.nsdb.common.statement.{ListFields, SelectSQLStatement}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{InputMapped, SelectStatementExecuted}
+import org.scalatest._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class RetentionSpec
+    extends TestKit(
+      ActorSystem(
+        "RetentionSpec",
+        ConfigFactory
+          .load()
+          .withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(2554))
+          .withValue("akka.actor.provider", ConfigValueFactory.fromAnyRef("cluster"))
+          .withValue("nsdb.sharding.interval", ConfigValueFactory.fromAnyRef("5ms"))
+          .withValue("nsdb.write.scheduler.interval", ConfigValueFactory.fromAnyRef("1s"))
+          .withValue("nsdb.retention.check.interval", ConfigValueFactory.fromAnyRef("2s"))
+      ))
+    with ImplicitSender
+    with WordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with WriteInterval {
+
+  val probe     = TestProbe()
+  val basePath  = "target/test_index/RetentionSpec"
+  val db        = "db"
+  val namespace = "namespace"
+
+  val metricWithRetention    = "metricWithRetention"
+  val metricWithoutRetention = "metricWithoutRetention"
+
+  val records: Seq[Bit] = Seq(
+    Bit(1L, 1L, Map("surname"  -> "Doe"), Map("name" -> "John")),
+    Bit(2L, 2L, Map("surname"  -> "Doe"), Map("name" -> "John")),
+    Bit(4L, 3L, Map("surname"  -> "D"), Map("name"   -> "J")),
+    Bit(6L, 4L, Map("surname"  -> "Doe"), Map("name" -> "Bill")),
+    Bit(8L, 5L, Map("surname"  -> "Doe"), Map("name" -> "Frank")),
+    Bit(10L, 6L, Map("surname" -> "Doe"), Map("name" -> "Frankie")),
+    Bit(12L, 7L, Map("surname" -> "Doe"), Map("name" -> "Bill")),
+    Bit(14L, 8L, Map("surname" -> "Doe"), Map("name" -> "Frank")),
+    Bit(16L, 9L, Map("surname" -> "Doe"), Map("name" -> "Frankie"))
+  )
+
+  def currentRecords(currentTime: Long): Seq[Bit] = Seq(
+    Bit(currentTime - 6000, 1L, Map("surname"  -> "Doe"), Map("name" -> "John")),
+    Bit(currentTime - 5000, 2L, Map("surname"  -> "Doe"), Map("name" -> "John")),
+    Bit(currentTime - 4000, 3L, Map("surname"  -> "D"), Map("name"   -> "J")),
+    Bit(currentTime - 3000, 4L, Map("surname"  -> "Doe"), Map("name" -> "Bill")),
+    Bit(currentTime - 2000, 5L, Map("surname"  -> "Doe"), Map("name" -> "Frank")),
+    Bit(currentTime - 1000, 6L, Map("surname"  -> "Doe"), Map("name" -> "Frankie")),
+    Bit(currentTime - 500, 7L, Map("surname"   -> "Doe"), Map("name" -> "Bill")),
+    Bit(currentTime, 8L, Map("surname"         -> "Doe"), Map("name" -> "Frank")),
+    Bit(currentTime + 10000, 9L, Map("surname" -> "Doe"), Map("name" -> "Frankie"))
+  )
+
+  val commitLogCoordinator = system.actorOf(Props[FakeCommitLogCoordinator])
+  val schemaCoordinator =
+    system.actorOf(SchemaCoordinator.props(system.actorOf(Props[FakeSchemaCache])), "schema-coordinator")
+  val metadataCoordinator =
+    system.actorOf(MetadataCoordinator.props(system.actorOf(Props[LocalMetadataCache]),
+                                             schemaCoordinator,
+                                             system.actorOf(Props.empty)),
+                   "metadata-coordinator")
+  val writeCoordinator =
+    system.actorOf(WriteCoordinator.props(metadataCoordinator, schemaCoordinator, system.actorOf(Props.empty)),
+                   "write-coordinator")
+  val readCoordinatorActor = system actorOf ReadCoordinator.props(metadataCoordinator,
+                                                                  schemaCoordinator,
+                                                                  system.actorOf(Props.empty))
+
+  implicit val timeout = Timeout(5.second)
+
+  private def selectAll(metric: String) = ExecuteStatement(
+    SelectSQLStatement(
+      db = db,
+      namespace = namespace,
+      metric = metric,
+      distinct = false,
+      fields = ListFields(List.empty),
+      condition = None,
+      groupBy = None
+    )
+  )
+
+  override def beforeAll = {
+    val cluster = Cluster(system)
+    cluster.join(cluster.selfAddress)
+
+    val nodeName = createNodeName(cluster.selfMember)
+
+    val metricsDataActor =
+      system.actorOf(MetricsDataActor.props(basePath, nodeName, Actor.noSender))
+
+    Await.result(readCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, nodeName), 10 seconds)
+    Await.result(metadataCoordinator ? SubscribeMetricsDataActor(metricsDataActor, nodeName), 10 seconds)
+    Await.result(metadataCoordinator ? SubscribeCommitLogCoordinator(commitLogCoordinator, nodeName), 10 seconds)
+    Await.result(writeCoordinator ? SubscribeMetricsDataActor(metricsDataActor, nodeName), 10 seconds)
+    Await.result(writeCoordinator ? SubscribeCommitLogCoordinator(commitLogCoordinator, nodeName), 10 seconds)
+
+    Await.result(writeCoordinator ? DropMetric(db, namespace, metricWithRetention), 10 seconds)
+    Await.result(writeCoordinator ? DropMetric(db, namespace, metricWithoutRetention), 10 seconds)
+
+    records.foreach { r =>
+      Await.result(writeCoordinator ? MapInput(r.timestamp, db, namespace, metricWithoutRetention, r), 10 seconds) shouldBe a[
+        InputMapped]
+    }
+
+    expectNoMessage(interval)
+  }
+
+  "NSDb Retention" when {
+
+    "is not set to a metric" should {
+
+      "do nothing" in {
+        awaitAssert {
+          probe.send(
+            readCoordinatorActor,
+            selectAll(metricWithoutRetention)
+          )
+          probe.expectMsgType[SelectStatementExecuted].values.size should be(9)
+        }
+
+        expectNoMessage(3.second)
+
+        awaitAssert {
+          probe.send(
+            readCoordinatorActor,
+            selectAll(metricWithoutRetention)
+          )
+          probe.expectMsgType[SelectStatementExecuted].values.size should be(9)
+        }
+      }
+
+    }
+
+    "is set to a metric" should {
+
+      "delete outdated records" in {
+
+        probe.send(metadataCoordinator, PutMetricInfo(MetricInfo(db, namespace, metricWithRetention, 5000, 5000)))
+
+        awaitAssert {
+          probe.expectMsgType[MetricInfoPut]
+        }
+
+        val currentTime = System.currentTimeMillis()
+
+        currentRecords(currentTime).foreach { r =>
+          probe.send(writeCoordinator, MapInput(r.timestamp, db, namespace, metricWithRetention, r))
+          awaitAssert {
+            probe.expectMsgType[InputMapped]
+          }
+        }
+
+        awaitAssert {
+          probe.send(
+            readCoordinatorActor,
+            selectAll(metricWithRetention)
+          )
+          probe.expectMsgType[SelectStatementExecuted].values.size should be(9)
+        }
+
+        expectNoMessage(3.second)
+
+        awaitAssert {
+          probe.send(
+            readCoordinatorActor,
+            selectAll(metricWithRetention)
+          )
+          probe.expectMsgType[SelectStatementExecuted].values.size should be(5)
+        }
+      }
+
+    }
+
+  }
+
+}

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/SchemaCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/SchemaCoordinatorSpec.scala
@@ -43,7 +43,7 @@ class SchemaCoordinatorSpec
   val schemaCoordinator =
     system.actorOf(
       SchemaCoordinator
-        .props("target/test_index/NamespaceSchemaCoordinatorSpec", system.actorOf(Props[FakeSchemaCache])))
+        .props(system.actorOf(Props[FakeSchemaCache])))
 
   val db         = "db"
   val namespace  = "namespace"

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
@@ -99,7 +99,7 @@ class WriteCoordinatorErrorsSpec
   lazy val failingCommitLogCoordinator: TestActorRef[MockedCommitLogCoordinator] =
     TestActorRef[MockedCommitLogCoordinator](MockedCommitLogCoordinator.props(failureCommitLogProbe.ref))
   lazy val schemaCoordinator =
-    TestActorRef[SchemaCoordinator](SchemaCoordinator.props(basePath, system.actorOf(Props[FakeSchemaCache])))
+    TestActorRef[SchemaCoordinator](SchemaCoordinator.props(system.actorOf(Props[FakeSchemaCache])))
   lazy val subscriber = TestActorRef[TestSubscriber](Props[TestSubscriber])
   lazy val publisherActor =
     TestActorRef[PublisherActor](PublisherActor.props(system.actorOf(Props[FakeReadCoordinatorActor])))

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteInterval.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteInterval.scala
@@ -24,7 +24,7 @@ trait WriteInterval { this: TestKit =>
 
   import scala.concurrent.duration._
 
-  lazy val interval = FiniteDuration(
+  lazy val indexingInterval = FiniteDuration(
     system.settings.config.getDuration("nsdb.write.scheduler.interval", TimeUnit.SECONDS),
     TimeUnit.SECONDS) + 1.second
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/FakeCommitLogCoordinator.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/FakeCommitLogCoordinator.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.coordinator.mockedActors
+
+import akka.actor.{Actor, ActorLogging}
+import io.radicalbit.nsdb.commit_log.CommitLogWriterActor.{WriteToCommitLog, WriteToCommitLogSucceeded}
+
+class FakeCommitLogCoordinator extends Actor with ActorLogging {
+  override def receive: Receive = {
+    case WriteToCommitLog(db, namespace, metric, timestamp, _, location) =>
+      sender ! WriteToCommitLogSucceeded(db, namespace, timestamp, metric, location)
+    case _ =>
+      log.error("UnexpectedMessage")
+  }
+}


### PR DESCRIPTION
This PR aims to extend the retention implementation by adding the management of the partially outdated locations.

When the locations check is performed, so far only the completely outdated ones are evicted.
With this PR, a delete statement is executed against all the partially outdated ones in order to delete the outdated records inside of them and keep the location itself.