### PR TITLE
Global Temporal Continuity

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
@@ -23,6 +23,7 @@ import akka.cluster.ddata._
 import akka.dispatch.ControlMessage
 import akka.pattern.{ask, pipe}
 import akka.util.Timeout
+import io.radicalbit.nsdb.cluster.util.ErrorManagementUtils
 import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.Coordinates
 import io.radicalbit.nsdb.model.Location
@@ -73,6 +74,7 @@ object ReplicatedMetadataCache {
   private final case class MetricLocationsRequest(key: MetricLocationsCacheKey, replyTo: ActorRef)
   private final case class MetricInfoRequest(key: MetricInfoCacheKey, replyTo: ActorRef)
   private final case class AllMetricInfoWithRetentionRequest(replyTo: ActorRef)
+  private final case class AllMetricInfoRequest(replyTo: ActorRef)
   private final case class DbsRequest(replyTo: ActorRef)
   private final case class NamespaceRequest(db: String, replyTo: ActorRef)
   private final case class MetricRequest(db: String, namespace: String, replyTo: ActorRef)
@@ -112,6 +114,7 @@ object ReplicatedMetadataCache {
   final case class MetricInfoAlreadyExisting(key: MetricInfoCacheKey, value: MetricInfo)
 
   final case class MetricInfoCached(db: String, namespace: String, metric: String, value: Option[MetricInfo])
+  final case class AllMetricInfoGot(metricInfo: Set[MetricInfo])              extends ControlMessage
   final case class AllMetricInfoWithRetentionGot(metricInfo: Set[MetricInfo]) extends ControlMessage
 
   final case class GetMetricInfoFromCache(db: String, namespace: String, metric: String)
@@ -288,21 +291,21 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
           locations.map(location => self ? EvictLocation(db, namespace, location))
         }
         metricInfo <- (self ? GetMetricInfoFromCache(db, namespace, metric)).mapTo[MetricInfoCached]
-        dropAllMetricInfo <- metricInfo.value
+        _ <- metricInfo.value
           .map(info =>
             (replicator ? Update(allMetricInfoKey, ORSet(), WriteLocal)(_ remove info)).mapTo[UpdateSuccess[_]])
           .getOrElse(Future(UpdateSuccess(allMetricInfoKey, None)))
-        dropMetricInfo <- {
+        _ <- {
           val key = MetricInfoCacheKey(db, namespace, metric)
           metricInfo.value
-            .map(info =>
+            .map(_ =>
               (replicator ? Update(metricInfoKey(key), LWWMap(), WriteLocal)(_ remove (address, key)))
                 .mapTo[UpdateSuccess[_]])
             .getOrElse(Future(UpdateSuccess(metricInfoKey(key), None)))
         }
         dropCoordinates <- {
-          val errors = dropLocationsResult.collect { case res: EvictLocationFailed => res }
-          if (errors.isEmpty)
+          val dropLocationsErrors = dropLocationsResult.collect { case res: EvictLocationFailed => res }
+          if (dropLocationsErrors.isEmpty)
             (replicator ? Update(coordinatesKey, ORSet(), WriteLocal)(_ remove Coordinates(db, namespace, metric)))
               .map {
                 case UpdateSuccess(_, _) =>
@@ -313,7 +316,7 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
       } yield dropCoordinates)
         .pipeTo(sender())
     case DropNamespaceFromCache(db, namespace) =>
-      (for {
+      val chain = for {
         metrics <- (self ? GetMetricsFromCache(db, namespace)).mapTo[MetricsFromCacheGot]
         locations <- {
           Future
@@ -323,21 +326,48 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
             }
             .map(_.flatten)
         }
-        _ <- Future.sequence {
-          locations.map(location => self ? EvictLocation(db, namespace, location))
-        }
-        coordinatesUpdate <- Future
-          .sequence(metrics.metrics
-            .map(location =>
-              replicator ? Update(coordinatesKey, ORSet(), WriteLocal)(_ remove Coordinates(db, namespace, location))))
-          .map { responses =>
-            val errors = responses.collect {
-              case res: UpdateFailure[_] => res
-            }
-            if (errors.isEmpty) NamespaceFromCacheDropped(db, namespace)
-            else DropNamespaceFromCacheFailed(db, namespace)
+        (_, failedEvictions) <- Future
+          .sequence {
+            locations.map(location =>
+              (self ? EvictLocation(db, namespace, location)).mapTo[Either[EvictLocationFailed, LocationEvicted]])
           }
-      } yield coordinatesUpdate).pipeTo(sender())
+          .map(responses => ErrorManagementUtils.partitionResponses(responses))
+        metricInfos <- (replicator ? Get(allMetricInfoKey, ReadLocal, request = Some(AllMetricInfoRequest(sender()))))
+          .map {
+            case g @ GetSuccess(_, _) =>
+              g.dataValue.asInstanceOf[ORSet[MetricInfo]].elements.filter(e => e.db == db && e.namespace == namespace)
+            case NotFound(_, _) => Set.empty[MetricInfo]
+          }
+        _ <- Future.sequence(metricInfos.map(info =>
+          (replicator ? Update(allMetricInfoKey, ORSet(), WriteLocal)(_ remove info)).mapTo[UpdateSuccess[_]]))
+        _ <- Future.sequence(metricInfos.map { metricInfo =>
+          val key = MetricInfoCacheKey(db, namespace, metricInfo.metric)
+          (replicator ? Update(metricInfoKey(key), LWWMap(), WriteLocal)(_ remove (address, key)))
+            .mapTo[UpdateSuccess[_]]
+        })
+        coordinatesUpdate <- if (failedEvictions.nonEmpty) {
+          Future(DropNamespaceFromCacheFailed(db, namespace))
+        } else
+          Future
+            .sequence(
+              metrics.metrics
+                .map(location =>
+                  replicator ? Update(coordinatesKey, ORSet(), WriteLocal)(
+                    _ remove Coordinates(db, namespace, location))))
+            .map { responses =>
+              val errors = responses.collect {
+                case res: UpdateFailure[_] => res
+              }
+              if (errors.isEmpty) NamespaceFromCacheDropped(db, namespace)
+              else DropNamespaceFromCacheFailed(db, namespace)
+            }
+      } yield coordinatesUpdate
+
+      chain
+        .recover {
+          case _ => DropNamespaceFromCacheFailed(db, namespace)
+        }
+        .pipeTo(sender())
     case g @ GetSuccess(LWWMapKey(_), Some(SingleLocationRequest(key, replyTo))) =>
       val values = g.dataValue.asInstanceOf[LWWMap[LocationWithNodeKey, Location]].entries.values.toList
       replyTo ! LocationsCached(key.db, key.namespace, key.metric, values)
@@ -357,6 +387,9 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
       replyTo ! MetricInfoCached(key.db, key.namespace, key.metric, dataValue)
     case g @ GetSuccess(_, Some(AllMetricInfoWithRetentionRequest(replyTo))) =>
       val elements = g.dataValue.asInstanceOf[ORSet[MetricInfo]].elements.filter(_.retention > 0)
+      replyTo ! AllMetricInfoWithRetentionGot(elements)
+    case g @ GetSuccess(_, Some(AllMetricInfoRequest(replyTo))) =>
+      val elements = g.dataValue.asInstanceOf[ORSet[MetricInfo]].elements
       replyTo ! AllMetricInfoWithRetentionGot(elements)
     case g @ GetSuccess(_, Some(DbsRequest(replyTo))) =>
       val elements = g.dataValue.asInstanceOf[ORSet[Coordinates]].elements.map(_.db)
@@ -378,12 +411,14 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
     case NotFound(_, Some(MetricInfoRequest(key, replyTo))) =>
       replyTo ! MetricInfoCached(key.db, key.namespace, key.metric, None)
     case NotFound(_, Some(AllMetricInfoWithRetentionRequest(replyTo))) =>
+      replyTo ! AllMetricInfoGot(Set.empty)
+    case NotFound(_, Some(AllMetricInfoRequest(replyTo))) =>
       replyTo ! AllMetricInfoWithRetentionGot(Set.empty)
-    case g @ NotFound(_, Some(DbsRequest(replyTo))) =>
+    case NotFound(_, Some(DbsRequest(replyTo))) =>
       replyTo ! DbsFromCacheGot(Set.empty)
-    case g @ NotFound(_, Some(NamespaceRequest(db, replyTo))) =>
+    case NotFound(_, Some(NamespaceRequest(db, replyTo))) =>
       replyTo ! NamespacesFromCacheGot(db, Set.empty)
-    case g @ NotFound(_, Some(MetricRequest(db, namespace, replyTo))) =>
+    case NotFound(_, Some(MetricRequest(db, namespace, replyTo))) =>
       replyTo ! MetricsFromCacheGot(db, namespace, Set.empty)
     case msg: UpdateResponse[_] =>
       log.debug("received not handled update message {}", msg)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -42,7 +42,7 @@ import io.radicalbit.nsdb.index.DirectorySupport
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
-import io.radicalbit.nsdb.statement.TimeRangeExtractor
+import io.radicalbit.nsdb.statement.TimeRangeManager
 import io.radicalbit.nsdb.util.ActorPathLogging
 import org.apache.lucene.index.{IndexNotFoundException, IndexUpgrader}
 import org.apache.lucene.store.Directory
@@ -302,7 +302,7 @@ class MetadataCoordinator(cache: ActorRef, schemaCoordinator: ActorRef, mediator
             .map {
               case LocationsCached(_, _, _, locations) =>
                 val (locationsToFullyEvict, locationsToPartiallyEvict) =
-                  TimeRangeExtractor.getLocationsToEvict(locations, threshold)
+                  TimeRangeManager.getLocationsToEvict(locations, threshold)
 
                 val cacheResponses = Future
                   .sequence(locationsToFullyEvict.map { location =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -361,16 +361,6 @@ class MetadataCoordinator(cache: ActorRef, schemaCoordinator: ActorRef, mediator
                     locationsToFullyEvict.map(location => fullyEvictPerform(db, namespace, location))
                   )
                 }
-
-              //check for outdated locations still written on disk
-              /*locations.groupBy(_.node).foreach {
-                  case (node, locations) =>
-                    metricsDataActors.get(node) match {
-                      case Some(metricDataActor) =>
-                        metricDataActor ! CheckForOutDatedShards(db, namespace, locations)
-                      case None => log.debug("no metrics data actor found for node {}", node)
-                    }
-                }*/
             }
       }
     case SubscribeMetricsDataActor(actor: ActorRef, nodeName) =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -536,7 +536,6 @@ object MetadataCoordinator {
                                     namespace: String,
                                     metric: String,
                                     occurredOn: Long = System.currentTimeMillis)
-    case class DeleteNamespaceMetadata(db: String, namespace: String, occurredOn: Long = System.currentTimeMillis)
 
     case class GetMetricInfo(db: String, namespace: String, metric: String)
     case class PutMetricInfo(metricInfo: MetricInfo)
@@ -555,7 +554,6 @@ object MetadataCoordinator {
     case class AddLocationsFailed(db: String, namespace: String, locations: Seq[Location])
     case class LocationDeleted(db: String, namespace: String, location: Location)
     case class MetricMetadataDeleted(db: String, namespace: String, metric: String, occurredOn: Long)
-    case class NamespaceMetadataDeleted(db: String, namespace: String, occurredOn: Long)
 
     case class MetricInfoGot(db: String, namespace: String, metric: String, metricInfo: Option[MetricInfo])
     case class MetricInfoPut(metricInfo: MetricInfo)

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -266,22 +266,42 @@ class ReplicatedMetadataCacheSpec
     "drop namespaces coordinates and allow reinserting them" in within(5.seconds) {
       val l1 = Location("metric1", "node1", 0,1)
       val l2 = Location("metric2", "node1", 0,1)
+
+      val metric1InfoValue = MetricInfo("db1", "namespace1", "metric1", 0, 1)
+      val metric2InfoValue = MetricInfo("db1", "namespace1", "metric2", 1, 0)
+
       runOn(node1) {
         replicatedCache ! PutLocationInCache("db1", "namespace1", "metric1", 0, 1, l1)
         expectMsg(LocationCached("db1", "namespace1", "metric1", 0, 1, l1))
+
+        replicatedCache ! PutMetricInfoInCache(metric1InfoValue)
+        expectMsg(MetricInfoCached("db1", "namespace1", "metric1", Some(metric1InfoValue)))
       }
 
       runOn(node1) {
         replicatedCache ! PutLocationInCache("db1", "namespace1", "metric2", 0, 1, l2)
         expectMsg(LocationCached("db1", "namespace1", "metric2", 0, 1, l2))
+
+        replicatedCache ! PutMetricInfoInCache(metric2InfoValue)
+        expectMsg(MetricInfoCached("db1", "namespace1", "metric2", Some(metric2InfoValue)))
       }
+
+      enterBarrier("after-add-metrics")
 
       awaitAssert {
         replicatedCache ! GetMetricsFromCache("db1", "namespace1")
         expectMsg(MetricsFromCacheGot("db1", "namespace1", Set("metric1","metric2")))
       }
 
-      enterBarrier("after-add-metric2")
+      awaitAssert {
+        replicatedCache ! GetMetricInfoFromCache("db1", "namespace1", "metric1")
+        expectMsg(MetricInfoCached("db1", "namespace1", "metric1", Some(metric1InfoValue)))
+
+        replicatedCache ! GetMetricInfoFromCache("db1", "namespace1", "metric2")
+        expectMsg(MetricInfoCached("db1", "namespace1", "metric2", Some(metric2InfoValue)))
+      }
+
+      enterBarrier("after-check-metrics")
 
       runOn(node2) {
         replicatedCache ! DropNamespaceFromCache("db1", "namespace1")
@@ -304,6 +324,14 @@ class ReplicatedMetadataCacheSpec
 
         replicatedCache ! GetLocationsFromCache("db1", "namespace1", "metric2")
         expectMsg(LocationsCached("db1", "namespace1", "metric2", Seq()))
+      }
+
+      awaitAssert {
+        replicatedCache ! GetMetricInfoFromCache("db1", "namespace1", "metric1")
+        expectMsg(MetricInfoCached("db1", "namespace1", "metric1", None))
+
+        replicatedCache ! GetMetricInfoFromCache("db1", "namespace1", "metric2")
+        expectMsg(MetricInfoCached("db1", "namespace1", "metric2", None))
       }
 
       enterBarrier("after-drop-namespace")

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -235,6 +235,9 @@ class ReplicatedMetadataCacheSpec
 
         replicatedCache ! GetLocationsFromCache("db1", "namespace1", "metric2")
         expectMsg(LocationsCached("db1", "namespace1", "metric2", Seq()))
+
+        replicatedCache ! GetMetricInfoFromCache("db1", "namespace1", "metric2")
+        expectMsg(MetricInfoCached("db1", "namespace1", "metric2", None))
       }
 
       enterBarrier("after-drop metrics")

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
@@ -75,7 +75,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
 
     Await.result(readCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "node1"), 10 seconds)
 
-    val location1 = Location(_: String, "node1", 100000, 150000)
+    val location1 = Location(_: String, "node1", 100000, 190000)
     val location2 = Location(_: String, "node1", 0, 90000)
 
     //long metric
@@ -132,14 +132,16 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           probe.expectMsgType[SelectStatementExecuted]
         }
 
-        expected.values.size shouldBe 5
+        expected.values.size shouldBe 7
 
         expected.values shouldBe Seq(
-          Bit(0, 2, Map("lowerBound"      -> 0, "upperBound"      -> 30000), Map()),
-          Bit(30000, 1, Map("lowerBound"  -> 30000, "upperBound"  -> 60000), Map()),
-          Bit(60000, 1, Map("lowerBound"  -> 60000, "upperBound"  -> 90000), Map()),
-          Bit(100000, 1, Map("lowerBound" -> 100000, "upperBound" -> 120000), Map()),
-          Bit(120000, 1, Map("lowerBound" -> 120000, "upperBound" -> 150000), Map())
+          Bit(0, 1, Map("lowerBound"      -> 0, "upperBound"      -> 10000), Map()),
+          Bit(10000, 1, Map("lowerBound"  -> 10000, "upperBound"  -> 40000), Map()),
+          Bit(40000, 1, Map("lowerBound"  -> 40000, "upperBound"  -> 70000), Map()),
+          Bit(70000, 1, Map("lowerBound"  -> 70000, "upperBound"  -> 100000), Map()),
+          Bit(100000, 1, Map("lowerBound" -> 100000, "upperBound" -> 130000), Map()),
+          Bit(130000, 1, Map("lowerBound" -> 130000, "upperBound" -> 160000), Map()),
+          Bit(160000, 0, Map("lowerBound" -> 160000, "upperBound" -> 190000), Map())
         )
 
       }
@@ -164,14 +166,14 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           probe.expectMsgType[SelectStatementExecuted]
         }
 
-        expected.values.size shouldBe 3
+        expected.values.size shouldBe 4
 
         expected.values shouldBe Seq(
-          Bit(0, 2, Map("lowerBound"      -> 0, "upperBound"      -> 30000), Map()),
-          Bit(30000, 2, Map("lowerBound"  -> 30000, "upperBound"  -> 90000), Map()),
-          Bit(100000, 2, Map("lowerBound" -> 100000, "upperBound" -> 150000), Map())
+          Bit(0, 1, Map("lowerBound"      -> 0, "upperBound"      -> 10000), Map()),
+          Bit(10000, 2, Map("lowerBound"  -> 10000, "upperBound"  -> 70000), Map()),
+          Bit(70000, 2, Map("lowerBound"  -> 70000, "upperBound"  -> 130000), Map()),
+          Bit(130000, 1, Map("lowerBound" -> 130000, "upperBound" -> 190000), Map())
         )
-
       }
 
     }
@@ -201,12 +203,14 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           probe.expectMsgType[SelectStatementExecuted]
         }
 
-        expected.values.size shouldBe 3
+        expected.values.size shouldBe 5
 
         expected.values shouldBe Seq(
-          Bit(60000, 2, Map("lowerBound"  -> 60000, "upperBound"  -> 90000), Map()),
-          Bit(90000, 1, Map("lowerBound"  -> 90000, "upperBound"  -> 120000), Map()),
-          Bit(120000, 1, Map("lowerBound" -> 120000, "upperBound" -> 150000), Map())
+          Bit(60000, 1, Map("lowerBound"  -> 60000, "upperBound"  -> 70000), Map()),
+          Bit(70000, 1, Map("lowerBound"  -> 70000, "upperBound"  -> 100000), Map()),
+          Bit(100000, 1, Map("lowerBound" -> 100000, "upperBound" -> 130000), Map()),
+          Bit(130000, 1, Map("lowerBound" -> 130000, "upperBound" -> 160000), Map()),
+          Bit(160000, 0, Map("lowerBound" -> 160000, "upperBound" -> 190000), Map())
         )
       }
 
@@ -237,6 +241,37 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
         expected.values shouldBe Seq(
           Bit(0, 1, Map("lowerBound"     -> 0, "upperBound"     -> 29999), Map()),
           Bit(29999, 1, Map("lowerBound" -> 29999, "upperBound" -> 59999), Map())
+        )
+      }
+    }
+
+    "receive a select containing a temporal group by with an interval higher than the shard interval" should {
+      "execute it successfully" in within(5.seconds) {
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalLongMetric.name,
+                distinct = false,
+                fields = ListFields(List(Field("value", Some(CountAggregation)))),
+                condition = None,
+                groupBy = Some(TemporalGroupByAggregation(100000L))
+              )
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values.size shouldBe 2
+
+        expected.values shouldBe Seq(
+          Bit(0, 4, Map("lowerBound"     -> 0, "upperBound"     -> 90000), Map()),
+          Bit(90000, 2, Map("lowerBound" -> 90000, "upperBound" -> 190000), Map())
         )
       }
     }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Location.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Location.scala
@@ -16,8 +16,13 @@
 
 package io.radicalbit.nsdb.model
 
+import spire.implicits._
+import spire.math.Interval
+import spire.math.interval.Closed
+
 /**
   * Metric shard location.
+  *
   * @param metric the metric.
   * @param node a string representation of a node, that is [hostname]_[port].
   * @param from shard interval lower bound.
@@ -25,4 +30,6 @@ package io.radicalbit.nsdb.model
   */
 case class Location(metric: String, node: String, from: Long, to: Long) {
   def shardName = s"${metric}_${from}_$to"
+
+  def interval: Interval[Long] = Interval.fromBounds(Closed(from), Closed(to))
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/TimeRange.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/TimeRange.scala
@@ -16,11 +16,23 @@
 
 package io.radicalbit.nsdb.model
 
+import spire.implicits._
+import spire.math.Interval
+import spire.math.interval.{Closed, Open}
+
 /**
   * Class that models a range between 2 time instants.
+  *
   * @param lowerBound The range's lower bound.
   * @param upperBound The ranges' upper bound.
   * @param lowerInclusive True if the lower bound is inclusive.
   * @param upperInclusive True if the upper bound is inclusive.
   */
-case class TimeRange(lowerBound: Long, upperBound: Long, lowerInclusive: Boolean, upperInclusive: Boolean)
+case class TimeRange(lowerBound: Long, upperBound: Long, lowerInclusive: Boolean, upperInclusive: Boolean) {
+
+  def interval: Interval[Long] =
+    Interval.fromBounds(if (lowerInclusive) Closed(lowerBound) else Open(lowerBound),
+                        if (upperInclusive) Closed(upperBound) else Open(upperBound))
+
+  def intersect(location: Location): Boolean = this.interval.intersects(location.interval)
+}


### PR DESCRIPTION
This PR improves the time range queries by calculating the time intervals globally, i.e. the upper boundary and the lower boundary are calculated by looking up to all the shards and not by demanding the calculation to each shard.

Each shard is only responsible to check if there are records for the global intervals.

By doing this, it will be avoided any possible overlap between the time intervals specified in the query and the metric partitions

 