### PR TITLE
[BUGFIX] fix temporal queries on empty intervals and for limit

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -239,10 +239,12 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
                   val sortedLocations = filteredLocations.sortBy(_.from)
 
                   val globalRanges: Seq[TimeRange] =
-                    TimeRangeManager.computeRangesForIntervalAndCondition(sortedLocations.last.to,
-                                                                          sortedLocations.head.from,
-                                                                          rangeLength,
-                                                                          condition)
+                    if (sortedLocations.isEmpty) Seq.empty
+                    else
+                      TimeRangeManager.computeRangesForIntervalAndCondition(sortedLocations.last.to,
+                                                                            sortedLocations.head.from,
+                                                                            rangeLength,
+                                                                            condition)
 
                   gatherNodeResults(statement, schema, uniqueLocationsByNode, globalRanges) { res =>
                     res

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
@@ -177,6 +177,67 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
 
       }
 
+      "execute it successfully when no shard has picked up" in within(5.seconds) {
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalLongMetric.name,
+                distinct = false,
+                condition = Some(
+                  Condition(ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterOrEqualToOperator,
+                                                 value = 200000L))),
+                fields = ListFields(List(Field("*", Some(CountAggregation)))),
+                groupBy = Some(TemporalGroupByAggregation(30000)),
+                limit = Some(LimitOperator(2))
+              )
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values.size shouldBe 0
+      }
+
+      "execute it successfully when only one shard has picked up" in within(5.seconds) {
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalLongMetric.name,
+                distinct = false,
+                condition = Some(
+                  Condition(ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterOrEqualToOperator,
+                                                 value = 100000L))),
+                fields = ListFields(List(Field("*", Some(CountAggregation)))),
+                groupBy = Some(TemporalGroupByAggregation(30000)),
+                limit = Some(LimitOperator(2))
+              )
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values.size shouldBe 2
+
+        expected.values shouldBe Seq(
+          Bit(130000, 1, Map("lowerBound" -> 130000, "upperBound" -> 160000), Map()),
+          Bit(160000, 0, Map("lowerBound" -> 160000, "upperBound" -> 190000), Map())
+        )
+      }
+
       "execute it successfully with limit" in within(5.seconds) {
 
         val expected = awaitAssert {

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/CommitLogFile.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/CommitLogFile.scala
@@ -50,6 +50,7 @@ object CommitLogFile {
           case Some(e: AccumulatedEntry) => if (!pending.contains(e.id)) pending += e.id
           case Some(e: PersistedEntry)   => if (!closedEntries.contains(e.id)) closedEntries += e.id
           case Some(e: RejectedEntry)    => if (!closedEntries.contains(e.id)) closedEntries += e.id
+          case Some(_)                   =>
           case None                      =>
         }
         r = inputStream.read(contents)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/RollingCommitLogFileWriter.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/RollingCommitLogFileWriter.scala
@@ -171,6 +171,10 @@ class RollingCommitLogFileWriter(db: String, namespace: String, metric: String) 
 
   override def receive: Receive = super.receive orElse {
     case ReceiveTimeout =>
+      context.child(childName).foreach {
+        log.debug(s"Sending commit log check for actual file before passivating : ${file.getName}")
+        _ ! CheckFiles(file)
+      }
       self ! PoisonPill
     case ForceRolling =>
       val f = newFile(file)

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
@@ -181,7 +181,7 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
               expression2 = EqualityExpression(dimension = "name", value = "john")
             )
           )) shouldBe List(
-          Interval.fromBounds(Closed(2l), Unbound())
+          Interval.fromBounds(Closed(2L), Unbound())
         )
       }
     }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
@@ -259,6 +259,21 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
       }
     }
 
+    "receive a select with a temporal group by with count aggregation with a limit" in {
+      parser.parse(db = "db",
+                   namespace = "registry",
+                   input = "select count(value) from people group by interval 1d limit 1") should be(
+        Success(SelectSQLStatement(
+          db = "db",
+          namespace = "registry",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("value", Some(CountAggregation)))),
+          groupBy = Some(TemporalGroupByAggregation(86400000)),
+          limit = Some(LimitOperator(1))
+        )))
+    }
+
     "receive a select with a temporal group by, filtered by time with measure" should {
       "parse it successfully if the interval contains a space" in {
         parser.parse(


### PR DESCRIPTION
This PR will fix the following bugs
- if the calculated ranges for a temporal group by are null. The query fails
- There is a syntactical  ambiguity in SQL parser for temporal group by with a limit