### PR TITLE
Round brackets support

### DIFF
--- a/docs/SQL_doc.md
+++ b/docs/SQL_doc.md
@@ -75,7 +75,7 @@ The `WHERE` clause allows to define a boolean condition, based on which data are
 ```sql
 SELECT <dimension_name>[,<dimension_name>, [...]]
 FROM <metric_name>
-WHERE <expression> [(AND|OR) <expression> [...]]
+WHERE [NOT] <expression> [(AND|OR) <expression> [...]]
 ```
 The WHERE clause supports comparisons against VARCHAR, INT, DECIMAL, BIGINT dimensions datatypes.
 
@@ -99,6 +99,25 @@ Supported string operators:
 ```sql
 SELECT dimension FROM metric WHERE string_dimension = myStringValue AND another_string_dimension LIKE startWith$
 ```
+
+#### Logical operators
+Where conditions can be chained using the logical AND and OR operators. A single condition can be negated using the NOT logical operator.
+By default, both AND and OR operators are right associative; in order to overcome this behaviour, round brackets can be used to set a custom associativity.
+The NOT operator si applied to the immediately following condition; round brackets can be also used in this case to apply that operator to a chain of conditions. 
+Examples:
+```sql
+SELECT dimension FROM metric WHERE string_dimension = myStringValue AND another_string_dimension LIKE startWith$ OR a_further_dimension >= 0  
+-- is translated into
+SELECT dimension FROM metric WHERE string_dimension = myStringValue AND (another_string_dimension LIKE startWith$ OR a_further_dimension >= 0)
+```
+
+```sql
+-- NOT is applied only to the like condition
+SELECT dimension FROM metric WHERE string_dimension = myStringValue AND NOT another_string_dimension LIKE startWith$ OR a_further_dimension >= 0
+-- NOT is applied to the whole chain of operators
+SELECT dimension FROM metric WHERE NOT (string_dimension = myStringValue AND another_string_dimension LIKE startWith$ OR a_further_dimension >= 0)
+```
+
 #### LIKE operator
 The `LIKE` operator is used to express `WHERE` conditions in which user have to match part of the complete string value.
 Accordingly to common databases standard the character `$` is used as placeholder.

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/CommandStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/CommandStatementParser.scala
@@ -49,12 +49,12 @@ class CommandStatementParser(db: String) extends RegexParsers {
   private val namespace = """(^[a-zA-Z][a-zA-Z0-9_]*)""".r
   private val metric    = """(^[a-zA-Z][a-zA-Z0-9_]*)""".r
 
-  private def showNamespaces = Show ~ Namespaces ^^ {
-    case _ => ShowNamespaces
+  private def showNamespaces = Show ~ Namespaces ^^ { _ =>
+    ShowNamespaces
   }
 
-  private def useNamespace = Use ~> namespace ^^ {
-    case ns => UseNamespace(ns)
+  private def useNamespace = Use ~> namespace ^^ { ns =>
+    UseNamespace(ns)
   }
 
   private def showMetrics(namespace: Option[String]) = Show ~ Metrics ^^ {

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -37,7 +37,7 @@ import scala.util.parsing.input.CharSequenceReader
   *   DeleteStatement := "delete" "from" literal ("where" expression)?
   *   SelectStatement := "select" "distinct"? selectFields "from" literal ("where" expression)? ("group by" (literal |  digit? timeMeasure))? ("order by" literal ("desc")?)? (limit digit)?
   *   selectFields := "*" | aggregation(literal | "*") | (literal | "*")+
-  *   expression := expression "and" expression | expression "or" expression | "not" expression |
+  *   expression := expression "and" expression | expression "or" expression | "not" expression | "(" expression ")"
   *                 literal "=" literal | literal comparison literal | literal "like" literal |
   *                 literal "in" "(" digit "," digit ")" | literal "is" "not"? "null"
   *   comparison := "=" | ">" | "<" | ">=" | "<="
@@ -154,7 +154,9 @@ final class SQLStatementParser extends RegexParsers with PackratParsers {
 
   // Please don't change the order of the expressions, can cause infinite recursions
   private lazy val expression: PackratParser[Expression] =
-    unaryLogicalExpression | tupledLogicalExpression | nullableExpression | rangeExpression | comparisonExpression | equalityExpression | likeExpression
+    unaryLogicalExpression | tupledLogicalExpression | nullableExpression | rangeExpression | comparisonExpression | equalityExpression | likeExpression | bracketedExpression
+
+  private lazy val bracketedExpression: PackratParser[Expression] = OpenRoundBracket ~> expression <~ CloseRoundBracket
 
   private lazy val unaryLogicalExpression = notUnaryLogicalExpression
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
@@ -25,7 +25,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
 
   private val parser = new SQLStatementParser
 
-  "A parser instance" when {
+  "A SQL parser instance" when {
 
     "receive a select with a group by and one aggregation" should {
       "parse it successfully" in {

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/CommandStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/CommandStatementSpec.scala
@@ -25,7 +25,7 @@ class CommandStatementSpec extends WordSpec with Matchers {
 
   private val parser = new CommandStatementParser("db")
 
-  "A parser instance" when {
+  "A Command parser instance" when {
 
     "receive the request to show the namespaces" should {
       "parse it successfully" in {

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
@@ -25,7 +25,7 @@ class DeleteSQLStatementSpec extends WordSpec with Matchers {
 
   private val parser = new SQLStatementParser
 
-  "A parser instance" when {
+  "A SQL parser instance" when {
 
     "receive a delete without a where condition" should {
       "fail" in {

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/InsertSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/InsertSQLStatementSpec.scala
@@ -25,7 +25,7 @@ class InsertSQLStatementSpec extends WordSpec with Matchers {
 
   private val parser = new SQLStatementParser
 
-  "A parser instance for insert statements" when {
+  "A SQL parser instance for insert statements" when {
 
     "receive an insert with a single dimension without tags" should {
       "parse it successfully" in {

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.sql.parser
+
+import io.radicalbit.nsdb.common.statement._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.util.Success
+
+class SQLStatementBracketsSpec extends WordSpec with Matchers {
+
+  private val parser = new SQLStatementParser
+
+  "A SQL parser instance" when {
+
+    "receive a select containing a range selection inside square brackets" should {
+      "parse it successfully" in {
+        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE (timestamp IN (2,4))") should be(
+          Success(SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 4L)))
+          )))
+      }
+
+      "parse it successfully using decimal values" in {
+        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE (timestamp IN (2, 3.5))") should be(
+          Success(SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 3.5)))
+          )))
+      }
+
+      "parse it successfully using relative time" in {
+        val statement = parser.parse(db = "db",
+                                     namespace = "registry",
+                                     input = "SELECT name FROM people WHERE (timestamp IN (now - 2 s, now + 4 s))")
+        statement.isSuccess shouldBe true
+      }
+    }
+
+    "receive a select containing a = selection" should {
+      "parse it successfully using string" in {
+        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE (timestamp = word_word)") should be(
+          Success(SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(Condition(EqualityExpression(dimension = "timestamp", value = "word_word")))
+          )))
+      }
+
+      "parse it successfully using relative time" in {
+        val statement =
+          parser.parse(db = "db",
+                       namespace = "registry",
+                       input = "SELECT name FROM people WHERE (timestamp = now - 10s)")
+        statement.isSuccess shouldBe true
+      }
+    }
+
+    "receive a select containing a like selection" should {
+      "parse it successfully with predicate containing special characters" in {
+        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE (name like $a_m-e$)") should be(
+          Success(SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_m-e$")))
+          )))
+      }
+    }
+
+    "receive a select containing a GTE selection" should {
+      "parse it successfully" in {
+        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE (timestamp >= 10)") should be(
+          Success(SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(Condition(
+              ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 10L)))
+          )))
+      }
+
+      "parse it successfully using relative time" in {
+        val statement =
+          parser.parse(db = "db",
+                       namespace = "registry",
+                       input = "SELECT name FROM people WHERE (timestamp >= now - 10s)")
+        statement.isSuccess shouldBe true
+      }
+    }
+
+    "receive a select containing a GT AND a = selection" should {
+      "parse it successfully" in {
+        parser.parse(db = "db",
+                     namespace = "registry",
+                     input = "SELECT name FROM people WHERE (timestamp > 2) AND (timestamp = 4)") should be(
+          Success(SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(Condition(TupledLogicalExpression(
+              expression1 = ComparisonExpression(dimension = "timestamp", comparison = GreaterThanOperator, value = 2L),
+              operator = AndOperator,
+              expression2 = EqualityExpression(dimension = "timestamp", value = 4L)
+            )))
+          )))
+      }
+
+      "parse it successfully using relative time" in {
+        val statement = parser.parse(
+          db = "db",
+          namespace = "registry",
+          input =
+            "SELECT name FROM people WHERE timestamp < now + 30d and (timestamp > now - 2h) AND (timestamp = now + 4m)")
+        statement.isSuccess shouldBe true
+      }
+    }
+
+    "receive a select containing a NOT and a OR expression" should {
+      "parse it successfully if not is applied to the or expression" in {
+        parser.parse(db = "db",
+                     namespace = "registry",
+                     input = "SELECT name FROM people WHERE NOT (timestamp >= 2 OR timestamp < 4)") should be(
+          Success(SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(Condition(UnaryLogicalExpression(
+              expression = TupledLogicalExpression(
+                expression1 =
+                  ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+                operator = OrOperator,
+                expression2 = ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = 4L)
+              ),
+              operator = NotOperator
+            )))
+          )))
+      }
+      "parse it successfully if not is applied only to the first expression" in {
+        parser.parse(db = "db",
+                     namespace = "registry",
+                     input = "SELECT name FROM people WHERE (NOT timestamp >= 2) OR (timestamp < 4)") should be(
+          Success(SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(Condition(TupledLogicalExpression(
+              expression1 = UnaryLogicalExpression(
+                ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+                operator = NotOperator),
+              operator = OrOperator,
+              expression2 = ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = 4L)
+            )))
+          )))
+      }
+
+      "receive a select containing a condition of not nullable" in {
+        parser.parse(
+          db = "db",
+          namespace = "registry",
+          input =
+            "select * from AreaOccupancy where (name=MeetingArea) and (name is not null) order by timestamp desc limit 1") shouldBe
+          Success(
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "AreaOccupancy",
+              distinct = false,
+              fields = AllFields,
+              condition = Some(
+                Condition(TupledLogicalExpression(EqualityExpression("name", "MeetingArea"),
+                                                  AndOperator,
+                                                  UnaryLogicalExpression(NullableExpression("name"), NotOperator)))),
+              order = Some(DescOrderOperator(dimension = "timestamp")),
+              limit = Some(LimitOperator(1))
+            ))
+      }
+    }
+
+    "receive a complex select containing 3 conditions a desc ordering statement and a limit statement" should {
+      "parse it successfully when the first 2 expression are in brackets" in {
+        parser.parse(
+          db = "db",
+          namespace = "registry",
+          input =
+            "SELECT name FROM people WHERE (name like $an$ and surname = pippo) and timestamp IN (2,4)  ORDER BY name DESC LIMIT 5"
+        ) should be(
+          Success(SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(Condition(TupledLogicalExpression(
+              expression1 = TupledLogicalExpression(expression1 = LikeExpression("name", "$an$"),
+                                                    operator = AndOperator,
+                                                    expression2 = EqualityExpression("surname", "pippo")),
+              operator = AndOperator,
+              expression2 = RangeExpression("timestamp", 2, 4)
+            ))),
+            order = Some(DescOrderOperator(dimension = "name")),
+            limit = Some(LimitOperator(5))
+          )))
+      }
+
+      "parse it successfully when the last 2 expression are in brackets" in {
+        parser.parse(
+          db = "db",
+          namespace = "registry",
+          input =
+            "SELECT name FROM people WHERE name like $an$ and (surname = pippo and timestamp IN (2,4))  ORDER BY name DESC LIMIT 5"
+        ) should be(
+          Success(SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(
+              Condition(TupledLogicalExpression(LikeExpression("name", "$an$"),
+                                                AndOperator,
+                                                TupledLogicalExpression(EqualityExpression("surname", "pippo"),
+                                                                        AndOperator,
+                                                                        RangeExpression("timestamp", 2, 4))))),
+            order = Some(DescOrderOperator(dimension = "name")),
+            limit = Some(LimitOperator(5))
+          )))
+      }
+
+      "receive a select containing two conditions of not nullable" in {
+        parser.parse(
+          db = "db",
+          namespace = "registry",
+          input =
+            "select * from AreaOccupancy where (name=MeetingArea and name is not null) or floor is not null order by timestamp desc limit 1"
+        ) shouldBe
+          Success(
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "AreaOccupancy",
+              distinct = false,
+              fields = AllFields,
+              condition = Some(
+                Condition(
+                  TupledLogicalExpression(
+                    expression1 =
+                      TupledLogicalExpression(expression1 = EqualityExpression("name", "MeetingArea"),
+                                              operator = AndOperator,
+                                              expression2 =
+                                                UnaryLogicalExpression(NullableExpression("name"), NotOperator)),
+                    operator = OrOperator,
+                    expression2 = UnaryLogicalExpression(NullableExpression("floor"), NotOperator)
+                  )
+                )),
+              order = Some(DescOrderOperator(dimension = "timestamp")),
+              limit = Some(LimitOperator(1))
+            ))
+      }
+    }
+  }
+}

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
@@ -25,7 +25,7 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
 
   private val parser = new SQLStatementParser
 
-  "A parser instance" when {
+  "A SQL parser instance" when {
 
     "receive a select projecting a wildcard" should {
       "parse it successfully" in {


### PR DESCRIPTION
This Pr adds support for round brackets in where conditions; with this feature, it's possible to set custom associativity of a chain of operators

e.g. 

```
SELECT dimension FROM metric WHERE string_dimension = myStringValue AND (another_string_dimension LIKE startWith$ OR a_further_dimension >= 0)

SELECT dimension FROM metric WHERE NOT (string_dimension = myStringValue AND another_string_dimension LIKE startWith$ OR a_further_dimension >= 0)
```

are now valid statements


