### PR TITLE
Streaming Flow Optimized

### DIFF
--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
@@ -60,8 +60,6 @@ case class NsdbQuery(uuid: String, query: SelectSQLStatement) {
   *
   * - [[SubscribeBySqlStatement]] the subscription is asked providing a query string, which is parsed into [[SelectSQLStatement]]. If the query does not exist, a new one will be created and registered.
   *
-  * - [[SubscribeByQueryId]] the subscription is asked providing a query id, which have already been registered.
-  *
   * A generic publisher must send a [[PublishRecord]] message in order to trigger the publishing mechanism.
   * Every published event will be checked against every registered query. If the event fulfills the query, it will be published to every query relatedsubscriber.
   * @param readCoordinator global read coordinator responsible to execute queries when needed

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
@@ -78,7 +78,7 @@ trait WsResources {
       Flow[Message]
         .map {
           case TextMessage.Strict(text) =>
-            parse(text).extractOpt[RegisterQuery] getOrElse "Message not handled by receiver"
+            parse(text).extractOpt[RegisterQuery] getOrElse s"Message $text not handled by receiver"
           case _ => "Message not handled by receiver"
         }
         .to(Sink.actorRef(connectedWsActor, Terminate))

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
@@ -75,8 +75,7 @@ trait WsResources {
       Flow[Message]
         .map {
           case TextMessage.Strict(text) =>
-            parse(text).extractOpt[RegisterQuery] orElse
-              parse(text).extractOpt[RegisterQuid] getOrElse "Message not handled by receiver"
+            parse(text).extractOpt[RegisterQuery] getOrElse "Message not handled by receiver"
           case _ => "Message not handled by receiver"
         }
         .to(Sink.actorRef(connectedWsActor, Terminate))

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiTest.scala
@@ -17,18 +17,15 @@
 package io.radicalbit.nsdb.web
 
 import akka.actor.{Actor, ActorRef, Props}
+import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.util.Timeout
-import io.radicalbit.nsdb.index._
-import io.radicalbit.nsdb.model.{Schema, SchemaField}
-import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
-import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
-import akka.http.scaladsl.model.StatusCodes._
 import io.radicalbit.nsdb.actor.FakeReadCoordinator
 import io.radicalbit.nsdb.common.model.MetricInfo
-import io.radicalbit.nsdb.common.protocol.DimensionFieldType
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.security.http.NSDBAuthProvider
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes.CommandApi
@@ -62,8 +59,8 @@ object CommandApiTest {
 
 class CommandApiTest extends FlatSpec with Matchers with ScalatestRouteTest with CommandApi {
 
-  import io.radicalbit.nsdb.web.CommandApiTest._
   import FakeReadCoordinator.Data._
+  import io.radicalbit.nsdb.web.CommandApiTest._
 
   override def readCoordinator: ActorRef = system.actorOf(Props[FakeReadCoordinator])
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/WebSocketSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/WebSocketSpec.scala
@@ -21,7 +21,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.testkit.{ScalatestRouteTest, WSProbe}
 import io.radicalbit.nsdb.actors.PublisherActor
-import io.radicalbit.nsdb.actors.PublisherActor.Events.{SubscribedByQueryString, SubscribedByQuid}
+import io.radicalbit.nsdb.actors.PublisherActor.Events.SubscribedByQueryString
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.ExecuteStatement
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.SelectStatementExecuted
 import io.radicalbit.nsdb.security.http.EmptyAuthorization
@@ -78,32 +78,6 @@ class WebSocketSpec() extends FlatSpec with ScalatestRouteTest with Matchers wit
 
         val subscribed = wsClient.expectMessage().asTextMessage.getStrictText
         parse(subscribed).extractOpt[SubscribedByQueryString].isDefined shouldBe true
-
-        //TODO find out how to test combining somehow the actorsystem coming from ScalatestRouteTest and from Testkit
-      }
-  }
-
-  "WebSocketStream" should "register to a queryID" in {
-
-    val wsClient = WSProbe()
-
-    WS("/ws-stream", wsClient.flow) ~> wsStandardResources ~>
-      check {
-
-        isWebSocketUpgrade shouldEqual true
-
-        wsClient.sendMessage(
-          """{"db":"db","namespace":"registry","metric":"people","queryString":"select * from people limit 1"}""")
-
-        val subscribed = wsClient.expectMessage().asTextMessage.getStrictText
-        parse(subscribed).extractOpt[SubscribedByQueryString].isDefined shouldBe true
-        val response = parse(subscribed).extractOpt[SubscribedByQueryString].get
-
-        wsClient.sendMessage(
-          s"""{"db":"db","namespace":"registry","metric":"people","quid":"${response.quid}"} """
-        )
-        val subscribedQId = wsClient.expectMessage().asTextMessage.getStrictText
-        parse(subscribedQId).extractOpt[SubscribedByQuid].isDefined shouldBe true
 
         //TODO find out how to test combining somehow the actorsystem coming from ScalatestRouteTest and from Testkit
       }

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/cluster/PublishSubscribeClusterSpec.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/cluster/PublishSubscribeClusterSpec.scala
@@ -82,18 +82,13 @@ class PublishSubscribeClusterSpec extends MiniClusterSpec {
     firstNodeWsClient.subscribe("db", "namespace", "metric1")
     //subscription phase
     val firstSubscriptionBuffer = eventually {
-
       val firstSubscriptionBuffer = firstNodeWsClient.receivedBuffer()
-
       assert(firstSubscriptionBuffer.length == 1)
-
       firstSubscriptionBuffer
     }
 
     val firstSubscriptionResponse =
       parse(firstSubscriptionBuffer.head.asTextMessage.getStrictText)
-
-    logger.error(s"received $firstSubscriptionResponse")
 
     assert((firstSubscriptionResponse \ "records").extract[JArray].arr.size == 1)
 

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/ws/SynchronizedBuffer.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/ws/SynchronizedBuffer.scala
@@ -30,12 +30,12 @@ trait SynchronizedBuffer[T] {
   /**
     * Remove all the elements from the buffer.
     */
-  def clearBuffer(): Boolean = _buffer.compareAndSet(_buffer.get(), ListBuffer.empty)
+  def clearBuffer(): Unit = _buffer.set(ListBuffer.empty)
 
   /**
     * @return the buffer state.
     */
-  def buffer: ListBuffer[T] = _buffer.get()
+  protected def buffer: ListBuffer[T] = _buffer.get()
 
   /**
     * Generic method to update the buffer given a transformation function


### PR DESCRIPTION
This PR aims to apply a few small optimizations to the streaming flow.
In particular:
* remove the unused subscribe by query id operation
* use a queue instead of a map for buffering events to publish (map's capabilities are no longer needed)
* avoid message transfer from WriteCoordinator to PublisherActor during replica write 