### PR TITLE
Use Web-socket subprotocol for custom headers passing

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
@@ -35,7 +35,7 @@ class NsdbNodeEndpoint(readCoordinator: ActorRef,
 
   override val config: Config = system.settings.config
 
-  override protected implicit val logger: LoggingAdapter = Logging.getLogger(system, this)
+  override implicit val logger: LoggingAdapter = Logging.getLogger(system, this)
 
   new GrpcEndpoint(readCoordinator = readCoordinator,
                    writeCoordinator = writeCoordinator,

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/WebSocketSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/WebSocketSpec.scala
@@ -17,7 +17,8 @@
 package io.radicalbit.nsdb.web
 
 import akka.actor.{Actor, Props}
-import akka.http.scaladsl.model.StatusCodes
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.{HttpProtocol, StatusCodes}
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.testkit.{ScalatestRouteTest, WSProbe}
 import io.radicalbit.nsdb.actors.PublisherActor
@@ -43,6 +44,8 @@ class FakeReadCoordinatorActor extends Actor {
 }
 
 class WebSocketSpec() extends FlatSpec with ScalatestRouteTest with Matchers with WsResources {
+
+  override def logger: LoggingAdapter = system.log
 
   implicit val formats = DefaultFormats
 
@@ -155,10 +158,7 @@ class WebSocketSpec() extends FlatSpec with ScalatestRouteTest with Matchers wit
 
     val wsClient = WSProbe()
 
-    val wsHeader = WS("/ws-stream", wsClient.flow).headers.head
-
-    WS("/ws-stream", wsClient.flow)
-      .withHeaders(wsHeader, RawHeader("testHeader", "testHeader")) ~> wsSecureResources ~>
+    WS("/ws-stream", wsClient.flow, Seq("testHeader")) ~> wsSecureResources ~>
       check {
         isWebSocketUpgrade shouldEqual true
 
@@ -217,5 +217,4 @@ class WebSocketSpec() extends FlatSpec with ScalatestRouteTest with Matchers wit
         response.status shouldBe StatusCodes.BadRequest
       }
   }
-
 }

--- a/nsdb-security/src/main/scala/io/radicalbit/nsdb/security/Security.scala
+++ b/nsdb-security/src/main/scala/io/radicalbit/nsdb/security/Security.scala
@@ -30,7 +30,7 @@ trait NsdbSecurity {
 
   def config: Config
 
-  protected def logger: LoggingAdapter
+  def logger: LoggingAdapter
 
   /**
     * configuration key to set if security is enabled or not.


### PR DESCRIPTION
This PR allows receiving custom headers (e.g. for security purposes) in a WebSocket request passed as a subprotocols.

More information can be found [here](https://hpbn.co/websocket/#subprotocol-negotiation)

Even if this might be a non-pure and not clean solution, it is the more pragmatic and effective way to pass custom headers in a ws request (afaik the only valid mechanism)