### PR TITLE
[RETENTION ]Delete outdated phisical locations

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
@@ -149,9 +149,10 @@ class GrpcEndpoint(readCoordinator: ActorRef, writeCoordinator: ActorRef, metada
   protected[this] object InitMetricService extends InitMetric {
     override def initMetric(request: InitMetricRequest): Future[InitMetricResponse] = {
 
-      Try { Duration(request.shardInterval).toMillis } match {
-        case Success(interval) =>
-          (metadataCoordinator ? PutMetricInfo(MetricInfo(request.db, request.namespace, request.metric, interval)))
+      Try { (Duration(request.shardInterval).toMillis, Duration(request.retention).toMillis) } match {
+        case Success((interval, retention)) =>
+          (metadataCoordinator ? PutMetricInfo(
+            MetricInfo(request.db, request.namespace, request.metric, interval, retention)))
             .map {
               case MetricInfoPut(_) =>
                 InitMetricResponse(request.db, request.namespace, request.metric, completedSuccessfully = true)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/util/ErrorManagementUtils.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/util/ErrorManagementUtils.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.util
+
+import scala.reflect.ClassTag
+
+object ErrorManagementUtils {
+
+  /**
+    * Filters a generic collection of responses, returns the successes and apply a behaviour to the failures.
+    * @param results the generic collection of responses.
+    * @param errorBehaviour a function to be applied to the list of errors found.
+    * @tparam S the success type.
+    * @tparam F the failure type.
+    * @return the list of succeeded responses.
+    */
+  def manageErrors[S, F](results: Traversable[Any])(errorBehaviour: Seq[F] => Unit)(implicit s: Manifest[S],
+                                                                                    f: Manifest[F]): List[S] = {
+    val (successes, errors) = partitionResponses(results)(s, f)
+    if (errors.nonEmpty) {
+      errorBehaviour(errors)
+    }
+    successes
+  }
+
+  /**
+    * Filters a collection of [[Either]] typed responses , returns the successes and apply a behaviour to the failures.
+    * @param results the generic collection of responses.
+    * @param errorBehaviour a function to be applied to the list of errors found.
+    * @tparam S the success type.
+    * @tparam F the failure type.
+    * @return the list of succeeded responses.
+    */
+  def manageErrors[S, F](results: Traversable[Either[F, S]])(errorBehaviour: Seq[F] => Unit)(
+      implicit d: DummyImplicit): List[S] = {
+    val (successes, errors) = partitionResponses(results)
+
+    if (errors.nonEmpty) {
+      errorBehaviour(errors)
+    }
+    successes
+  }
+
+  /**
+    * Partitions a generic collection of responses, separating errors and successes.
+    * @param responses the generic collection of responses.
+    * @tparam S the success type.
+    * @tparam F the failure type.
+    * @return a tuple containing the succeeded and the failures .
+    */
+  def partitionResponses[S, F](responses: Traversable[Any])(implicit s: Manifest[S],
+                                                            f: Manifest[F]): (List[S], List[F]) =
+    responses.foldRight((List.empty[S], List.empty[F])) {
+      case (f, (successAcc, errorAcc)) =>
+        if (manifest[S].runtimeClass.isInstance(f))
+          (f.asInstanceOf[S] :: successAcc, errorAcc)
+        else
+          (successAcc, f.asInstanceOf[F] :: errorAcc)
+    }
+
+  /**
+    * Partitions a collection of [[Either]] typed responses, separating errors and successes.
+    * @param responses the generic collection of responses.
+    * @tparam S the success type.
+    * @tparam F the failure type.
+    * @return a tuple containing the succeeded and the failures .
+    */
+  def partitionResponses[S, F](responses: Traversable[Either[F, S]])(implicit d: DummyImplicit): (List[S], List[F]) =
+    responses.foldRight((List.empty[S], List.empty[F])) {
+      case (f, (successAcc, errorAcc)) =>
+        f match {
+          case Right(success) => (success :: successAcc, errorAcc)
+          case Left(error)    => (successAcc, error :: errorAcc)
+        }
+    }
+
+}

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
@@ -16,6 +16,7 @@
 
 package io.radicalbit.nsdb.cluster.actor
 
+import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorRef, ActorSystem}
@@ -24,6 +25,7 @@ import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.{AddRecordToLocation, DeleteRecordFromLocation}
 import io.radicalbit.nsdb.cluster.coordinator.mockedActors.{LocalMetadataCache, LocalMetadataCoordinator}
+import io.radicalbit.nsdb.cluster.util.FileUtils
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
@@ -161,6 +163,42 @@ class MetricsDataActorSpec()
     }
 
     expectNoMessage(interval)
+
+  }
+
+  "metricsDataActor" should "delete outdated locations" in within(5.seconds) {
+    val namespaceToCheck = "namespaceToCheck"
+
+    val record = Bit(System.currentTimeMillis, 23, Map("dimension" -> s"dimension"), Map("tag" -> s"tag"))
+
+    val locationToEvict    = Location("metricToCheck", "testNode", 0, 100)
+    val locationNotToEvict = Location("metricToCheck", "testNode", 100, 200)
+
+    probe.send(metricsDataActor, AddRecordToLocation(db, namespaceToCheck, record, locationToEvict))
+    awaitAssert {
+      probe.expectMsgType[RecordAdded]
+    }
+    probe.send(metricsDataActor, AddRecordToLocation(db, namespaceToCheck, record, locationNotToEvict))
+    awaitAssert {
+      probe.expectMsgType[RecordAdded]
+    }
+
+    expectNoMessage(interval)
+
+    awaitAssert {
+      FileUtils
+        .getSubDirs(Paths.get(basePath, db, namespaceToCheck, "shards"))
+        .map(_.getName)
+        .sortBy(identity) shouldBe Seq(locationToEvict.shardName, locationNotToEvict.shardName)
+    }
+
+    probe.send(metricsDataActor, CheckForOutDatedShards(db, namespaceToCheck, Seq(locationNotToEvict)))
+    awaitAssert {
+      FileUtils
+        .getSubDirs(Paths.get(basePath, db, namespaceToCheck, "shards"))
+        .map(_.getName)
+        .sortBy(identity) shouldBe Seq(locationNotToEvict.shardName)
+    }
 
   }
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -344,8 +344,6 @@ class MetadataCoordinatorSpec
         locationsGot.locations.sortBy(_.from) shouldBe locations
       }
 
-      Thread.sleep(2000)
-
       awaitAssert {
         probe.send(metadataCoordinator, GetLocations(db, namespace, metric))
         val locationsGot = probe.expectMsgType[LocationsGot]
@@ -354,8 +352,6 @@ class MetadataCoordinatorSpec
         val deleteCommand = metricsDataActorProbe.expectMsgType[ExecuteDeleteStatementInternalInLocations]
         deleteCommand.locations shouldBe Seq(locations.takeRight(2).head)
       }
-
-      Thread.sleep(3000)
 
       awaitAssert {
         probe.send(metadataCoordinator, GetLocations(db, namespace, metric))

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
@@ -94,7 +94,7 @@ class MetricAccumulatorActor(val basePath: String,
   }
 
   private def deleteLocation(location: Location): Unit = {
-    val path = Paths.get(basePath, db, namespace, "shards", s"${location.metric}_${location.from}_${location.to}")
+    val path = Paths.get(basePath, db, namespace, "shards", s"${location.shardName}")
     if (path.toFile.exists())
       FileUtils.deleteDirectory(path.toFile)
   }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
@@ -65,8 +65,8 @@ class MetricPerformerActor(val basePath: String,
 
       groupedByKey.foreach {
         case (loc, ops) =>
-          val index               = getIndex(loc)
-          val facetIndexes        = facetIndexesFor(loc)
+          val index               = getOrCreateIndex(loc)
+          val facetIndexes        = getOrCreatefacetIndexesFor(loc)
           val writer: IndexWriter = index.getWriter
 
           val facetsIndexWriter = facetIndexes.newIndexWriter
@@ -146,8 +146,8 @@ class MetricPerformerActor(val basePath: String,
           log.error("retrying operation {} attempt {} ", op, attempt)
 
           val loc                          = op.location
-          val index                        = getIndex(loc)
-          val facetIndexes                 = facetIndexesFor(loc)
+          val index                        = getOrCreateIndex(loc)
+          val facetIndexes                 = getOrCreatefacetIndexesFor(loc)
           implicit val writer: IndexWriter = index.getWriter
 
           val facets            = new AllFacetIndexes(basePath = basePath, db = db, namespace = namespace, location = loc)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricsActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricsActor.scala
@@ -92,8 +92,7 @@ trait MetricsActor extends DirectorySupport { this: Actor =>
     shards.getOrElse(
       location, {
         val directory =
-          createMmapDirectory(
-            Paths.get(basePath, db, namespace, "shards", s"${location.metric}_${location.from}_${location.to}"))
+          createMmapDirectory(Paths.get(basePath, db, namespace, "shards", s"${location.shardName}"))
         val newIndex = new TimeSeriesIndex(directory)
         shards += (location -> newIndex)
         newIndex

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -49,8 +49,7 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
     with DirectorySupport {
 
   lazy val directory: Directory =
-    createMmapDirectory(
-      Paths.get(basePath, db, namespace, "shards", s"${location.metric}_${location.from}_${location.to}"))
+    createMmapDirectory(Paths.get(basePath, db, namespace, "shards", s"${location.shardName}"))
 
   lazy val index = new TimeSeriesIndex(directory)
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/CommitLogWriterActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/CommitLogWriterActor.scala
@@ -32,10 +32,15 @@ object CommitLogWriterActor {
     def bit: Bit
   }
 
+  sealed trait LocationEntryAction extends CommitLogAction {
+    def location: Location
+  }
+
   case class ReceivedEntryAction(bit: Bit)                        extends BitEntryAction
   case class AccumulatedEntryAction(bit: Bit)                     extends BitEntryAction
   case class PersistedEntryAction(bit: Bit)                       extends BitEntryAction
   case class RejectedEntryAction(bit: Bit)                        extends BitEntryAction
+  case class EvictShardAction(location: Location)                 extends LocationEntryAction
   case class DeleteAction(deleteSQLStatement: DeleteSQLStatement) extends CommitLogAction
   case object DeleteNamespaceAction                               extends CommitLogAction
   case object DeleteMetricAction                                  extends CommitLogAction

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AllFacetIndexes.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AllFacetIndexes.scala
@@ -35,12 +35,11 @@ class AllFacetIndexes(basePath: String, db: String, namespace: String, location:
     with DirectorySupport {
 
   private val directory =
-    createMmapDirectory(
-      Paths.get(basePath, db, namespace, "shards", s"${location.metric}_${location.from}_${location.to}", "facet"))
+    createMmapDirectory(Paths.get(basePath, db, namespace, "shards", s"${location.shardName}", "facet"))
 
   private val taxoDirectory = createMmapDirectory(
     Paths
-      .get(basePath, db, namespace, "shards", s"${location.metric}_${location.from}_${location.to}", "facet", "taxo"))
+      .get(basePath, db, namespace, "shards", s"${location.shardName}", "facet", "taxo"))
 
   val facetCountIndex = new FacetCountIndex(directory, taxoDirectory)
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Location.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Location.scala
@@ -23,4 +23,6 @@ package io.radicalbit.nsdb.model
   * @param from shard interval lower bound.
   * @param to shard interval upper bound.
   */
-case class Location(metric: String, node: String, from: Long, to: Long)
+case class Location(metric: String, node: String, from: Long, to: Long) {
+  def shardName = s"${metric}_${from}_$to"
+}

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -142,6 +142,7 @@ object MessageProtocol {
     case class AllMetricsDeleted(db: String, namespace: String)
     case class ShardEvicted(db: String, namespace: String, location: Location)
     case class EvictedShardFailed(db: String, namespace: String, location: Location, reason: String)
+    case class CheckForOutDatedShards(db: String, namespace: String, location: Seq[Location])
 
     case class CommitLogCoordinatorSubscribed(actor: ActorRef, nodeName: String)
     case class MetricsDataActorSubscribed(actor: ActorRef, nodeName: String)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -51,6 +51,8 @@ object MessageProtocol {
     case class PublishRecord(db: String, namespace: String, metric: String, record: Bit, schema: Schema)
     case class ExecuteDeleteStatement(statement: DeleteSQLStatement)
     case class ExecuteDeleteStatementInShards(statement: DeleteSQLStatement, schema: Schema, keys: Seq[Location])
+    case class EvictShard(db: String, namespace: String, location: Location)
+
     case class DropMetric(db: String, namespace: String, metric: String)
     case class DropMetricWithLocations(db: String, namespace: String, metric: String, locations: Seq[Location])
     case class DeleteNamespace(db: String, namespace: String)
@@ -138,6 +140,8 @@ object MessageProtocol {
     case class CountGot(db: String, namespace: String, metric: String, count: Int)
     case class RecordDeleted(db: String, namespace: String, metric: String, record: Bit)
     case class AllMetricsDeleted(db: String, namespace: String)
+    case class ShardEvicted(db: String, namespace: String, location: Location)
+    case class EvictedShardFailed(db: String, namespace: String, location: Location, reason: String)
 
     case class CommitLogCoordinatorSubscribed(actor: ActorRef, nodeName: String)
     case class MetricsDataActorSubscribed(actor: ActorRef, nodeName: String)

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
@@ -25,7 +25,6 @@ import akka.routing.RoundRobinPool
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import akka.util.Timeout
 import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType, TagFieldType}
-import io.radicalbit.nsdb.common.statement.{AscOrderOperator, ListFields, SelectSQLStatement}
 import io.radicalbit.nsdb.index.VARCHAR
 import io.radicalbit.nsdb.model.{Location, Schema, SchemaField}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
@@ -45,8 +44,9 @@ class MetricAccumulatorActorSpec()
   val probe      = TestProbe()
   val probeActor = probe.ref
 
-  val indexingInterval = FiniteDuration(system.settings.config.getDuration("nsdb.write.scheduler.interval", TimeUnit.SECONDS),
-                                TimeUnit.SECONDS) + 1.second
+  val indexingInterval = FiniteDuration(
+    system.settings.config.getDuration("nsdb.write.scheduler.interval", TimeUnit.SECONDS),
+    TimeUnit.SECONDS) + 1.second
   val basePath  = "target/test_index"
   val db        = "db_shard"
   val namespace = "namespace"
@@ -61,29 +61,14 @@ class MetricAccumulatorActorSpec()
       MetricAccumulatorActor.props(basePath, db, namespace, metricsReaderActor, system.actorOf(Props.empty)),
       probeActor)
 
-
   val schema =
     Schema("",
-      Set(SchemaField("dimension", DimensionFieldType, VARCHAR()), SchemaField("tag", TagFieldType, VARCHAR())))
+           Set(SchemaField("dimension", DimensionFieldType, VARCHAR()), SchemaField("tag", TagFieldType, VARCHAR())))
 
   private val location = Location("testMetric", nodeName, 0, 0)
 
-
-  private def selectAllOrderByTimestamp(metric: String) = ExecuteStatement(
-    SelectSQLStatement(
-      db = db,
-      namespace = namespace,
-      metric = metric,
-      distinct = false,
-      fields = ListFields(List.empty),
-      condition = None,
-      groupBy = None,
-      order = Some(AscOrderOperator("timestamp"))
-    )
-  )
-
   private def checkExistance(location: Location): Boolean =
-  Paths.get(basePath, db, namespace, "shards", s"${location.metric}_${location.from}_${location.to}").toFile.exists()
+    Paths.get(basePath, db, namespace, "shards", s"${location.metric}_${location.from}_${location.to}").toFile.exists()
 
   before {
     implicit val timeout = Timeout(5 second)

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
@@ -68,7 +68,7 @@ class MetricAccumulatorActorSpec()
   private val location = Location("testMetric", nodeName, 0, 0)
 
   private def checkExistance(location: Location): Boolean =
-    Paths.get(basePath, db, namespace, "shards", s"${location.metric}_${location.from}_${location.to}").toFile.exists()
+    Paths.get(basePath, db, namespace, "shards", s"${location.shardName}").toFile.exists()
 
   before {
     implicit val timeout = Timeout(5 second)

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricPerformerActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricPerformerActorSpec.scala
@@ -87,7 +87,7 @@ class MetricPerformerActorSpec
     val directory =
       new MMapDirectory(
         Paths
-          .get(basePath, db, namespace, "shards", s"${errorLocation.metric}_${errorLocation.from}_${errorLocation.to}"))
+          .get(basePath, db, namespace, "shards", s"${errorLocation.shardName}"))
 
     indexerPerformerActor.underlyingActor.shards += (errorLocation -> new BrokenTimeSeriesIndex(directory))
   }


### PR DESCRIPTION
This PR's intent is to remove the outdated locations remained after the evition process.

So far, in fact, those locations are simply Unlinked from the metadata, thus, they are not considered during queries, but they are still written in the file system.

This PR is to remove those locations in 2 different moments:

- when the eviction is performed; plus unlink the location, it will be deleted from the FS
- a periodical check if there is some outdated location is performed.