### PR TITLE
Schema Fields And Data children actors optimization

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
@@ -35,7 +35,7 @@ import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.util.ActorPathLogging
 import org.apache.commons.io.FileUtils
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Actor responsible for dispatching read or write commands to the proper actor and index.
@@ -48,54 +48,60 @@ class MetricsDataActor(val basePath: String, val nodeName: String, commitLogCoor
   lazy val readParallelism = ReadParallelism(context.system.settings.config.getConfig("nsdb.read.parallelism"))
 
   /**
-    * Gets or creates:
-    * - reader child actor of class [[MetricReaderActor]] to handle read requests
-    * - accumulator child actor of class [[MetricAccumulatorActor]] to handle write requests
+    * Gets or creates reader child actor of class [[MetricReaderActor]] to handle read requests
     *
     * @param db database name
     * @param namespace namespace name
-    * @return ([[MetricReaderActor]], [[MetricAccumulatorActor]]) for selected database and namespace
+    * @return [[MetricReaderActor]] for selected database and namespace
     */
-  private def getOrCreateChildren(db: String, namespace: String): (ActorRef, ActorRef) = {
-    val readerOpt      = context.child(s"metric_reader_${db}_$namespace")
-    val accumulatorOpt = context.child(s"metric_accumulator_${db}_$namespace")
+  private def getOrCreateReader(db: String, namespace: String): ActorRef =
+    context
+      .child(s"metric_reader_${db}_$namespace")
+      .getOrElse(
+        context.actorOf(
+          readParallelism.pool.props(
+            MetricReaderActor
+              .props(basePath, nodeName, db, namespace)
+              .withDispatcher("akka.actor.control-aware-dispatcher")),
+          s"metric_reader_${db}_$namespace"
+        ))
 
-    val reader = readerOpt.getOrElse(
-      context.actorOf(
-        readParallelism.pool.props(
-          MetricReaderActor
+  /**
+    * Gets or creates accumulator child actor of class [[MetricAccumulatorActor]] to handle write requests
+    *
+    * @param db database name
+    * @param namespace namespace name
+    * @return [[MetricAccumulatorActor]] for selected database and namespace
+    */
+  private def getOrCreateAccumulator(db: String, namespace: String): ActorRef =
+    context.child(s"metric_accumulator_${db}_$namespace").getOrElse {
+      val reader = context
+        .child(s"metric_reader_${db}_$namespace")
+        .getOrElse(context.actorOf(
+          readParallelism.pool.props(MetricReaderActor
             .props(basePath, nodeName, db, namespace)
             .withDispatcher("akka.actor.control-aware-dispatcher")),
-        s"metric_reader_${db}_$namespace"
-      ))
-    val accumulator = accumulatorOpt.getOrElse(
+          s"metric_reader_${db}_$namespace"
+        ))
       context.actorOf(MetricAccumulatorActor.props(basePath, db, namespace, reader, commitLogCoordinator),
-                      s"metric_accumulator_${db}_$namespace"))
-    (reader, accumulator)
+                      s"metric_accumulator_${db}_$namespace")
+    }
+
+  /**
+    * Gracefully stops reader and accumulator children.
+    * @param db database name
+    * @param namespace namespace name
+    */
+  private def stopChildren(db: String, namespace: String)(implicit ec: ExecutionContext) = {
+    Future.sequence(
+      Seq(
+        context.child(s"metric_reader_${db}_$namespace").map(gracefulStop(_, timeout.duration)).getOrElse(Future(true)),
+        context
+          .child(s"metric_accumulator_${db}_$namespace")
+          .map(gracefulStop(_, timeout.duration))
+          .getOrElse(Future(true))
+      ))
   }
-
-  /**
-    * Gets it exists:
-    * - reader child actor of class [[MetricReaderActor]] to handle read requests
-    * - accumulator child actor of class [[MetricAccumulatorActor]] to handle write requests
-    *
-    * @param db database name
-    * @param namespace namespace name
-    * @return (Option[[MetricReaderActor]], Option[[MetricAccumulatorActor]]) for selected database and namespace
-    */
-  private def getChildren(db: String, namespace: String): (Option[ActorRef], Option[ActorRef]) =
-    (context.child(s"metric_reader_${db}_$namespace"), context.child(s"metric_accumulator_${db}_$namespace"))
-
-  /**
-    * If exists, gets the reader for selected namespace and database.
-    * Use in case of read
-    *
-    * @param db database name
-    * @param namespace namespace name
-    * @return Option containing child actor of class [[MetricAccumulatorActor]]
-    */
-  private def getReader(db: String, namespace: String): Option[ActorRef] =
-    context.child(s"metric_reader_${db}_$namespace")
 
   implicit val timeout: Timeout = Timeout(
     context.system.settings.config.getDuration("nsdb.namespace-data.timeout", TimeUnit.SECONDS),
@@ -105,21 +111,14 @@ class MetricsDataActor(val basePath: String, val nodeName: String, commitLogCoor
 
   override def receive: Receive = {
     case DeleteNamespace(db, namespace) =>
-      val children = getChildren(db, namespace)
-      val f = children._2
-        .map(indexToRemove => indexToRemove ? DeleteAllMetrics(db, namespace))
-        .getOrElse(Future(AllMetricsDeleted(db, namespace)))
-      f.flatMap(_ => {
-          Future
-            .sequence(Seq(children._1.map(gracefulStop(_, timeout.duration)).getOrElse(Future(true)),
-                          children._2.map(gracefulStop(_, timeout.duration)).getOrElse(Future(true))))
-        })
+      (getOrCreateAccumulator(db, namespace) ? DeleteAllMetrics(db, namespace))
+        .flatMap(_ => stopChildren(db, namespace))
         .map(_ => NamespaceDeleted(db, namespace))
         .pipeTo(sender())
     case msg @ DropMetricWithLocations(db, namespace, _, _) =>
-      getOrCreateChildren(db, namespace)._2 forward msg
+      getOrCreateAccumulator(db, namespace) forward msg
     case msg @ EvictShard(db, namespace, _) =>
-      getOrCreateChildren(db, namespace)._2 forward msg
+      getOrCreateAccumulator(db, namespace) forward msg
     case CheckForOutDatedShards(db, namespace, locations) =>
       val locationGrouped = locations.groupBy(_.metric)
 
@@ -138,29 +137,27 @@ class MetricsDataActor(val basePath: String, val nodeName: String, commitLogCoor
           }
       }
 
-    case msg @ GetCountWithLocations(db, namespace, metric, _) =>
-      getReader(db, namespace) match {
-        case Some(child) => child forward msg
-        case None        => sender() ! CountGot(db, namespace, metric, 0)
-      }
+    case msg @ GetCountWithLocations(db, namespace, _, _) =>
+      getOrCreateReader(db, namespace) forward msg
     case msg @ ExecuteSelectStatement(statement, _, _, _) =>
-      getReader(statement.db, statement.namespace) match {
-        case Some(child) => child forward msg
-        case None        => sender() ! SelectStatementExecuted(statement.db, statement.namespace, statement.metric, Seq.empty)
-      }
-    case msg @ AddRecordToLocation(db, namespace, bit, location) =>
-      log.debug("received message {}", msg)
-      getOrCreateChildren(db, namespace)._2
-        .forward(AddRecordToShard(db, namespace, Location(location.metric, nodeName, location.from, location.to), bit))
+      getOrCreateReader(statement.db, statement.namespace) forward msg
+    case AddRecordToLocation(db, namespace, bit, location) =>
+      getOrCreateAccumulator(db, namespace) forward AddRecordToShard(
+        db,
+        namespace,
+        Location(location.metric, nodeName, location.from, location.to),
+        bit)
     case DeleteRecordFromLocation(db, namespace, bit, location) =>
-      getOrCreateChildren(db, namespace)._2
-        .forward(
-          DeleteRecordFromShard(db, namespace, Location(location.metric, nodeName, location.from, location.to), bit))
+      getOrCreateAccumulator(db, namespace) forward DeleteRecordFromShard(
+        db,
+        namespace,
+        Location(location.metric, nodeName, location.from, location.to),
+        bit)
     case ExecuteDeleteStatementInternalInLocations(statement, schema, locations) =>
-      getOrCreateChildren(statement.db, statement.namespace)._2.forward(
-        ExecuteDeleteStatementInShards(statement,
-                                       schema,
-                                       locations.map(l => Location(l.metric, nodeName, l.from, l.to))))
+      getOrCreateAccumulator(statement.db, statement.namespace) forward ExecuteDeleteStatementInShards(
+        statement,
+        schema,
+        locations.map(l => Location(l.metric, nodeName, l.from, l.to)))
   }
 
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
@@ -202,15 +202,15 @@ class GrpcEndpoint(readCoordinator: ActorRef, writeCoordinator: ActorRef, metada
 
     override def describeMetric(request: DescribeMetric): Future[GrpcDescribeMetricResponse] = {
 
-      def extractField(schema: Option[Schema]): Set[MetricField] =
+      def extractField(schema: Option[Schema]): Iterable[MetricField] =
         schema
-          .map(
-            _.fields.map(
-              field =>
-                MetricField(name = field.name,
-                            fieldClassType = field.fieldClassType,
-                            `type` = field.indexType.getClass.getSimpleName)))
-          .getOrElse(Set.empty[MetricField])
+          .map(_.fieldsMap.map {
+            case (_, field) =>
+              MetricField(name = field.name,
+                          fieldClassType = field.fieldClassType,
+                          `type` = field.indexType.getClass.getSimpleName)
+          })
+          .getOrElse(Iterable.empty[MetricField])
 
       def extractFieldClassType(f: MetricField): GrpcFieldClassType = {
         f.fieldClassType match {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSimpleStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSimpleStatementsSpec.scala
@@ -164,7 +164,7 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
           expected.metric shouldBe LongMetric.name
           expected.schema shouldBe defined
 
-          expected.schema.get.fields.toSeq.sortBy(_.name) shouldBe
+          expected.schema.get.fieldsMap.values.toSeq.sortBy(_.name) shouldBe
             Seq(
               SchemaField("name", TagFieldType, VARCHAR()),
               SchemaField("surname", DimensionFieldType, VARCHAR()),
@@ -181,7 +181,7 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
           expected.metric shouldBe DoubleMetric.name
           expected.schema shouldBe defined
 
-          expected.schema.get.fields.toSeq.sortBy(_.name) shouldBe
+          expected.schema.get.fieldsMap.values.toSeq.sortBy(_.name) shouldBe
             Seq(
               SchemaField("name", TagFieldType, VARCHAR()),
               SchemaField("surname", DimensionFieldType, VARCHAR()),

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/SchemaIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/SchemaIndex.scala
@@ -38,13 +38,13 @@ class SchemaIndex(override val directory: Directory) extends SimpleIndex[Schema]
 
   override val _keyField: String = "metric"
 
-  override def validateRecord(data: Schema): Try[Seq[Field]] = {
+  override def validateRecord(data: Schema): Try[Seq[Field]] =
     Success(
       Seq(
         new StringField(_keyField, data.metric, Store.YES)
       ) ++
-        data.fields.map(e => new StringField(e.name, stringFieldValue(e), Store.YES)))
-  }
+        data.fieldsMap.map { case (_, e) => new StringField(e.name, stringFieldValue(e), Store.YES) }
+    )
 
   override def write(data: Schema)(implicit writer: IndexWriter): Try[Long] = {
     val doc = new Document
@@ -64,8 +64,8 @@ class SchemaIndex(override val directory: Directory) extends SimpleIndex[Schema]
       document.get(_keyField),
       fields.map { f =>
         val (fieldType, indexType) = fieldValue(f.stringValue)
-        SchemaField(f.name(), fieldType, indexType)
-      }.toSet
+        f.name() -> SchemaField(f.name(), fieldType, indexType)
+      }.toMap
     )
   }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/Index.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/Index.scala
@@ -73,7 +73,7 @@ trait Index[T] {
     * @param data the record to be validated.
     * @return a sequence of lucene [[Field]] that can be safely written in the index.
     */
-  def validateRecord(data: T): Try[Seq[Field]]
+  def validateRecord(data: T): Try[Iterable[Field]]
 
   /**
     * Writes an entry into the index.

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -43,13 +43,13 @@ package object post_proc {
             val sortedResults = seq.sortBy(_.timestamp)
             statement.limit.map(_.value).map(v => Right(sortedResults.takeRight(v))) getOrElse Right(sortedResults)
           case _ =>
-            val sortedResults = if (statement.order.isDefined) {
-              val o = schema.fields.find(_.name == statement.order.get.dimension).get.indexType.ord
+            val sortedResults = statement.order.map { order =>
+              val o = schema.fieldsMap(order.dimension).indexType.ord
               implicit val ord: Ordering[JSerializable] =
                 if (statement.order.get.isInstanceOf[DescOrderOperator]) o.reverse
                 else o
               seq.sortBy(_.fields(statement.order.get.dimension)._1)
-            } else seq
+            } getOrElse seq
             statement.limit.map(_.value).map(v => Right(sortedResults.take(v))) getOrElse Right(sortedResults)
         }
       case l @ Left(_) => l

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
@@ -63,7 +63,8 @@ class MetricAccumulatorActorSpec()
 
   val schema =
     Schema("",
-           Set(SchemaField("dimension", DimensionFieldType, VARCHAR()), SchemaField("tag", TagFieldType, VARCHAR())))
+           Map("dimension" -> SchemaField("dimension", DimensionFieldType, VARCHAR()),
+               "tag"       -> SchemaField("tag", TagFieldType, VARCHAR())))
 
   private val location = Location("testMetric", nodeName, 0, 0)
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -66,9 +66,9 @@ class PublisherActorSpec
   val testRecordNotSatisfy = Bit(0, 23, Map("name"   -> "john"), Map.empty)
   val testRecordSatisfy    = Bit(100, 25, Map("name" -> "john"), Map.empty)
 
-  val schema = Schema(
-    "people",
-    Set(SchemaField("timestamp", DimensionFieldType, BIGINT()), SchemaField("name", DimensionFieldType, VARCHAR())))
+  val schema = Schema("people",
+                      Map("timestamp" -> SchemaField("timestamp", DimensionFieldType, BIGINT()),
+                          "name"      -> SchemaField("name", DimensionFieldType, VARCHAR())))
 
   "PublisherActor" should "make other actors subscribe and unsubscribe" in {
     probe.send(publisherActor, SubscribeBySqlStatement(probeActor, "queryString", testSqlStatement))

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/SchemaIndexTest.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/SchemaIndexTest.scala
@@ -31,18 +31,18 @@ class SchemaIndexTest extends FlatSpec with Matchers with OneInstancePerTest wit
 
     val schema1 = Schema(
       s"metric",
-      Set(
-        SchemaField("field1", DimensionFieldType, BIGINT()),
-        SchemaField("field2", TagFieldType, VARCHAR()),
-        SchemaField(s"field3", DimensionFieldType, VARCHAR())
+      Map(
+        "field1" -> SchemaField("field1", DimensionFieldType, BIGINT()),
+        "field2" -> SchemaField("field2", TagFieldType, VARCHAR()),
+        "field3" -> SchemaField("field3", DimensionFieldType, VARCHAR())
       )
     )
 
     val schema2 = Schema(
       s"metric",
-      Set(
-        SchemaField("field1", DimensionFieldType, BIGINT()),
-        SchemaField("field2", TagFieldType, VARCHAR())
+      Map(
+        "field1" -> SchemaField("field1", DimensionFieldType, BIGINT()),
+        "field2" -> SchemaField("field2", TagFieldType, VARCHAR())
       )
     )
 
@@ -61,10 +61,10 @@ class SchemaIndexTest extends FlatSpec with Matchers with OneInstancePerTest wit
     (0 to 100).foreach { i =>
       val testData = Schema(
         s"metric_$i",
-        Set(
-          SchemaField("field1", DimensionFieldType, BIGINT()),
-          SchemaField("field2", DimensionFieldType, VARCHAR()),
-          SchemaField(s"field$i", DimensionFieldType, VARCHAR())
+        Map(
+          "field1"   -> SchemaField("field1", DimensionFieldType, BIGINT()),
+          "field2"   -> SchemaField("field2", DimensionFieldType, VARCHAR()),
+          s"field$i" -> SchemaField(s"field$i", DimensionFieldType, VARCHAR())
         )
       )
       schemaIndex.write(testData)
@@ -80,10 +80,10 @@ class SchemaIndexTest extends FlatSpec with Matchers with OneInstancePerTest wit
     firstSchema shouldBe Some(
       Schema(
         s"metric_0",
-        Set(
-          SchemaField("field1", DimensionFieldType, BIGINT()),
-          SchemaField("field2", DimensionFieldType, VARCHAR()),
-          SchemaField(s"field0", DimensionFieldType, VARCHAR())
+        Map(
+          "field1" -> SchemaField("field1", DimensionFieldType, BIGINT()),
+          "field2" -> SchemaField("field2", DimensionFieldType, VARCHAR()),
+          "field0" -> SchemaField("field0", DimensionFieldType, VARCHAR())
         )
       ))
   }
@@ -92,10 +92,14 @@ class SchemaIndexTest extends FlatSpec with Matchers with OneInstancePerTest wit
 
     val testData = Schema(
       "metric_1",
-      Set(SchemaField("field1", DimensionFieldType, BIGINT()), SchemaField("field2", DimensionFieldType, VARCHAR())))
+      Map("field1" -> SchemaField("field1", DimensionFieldType, BIGINT()),
+          "field2" -> SchemaField("field2", DimensionFieldType, VARCHAR()))
+    )
     val testData2 = Schema(
       "metric_1",
-      Set(SchemaField("field1", DimensionFieldType, INT()), SchemaField("field2", DimensionFieldType, VARCHAR())))
+      Map("field1" -> SchemaField("field1", DimensionFieldType, INT()),
+          "field2" -> SchemaField("field2", DimensionFieldType, VARCHAR()))
+    )
 
     lazy val directory = createMmapDirectory(Files.createTempDirectory(UUID.randomUUID().toString))
 
@@ -130,12 +134,16 @@ class SchemaIndexTest extends FlatSpec with Matchers with OneInstancePerTest wit
 
     val testData = Schema(
       s"metric_2",
-      Set(SchemaField("field1", DimensionFieldType, BIGINT()), SchemaField("field2", DimensionFieldType, VARCHAR())))
+      Map("field1" -> SchemaField("field1", DimensionFieldType, BIGINT()),
+          "field2" -> SchemaField("field2", DimensionFieldType, VARCHAR()))
+    )
     schemaIndex.write(testData)
 
     val testDataBis = Schema(
       s"metric_3",
-      Set(SchemaField("field1", DimensionFieldType, BIGINT()), SchemaField("field2", DimensionFieldType, VARCHAR())))
+      Map("field1" -> SchemaField("field1", DimensionFieldType, BIGINT()),
+          "field2" -> SchemaField("field2", DimensionFieldType, VARCHAR()))
+    )
     schemaIndex.write(testDataBis)
     writer.close()
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeSeriesIndexTest.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeSeriesIndexTest.scala
@@ -29,9 +29,9 @@ import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
 
 class TimeSeriesIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
 
-  private val schema = Schema(
-    "",
-    Set(SchemaField("dimension", DimensionFieldType, VARCHAR()), SchemaField("tag", TagFieldType, VARCHAR())))
+  private val schema = Schema("",
+                              Map("dimension" -> SchemaField("dimension", DimensionFieldType, VARCHAR()),
+                                  "tag"       -> SchemaField("tag", TagFieldType, VARCHAR())))
 
   "TimeSeriesIndex" should "write and read properly on disk" in {
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
@@ -34,16 +34,16 @@ class StatementParserSpec extends WordSpec with Matchers {
 
   val schema = Schema(
     "people",
-    Set(
-      SchemaField("timestamp", TimestampFieldType, BIGINT()),
-      SchemaField("value", ValueFieldType, DECIMAL()),
-      SchemaField("name", DimensionFieldType, VARCHAR()),
-      SchemaField("surname", DimensionFieldType, VARCHAR()),
-      SchemaField("amount", DimensionFieldType, DECIMAL()),
-      SchemaField("creationDate", DimensionFieldType, BIGINT()),
-      SchemaField("city", TagFieldType, VARCHAR()),
-      SchemaField("country", TagFieldType, VARCHAR()),
-      SchemaField("age", TagFieldType, INT())
+    Map(
+      "timestamp"    -> SchemaField("timestamp", TimestampFieldType, BIGINT()),
+      "value"        -> SchemaField("value", ValueFieldType, DECIMAL()),
+      "name"         -> SchemaField("name", DimensionFieldType, VARCHAR()),
+      "surname"      -> SchemaField("surname", DimensionFieldType, VARCHAR()),
+      "amount"       -> SchemaField("amount", DimensionFieldType, DECIMAL()),
+      "creationDate" -> SchemaField("creationDate", DimensionFieldType, BIGINT()),
+      "city"         -> SchemaField("city", TagFieldType, VARCHAR()),
+      "country"      -> SchemaField("country", TagFieldType, VARCHAR()),
+      "age"          -> SchemaField("age", TagFieldType, INT())
     )
   )
 

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
@@ -236,8 +236,10 @@ trait CommandApi {
                           ContentTypes.`application/json`,
                           write(
                             DescribeMetricResponse(
-                              schema.fields
-                                .map(field => Field(name = field.name, `type` = field.indexType.getClass.getSimpleName))
+                              schema.fieldsMap.map {
+                                case (_, field) =>
+                                  Field(name = field.name, `type` = field.indexType.getClass.getSimpleName)
+                              }.toSet
                             )
                           )
                         )

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiTest.scala
@@ -46,15 +46,19 @@ object CommandApiTest {
     val schemas = Map(
       "metric1" -> Schema(
         "metric1",
-        Set(SchemaField("dim1", DimensionFieldType, VARCHAR()),
-            SchemaField("dim2", DimensionFieldType, INT()),
-            SchemaField("dim3", DimensionFieldType, BIGINT()))
+        Map(
+          "dim1" -> SchemaField("dim1", DimensionFieldType, VARCHAR()),
+          "dim2" -> SchemaField("dim2", DimensionFieldType, INT()),
+          "dim3" -> SchemaField("dim3", DimensionFieldType, BIGINT())
+        )
       ),
       "metric2" -> Schema(
         "metric2",
-        Set(SchemaField("dim1", DimensionFieldType, VARCHAR()),
-            SchemaField("dim2", DimensionFieldType, INT()),
-            SchemaField("dim3", DimensionFieldType, BIGINT()))
+        Map(
+          "dim1" -> SchemaField("dim1", DimensionFieldType, VARCHAR()),
+          "dim2" -> SchemaField("dim2", DimensionFieldType, INT()),
+          "dim3" -> SchemaField("dim3", DimensionFieldType, BIGINT())
+        )
       )
     )
   }
@@ -131,8 +135,9 @@ class CommandApiTest extends FlatSpec with Matchers with ScalatestRouteTest with
       val entity = entityAs[String]
       entity shouldBe write(
         DescribeMetricResponse(
-          schemas("metric1").fields
-            .map(field => Field(name = field.name, `type` = field.indexType.getClass.getSimpleName))
+          schemas("metric1").fieldsMap.map {
+            case (_, field) => Field(name = field.name, `type` = field.indexType.getClass.getSimpleName)
+          }.toSet
         ))
     }
   }

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
@@ -48,7 +48,7 @@ object QueryApiTest {
           if statement.condition.isDefined && statement.condition.get.expression.isInstanceOf[RangeExpression[Long]] =>
         StatementParser.parseStatement(
           statement,
-          Schema("metric", bits.head).getOrElse(Schema("metric", Set.empty[SchemaField]))) match {
+          Schema("metric", bits.head).getOrElse(Schema("metric", Map.empty[String, SchemaField]))) match {
           case scala.util.Success(_) =>
             val e = statement.condition.get.expression.asInstanceOf[RangeExpression[Long]]
             sender ! SelectStatementExecuted(statement.db,
@@ -60,7 +60,7 @@ object QueryApiTest {
       case ExecuteStatement(statement) =>
         StatementParser.parseStatement(
           statement,
-          Schema("metric", bits.head).getOrElse(Schema("metric", Set.empty[SchemaField]))) match {
+          Schema("metric", bits.head).getOrElse(Schema("metric", Map.empty[String, SchemaField]))) match {
           case scala.util.Success(_) =>
             sender ! SelectStatementExecuted(statement.db, statement.namespace, statement.metric, bits)
           case Failure(_) => sender ! SelectStatementFailed("statement not valid")


### PR DESCRIPTION
This PR has the purpose to implement 2 optimizations:

- a Map has been chosen as the data structure to store schema fields (in order to optimize read accesses)
- The reader and accumulator actors management has been separated in MetricDataActor