### PR TITLE
Commit Log Passivation

### DIFF
--- a/nsdb-cluster/src/main/resources/cluster.conf
+++ b/nsdb-cluster/src/main/resources/cluster.conf
@@ -136,7 +136,7 @@ nsdb {
     directory = "/tmp/nsdb"
     // Size expressed in KB
     max-size = 10000000
-    check-interval = 30 seconds
+    passivate-after = 1h
   }
 
   cluster{

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -62,6 +62,7 @@ object MetadataSpec extends MultiNodeConfig {
     |    writer = "io.radicalbit.nsdb.commit_log.RollingCommitLogFileWriter"
     |    directory = "target/commitLog"
     |    max-size = 50000
+    |    passivate-after = 5s
     |  }
     |}
     """.stripMargin))

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -53,6 +53,7 @@ object ReplicatedMetadataCacheSpec extends MultiNodeConfig {
     |    writer = "io.radicalbit.nsdb.commit_log.RollingCommitLogFileWriter"
     |    directory = "target/commitLog"
     |    max-size = 50000
+    |    passivate-after = 5s
     |  }
     |}
     """.stripMargin))

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCacheSpec.scala
@@ -50,6 +50,7 @@ object ReplicatedSchemaCacheSpec extends MultiNodeConfig {
     |    writer = "io.radicalbit.nsdb.commit_log.RollingCommitLogFileWriter"
     |    directory = "target/commitLog"
     |    max-size = 50000
+    |    passivate-after = 5s
     |  }
     |}
     """.stripMargin))

--- a/nsdb-cluster/src/test/resources/application.conf
+++ b/nsdb-cluster/src/test/resources/application.conf
@@ -36,7 +36,7 @@ nsdb {
     writer = "io.radicalbit.nsdb.commit_log.RollingCommitLogFileWriter"
     directory = "target/commit-logs/"
     max-size = 50000
-    check-interval = 30 seconds
+    passivate-after = 5s
   }
 
   cluster{

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/CommitLogFile.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/CommitLogFile.scala
@@ -55,6 +55,7 @@ object CommitLogFile {
         r = inputStream.read(contents)
       }
 
+      inputStream.close()
       (pending.toList, closedEntries.toList)
     }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/CommitLogWriterActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/CommitLogWriterActor.scala
@@ -171,7 +171,7 @@ trait CommitLogWriterActor extends ActorPathLogging {
 
   def receive: Receive = {
 
-    case _ @WriteToCommitLog(db, namespace, metric, timestamp, bitEntryAction: ReceivedEntryAction, location) =>
+    case WriteToCommitLog(db, namespace, metric, timestamp, bitEntryAction: ReceivedEntryAction, location) =>
       createEntry(
         ReceivedEntry(db,
                       namespace,
@@ -184,7 +184,7 @@ trait CommitLogWriterActor extends ActorPathLogging {
           sender() ! WriteToCommitLogFailed(db, namespace, timestamp, metric, ex.getMessage)
       }
 
-    case _ @WriteToCommitLog(db, namespace, metric, timestamp, bitEntryAction: AccumulatedEntryAction, location) =>
+    case WriteToCommitLog(db, namespace, metric, timestamp, bitEntryAction: AccumulatedEntryAction, location) =>
       createEntry(
         AccumulatedEntry(db,
                          namespace,
@@ -196,7 +196,7 @@ trait CommitLogWriterActor extends ActorPathLogging {
         case Failure(ex) =>
           sender() ! WriteToCommitLogFailed(db, namespace, timestamp, metric, ex.getMessage)
       }
-    case _ @WriteToCommitLog(db, namespace, metric, timestamp, bitEntryAction: PersistedEntryAction, location) =>
+    case WriteToCommitLog(db, namespace, metric, timestamp, bitEntryAction: PersistedEntryAction, location) =>
       createEntry(
         PersistedEntry(db,
                        namespace,
@@ -208,7 +208,7 @@ trait CommitLogWriterActor extends ActorPathLogging {
         case Failure(ex) =>
           sender() ! WriteToCommitLogFailed(db, namespace, timestamp, metric, ex.getMessage)
       }
-    case _ @WriteToCommitLog(db, namespace, metric, timestamp, bitEntryAction: RejectedEntryAction, location) =>
+    case WriteToCommitLog(db, namespace, metric, timestamp, bitEntryAction: RejectedEntryAction, location) =>
       createEntry(
         RejectedEntry(db,
                       namespace,
@@ -231,13 +231,13 @@ trait CommitLogWriterActor extends ActorPathLogging {
         case Failure(ex) =>
           sender() ! WriteToCommitLogFailed(db, namespace, timestamp, metric, ex.getMessage)
       }
-    case _ @WriteToCommitLog(db, namespace, metric, timestamp, DeleteMetricAction, location) =>
+    case WriteToCommitLog(db, namespace, metric, timestamp, DeleteMetricAction, location) =>
       createEntry(DeleteMetricEntry(db, namespace, metric, timestamp)) match {
         case Success(_) => sender() ! WriteToCommitLogSucceeded(db, namespace, timestamp, metric, location)
         case Failure(ex) =>
           sender() ! WriteToCommitLogFailed(db, namespace, timestamp, metric, ex.getMessage)
       }
-    case _ @WriteToCommitLog(db, namespace, _, timestamp, DeleteNamespaceAction, location) =>
+    case WriteToCommitLog(db, namespace, _, timestamp, DeleteNamespaceAction, location) =>
       createEntry(DeleteNamespaceEntry(db, namespace, timestamp)) match {
         case Success(_) => sender() ! WriteToCommitLogSucceeded(db, namespace, timestamp, "", location)
         case Failure(ex) =>

--- a/nsdb-core/src/test/resources/application.conf
+++ b/nsdb-core/src/test/resources/application.conf
@@ -41,7 +41,7 @@ nsdb{
     writer = "io.radicalbit.nsdb.commit_log.RollingCommitLogFileWriter"
     directory = "target/commit_log"
     max-size = 50000
-    check-interval = 5 seconds
+    passivate-after = 6s
   }
 
   read-coordinator.timeout = 10 seconds

--- a/nsdb-it/src/test/resources/minicluster.conf
+++ b/nsdb-it/src/test/resources/minicluster.conf
@@ -137,7 +137,7 @@ nsdb {
     writer = "io.radicalbit.nsdb.commit_log.RollingCommitLogFileWriter"
     directory = "/tmp/"
     max-size = 50000
-    check-interval = 30 seconds
+    passivate-after = 1h
   }
 
   cluster{


### PR DESCRIPTION
This Pr extends the feature of passivation already implemented for shards to the commit log.

If a commit log actor did not receive any message for a configurable period, it will be passivated.

This mechanism has the purpose to optimize resource usages.