### PR TITLE
Add fields to objects returned by SQLStatementParser

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -528,8 +528,10 @@ object MetadataCoordinator {
       db = db,
       namespace = namespace,
       metric = metric,
-      condition =
-        Condition(ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = threshold))
+      condition = Condition(
+        ComparisonExpression(dimension = "timestamp",
+                             comparison = LessThanOperator,
+                             value = AbsoluteComparisonValue(threshold)))
     )
 
   object commands {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/CommitLogCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/CommitLogCoordinatorSpec.scala
@@ -23,7 +23,7 @@ import akka.testkit.{ImplicitSender, TestKit}
 import com.typesafe.config.ConfigFactory
 import io.radicalbit.nsdb.commit_log.CommitLogWriterActor._
 import io.radicalbit.nsdb.common.protocol.Bit
-import io.radicalbit.nsdb.common.statement.{Condition, DeleteSQLStatement, RangeExpression}
+import io.radicalbit.nsdb.common.statement.{AbsoluteComparisonValue, Condition, DeleteSQLStatement, RangeExpression}
 import io.radicalbit.nsdb.model.Location
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
@@ -78,7 +78,10 @@ class CommitLogCoordinatorSpec
     }
     "write a delete by query" in within(5.seconds) {
       val deleteStatement =
-        DeleteSQLStatement("db2", "namespace2", "metric2", Condition(RangeExpression("age", 1L, 2L)))
+        DeleteSQLStatement("db2",
+                           "namespace2",
+                           "metric2",
+                           Condition(RangeExpression("age", AbsoluteComparisonValue(1L), AbsoluteComparisonValue(2L))))
       awaitAssert {
         commitLogCoordinatorActor ! WriteToCommitLog("db2",
                                                      "namespace2",

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorAggregatedStatementsSpec.scala
@@ -38,8 +38,10 @@ class ReadCoordinatorAggregatedStatementsSpec extends AbstractReadCoordinatorSpe
               metric = LongMetric.name,
               distinct = false,
               fields = ListFields(List(Field("value", Some(SumAggregation)))),
-              condition = Some(Condition(
-                ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L))),
+              condition = Some(
+                Condition(ComparisonExpression(dimension = "timestamp",
+                                               comparison = GreaterOrEqualToOperator,
+                                               value = AbsoluteComparisonValue(2L)))),
               groupBy = Some(SimpleGroupByAggregation("name"))
             )
           )
@@ -63,8 +65,10 @@ class ReadCoordinatorAggregatedStatementsSpec extends AbstractReadCoordinatorSpe
               metric = LongMetric.name,
               distinct = false,
               fields = ListFields(List(Field("creationDate", None))),
-              condition = Some(Condition(
-                ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L))),
+              condition = Some(
+                Condition(ComparisonExpression(dimension = "timestamp",
+                                               comparison = GreaterOrEqualToOperator,
+                                               value = AbsoluteComparisonValue(2L)))),
               groupBy = Some(SimpleGroupByAggregation("name"))
             )
           )

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSimpleStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSimpleStatementsSpec.scala
@@ -581,7 +581,10 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
               metric = LongMetric.name,
               distinct = false,
               fields = ListFields(List(Field("name", None))),
-              condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 4L))),
+              condition = Some(
+                Condition(RangeExpression(dimension = "timestamp",
+                                          value1 = AbsoluteComparisonValue(2L),
+                                          value2 = AbsoluteComparisonValue(4L)))),
               limit = Some(LimitOperator(4))
             )
           )
@@ -604,8 +607,10 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
               metric = LongMetric.name,
               distinct = false,
               fields = ListFields(List(Field("name", None))),
-              condition = Some(Condition(
-                ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 10L))),
+              condition = Some(
+                Condition(ComparisonExpression(dimension = "timestamp",
+                                               comparison = GreaterOrEqualToOperator,
+                                               value = AbsoluteComparisonValue(10L)))),
               limit = Some(LimitOperator(4))
             )
           )
@@ -634,7 +639,9 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
               condition = Some(
                 Condition(
                   UnaryLogicalExpression(
-                    ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 10L),
+                    ComparisonExpression(dimension = "timestamp",
+                                         comparison = GreaterOrEqualToOperator,
+                                         value = AbsoluteComparisonValue(10L)),
                     NotOperator
                   ))),
               limit = Some(LimitOperator(6))
@@ -662,11 +669,13 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
               distinct = false,
               fields = ListFields(List(Field("name", None))),
               condition = Some(Condition(TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression(dimension = "timestamp", comparison = GreaterThanOperator, value = 2L),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterThanOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
                 operator = AndOperator,
-                expression2 =
-                  ComparisonExpression(dimension = "timestamp", comparison = LessOrEqualToOperator, value = 4l)
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(4L))
               ))),
               limit = Some(LimitOperator(4))
             )
@@ -692,10 +701,13 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
               distinct = false,
               fields = ListFields(List(Field("name", None))),
               condition = Some(Condition(expression = TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
                 operator = OrOperator,
-                expression2 = ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = 4L)
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessThanOperator,
+                                                   value = AbsoluteComparisonValue(4L))
               ))),
               limit = Some(LimitOperator(6))
             )
@@ -720,7 +732,8 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
               metric = LongMetric.name,
               distinct = false,
               fields = ListFields(List(Field("name", None))),
-              condition = Some(Condition(EqualityExpression(dimension = "timestamp", value = 2L))),
+              condition =
+                Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(2L)))),
               limit = Some(LimitOperator(4))
             )
           )
@@ -745,10 +758,11 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
               distinct = false,
               fields = ListFields(List(Field("name", None))),
               condition = Some(Condition(expression = TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
                 operator = AndOperator,
-                expression2 = EqualityExpression(dimension = "name", value = "John")
+                expression2 = EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("John"))
               ))),
               limit = Some(LimitOperator(6))
             )

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
@@ -191,7 +191,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 condition = Some(
                   Condition(ComparisonExpression(dimension = "timestamp",
                                                  comparison = GreaterOrEqualToOperator,
-                                                 value = 200000L))),
+                                                 value = AbsoluteComparisonValue(200000L)))),
                 fields = ListFields(List(Field("*", Some(CountAggregation)))),
                 groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
                 limit = Some(LimitOperator(2))
@@ -219,7 +219,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 condition = Some(
                   Condition(ComparisonExpression(dimension = "timestamp",
                                                  comparison = GreaterOrEqualToOperator,
-                                                 value = 100000L))),
+                                                 value = AbsoluteComparisonValue(100000L)))),
                 fields = ListFields(List(Field("*", Some(CountAggregation)))),
                 groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
                 limit = Some(LimitOperator(2))
@@ -384,7 +384,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 condition = Some(
                   Condition(ComparisonExpression(dimension = "timestamp",
                                                  comparison = GreaterOrEqualToOperator,
-                                                 value = 60000L))),
+                                                 value = AbsoluteComparisonValue(60000L)))),
                 groupBy = Some(TemporalGroupByAggregation(30000L, 30, "s"))
               )
             )
@@ -416,8 +416,10 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalLongMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("value", Some(CountAggregation)))),
-                condition = Some(Condition(
-                  ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = 60000L))),
+                condition = Some(
+                  Condition(ComparisonExpression(dimension = "timestamp",
+                                                 comparison = LessThanOperator,
+                                                 value = AbsoluteComparisonValue(60000L)))),
                 groupBy = Some(TemporalGroupByAggregation(30000L, 30, "s"))
               )
             )
@@ -480,7 +482,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 condition = Some(
                   Condition(ComparisonExpression(dimension = "timestamp",
                                                  comparison = GreaterOrEqualToOperator,
-                                                 value = 60000L))),
+                                                 value = AbsoluteComparisonValue(60000L)))),
                 groupBy = Some(TemporalGroupByAggregation(100000L, 100, "s"))
               )
             )

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
@@ -155,7 +155,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalLongMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("*", Some(CountAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(30000))
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s"))
               )
             )
           )
@@ -193,7 +193,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                                                  comparison = GreaterOrEqualToOperator,
                                                  value = 200000L))),
                 fields = ListFields(List(Field("*", Some(CountAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(30000)),
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
                 limit = Some(LimitOperator(2))
               )
             )
@@ -221,7 +221,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                                                  comparison = GreaterOrEqualToOperator,
                                                  value = 100000L))),
                 fields = ListFields(List(Field("*", Some(CountAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(30000)),
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
                 limit = Some(LimitOperator(2))
               )
             )
@@ -251,7 +251,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalLongMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("*", Some(CountAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(30000)),
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
                 limit = Some(LimitOperator(2))
               )
             )
@@ -280,7 +280,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalLongMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("value", Some(CountAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(60000))
+                groupBy = Some(TemporalGroupByAggregation(60000, 60, "s"))
               )
             )
           )
@@ -314,7 +314,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalDoubleMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("*", Some(CountAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(30000))
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s"))
               )
             )
           )
@@ -348,7 +348,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalDoubleMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("value", Some(CountAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(60000))
+                groupBy = Some(TemporalGroupByAggregation(60000, 60, "s"))
               )
             )
           )
@@ -385,7 +385,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                   Condition(ComparisonExpression(dimension = "timestamp",
                                                  comparison = GreaterOrEqualToOperator,
                                                  value = 60000L))),
-                groupBy = Some(TemporalGroupByAggregation(30000L))
+                groupBy = Some(TemporalGroupByAggregation(30000L, 30, "s"))
               )
             )
           )
@@ -418,7 +418,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 fields = ListFields(List(Field("value", Some(CountAggregation)))),
                 condition = Some(Condition(
                   ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = 60000L))),
-                groupBy = Some(TemporalGroupByAggregation(30000L))
+                groupBy = Some(TemporalGroupByAggregation(30000L, 30, "s"))
               )
             )
           )
@@ -449,7 +449,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 distinct = false,
                 fields = ListFields(List(Field("value", Some(CountAggregation)))),
                 condition = None,
-                groupBy = Some(TemporalGroupByAggregation(100000L))
+                groupBy = Some(TemporalGroupByAggregation(100000L, 100, "s"))
               )
             )
           )
@@ -481,7 +481,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                   Condition(ComparisonExpression(dimension = "timestamp",
                                                  comparison = GreaterOrEqualToOperator,
                                                  value = 60000L))),
-                groupBy = Some(TemporalGroupByAggregation(100000L))
+                groupBy = Some(TemporalGroupByAggregation(100000L, 100, "s"))
               )
             )
           )
@@ -512,7 +512,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalLongMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("*", Some(SumAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(30000))
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s"))
               )
             )
           )
@@ -546,7 +546,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalLongMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("value", Some(SumAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(60000))
+                groupBy = Some(TemporalGroupByAggregation(60000, 60, "s"))
               )
             )
           )
@@ -580,7 +580,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalDoubleMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("*", Some(SumAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(30000))
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s"))
               )
             )
           )
@@ -614,7 +614,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalDoubleMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("value", Some(SumAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(60000))
+                groupBy = Some(TemporalGroupByAggregation(60000, 60, "s"))
               )
             )
           )
@@ -648,7 +648,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalLongMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("*", Some(MaxAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(30000))
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s"))
               )
             )
           )
@@ -682,7 +682,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalLongMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("value", Some(MaxAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(60000))
+                groupBy = Some(TemporalGroupByAggregation(60000, 60, "s"))
               )
             )
           )
@@ -716,7 +716,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalDoubleMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("*", Some(MaxAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(30000))
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s"))
               )
             )
           )
@@ -750,7 +750,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalDoubleMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("value", Some(MaxAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(60000))
+                groupBy = Some(TemporalGroupByAggregation(60000, 60, "s"))
               )
             )
           )
@@ -784,7 +784,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalLongMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("*", Some(MinAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(30000))
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s"))
               )
             )
           )
@@ -818,7 +818,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalLongMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("value", Some(MinAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(60000))
+                groupBy = Some(TemporalGroupByAggregation(60000, 60, "s"))
               )
             )
           )
@@ -852,7 +852,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalDoubleMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("*", Some(MinAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(30000))
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s"))
               )
             )
           )
@@ -886,7 +886,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
                 metric = TemporalDoubleMetric.name,
                 distinct = false,
                 fields = ListFields(List(Field("value", Some(MinAggregation)))),
-                groupBy = Some(TemporalGroupByAggregation(60000))
+                groupBy = Some(TemporalGroupByAggregation(60000, 60, "s"))
               )
             )
           )

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -127,7 +127,10 @@ trait WriteCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers 
         distinct = false,
         fields = AllFields,
         condition = Some(
-          Condition(ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 10L))),
+          Condition(
+            ComparisonExpression(dimension = "timestamp",
+                                 comparison = GreaterOrEqualToOperator,
+                                 value = AbsoluteComparisonValue(10L)))),
         limit = Some(LimitOperator(4))
       )
 
@@ -197,7 +200,10 @@ trait WriteCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers 
             db = db,
             namespace = "testDelete",
             metric = "testMetric",
-            condition = Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 4L))
+            condition = Condition(
+              RangeExpression(dimension = "timestamp",
+                              value1 = AbsoluteComparisonValue(2L),
+                              value2 = AbsoluteComparisonValue(4L)))
           )
         )
       )

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -147,6 +147,17 @@ case class DescOrderOperator(override val dimension: String) extends OrderOperat
   */
 case class LimitOperator(value: Int)
 
+// Timestamp
+sealed trait TimestampValue {
+  def timestamp: Long
+}
+
+case class AbsoluteTimestampValue(override val timestamp: Long) extends TimestampValue
+case class RelativeTimestampValue(override val timestamp: Long, quantity: Long, unitMeasure: String)
+    extends TimestampValue
+
+// Timestamp
+
 sealed trait GroupByAggregation {
   def dimension: String
 }

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -153,7 +153,7 @@ sealed trait TimestampValue {
 }
 
 case class AbsoluteTimestampValue(override val timestamp: Long) extends TimestampValue
-case class RelativeTimestampValue(override val timestamp: Long, quantity: Long, unitMeasure: String)
+case class RelativeTimestampValue(override val timestamp: Long, operator: String, quantity: Long, unitMeasure: String)
     extends TimestampValue
 
 // Timestamp

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -153,8 +153,16 @@ case class LimitOperator(value: Int)
 sealed trait TimestampValue {
   def timestamp: Long
 }
+// consider if have to change all the timestamp (now are Long) to AbsoluteTimestampValue
+// case class AbsoluteTimestampValue(override val timestamp: Long) extends TimestampValue
 
-case class AbsoluteTimestampValue(override val timestamp: Long) extends TimestampValue
+/**
+  * Class that represent a relative timestamp.
+  * @param timestamp the absolute timestamp
+  * @param operator the operator of the now (plus or minus)
+  * @param quantity the quantity of the relative time
+  * @param unitMeasure the unit measure of the relative time (s, m, h, d)
+  */
 case class RelativeTimestampValue(override val timestamp: Long, operator: String, quantity: Long, unitMeasure: String)
     extends TimestampValue
 

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -147,7 +147,9 @@ case class DescOrderOperator(override val dimension: String) extends OrderOperat
   */
 case class LimitOperator(value: Int)
 
-// Timestamp
+/**
+  * Timestamp to wrap timestamp value for tracking relative timestamp
+  */
 sealed trait TimestampValue {
   def timestamp: Long
 }
@@ -155,8 +157,6 @@ sealed trait TimestampValue {
 case class AbsoluteTimestampValue(override val timestamp: Long) extends TimestampValue
 case class RelativeTimestampValue(override val timestamp: Long, operator: String, quantity: Long, unitMeasure: String)
     extends TimestampValue
-
-// Timestamp
 
 sealed trait GroupByAggregation {
   def dimension: String
@@ -171,8 +171,10 @@ case class SimpleGroupByAggregation(dimension: String) extends GroupByAggregatio
 /**
   * Temporal aggregation.
   * @param interval The time aggregation interval in Milliseconds.
+  * @param quantity The quantity for unitMeasure
+  * @param unitMeasure identifier for time measure (s, m, h, d)
   */
-case class TemporalGroupByAggregation(interval: Long) extends GroupByAggregation {
+case class TemporalGroupByAggregation(interval: Long, quantity: Long, unitMeasure: String) extends GroupByAggregation {
   override val dimension: String = "timestamp"
 }
 

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -164,7 +164,7 @@ object ComparisonValue {
   * Class that represent an absolute comparison value
   * @param value the absolute value
   */
-case class AbsoluteComparisonValue[T](override val value: T) extends ComparisonValue[T]
+final case class AbsoluteComparisonValue[T](override val value: T) extends ComparisonValue[T]
 
 /**
   * Class that represent a relative comparison value.
@@ -173,7 +173,7 @@ case class AbsoluteComparisonValue[T](override val value: T) extends ComparisonV
   * @param quantity the quantity of the relative time
   * @param unitMeasure the unit measure of the relative time (s, m, h, d)
   */
-case class RelativeComparisonValue[T](override val value: T, operator: String, quantity: T, unitMeasure: String)
+final case class RelativeComparisonValue[T](override val value: T, operator: String, quantity: T, unitMeasure: String)
     extends ComparisonValue[T]
 
 sealed trait GroupByAggregation {

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -24,7 +24,7 @@ import io.radicalbit.nsdb.common.JSerializable
   * @param name field's name.
   * @param aggregation if there is an aggregation for the field (sum, count ecc.).
   */
-case class Field(name: String, aggregation: Option[Aggregation])
+final case class Field(name: String, aggregation: Option[Aggregation])
 
 /**
   * Parsed select fields objects.
@@ -32,11 +32,11 @@ case class Field(name: String, aggregation: Option[Aggregation])
   * [[ListFields]] if a list of fields are specified in the query.
   */
 sealed trait SelectedFields
-case object AllFields                      extends SelectedFields
-case class ListFields(fields: List[Field]) extends SelectedFields
+case object AllFields                            extends SelectedFields
+final case class ListFields(fields: List[Field]) extends SelectedFields
 
-case class ListAssignment(fields: Map[String, JSerializable])
-case class Condition(expression: Expression)
+final case class ListAssignment(fields: Map[String, JSerializable])
+final case class Condition(expression: Expression)
 
 /**
   * Where condition expression for queries.
@@ -49,7 +49,7 @@ sealed trait Expression
   * @param expression the simple expression.
   * @param operator the operator to be applied to the expression.
   */
-case class UnaryLogicalExpression(expression: Expression, operator: SingleLogicalOperator) extends Expression
+final case class UnaryLogicalExpression(expression: Expression, operator: SingleLogicalOperator) extends Expression
 
 /**
   * A couple of simple expressions having a [[TupledLogicalOperator]] applied.
@@ -57,7 +57,9 @@ case class UnaryLogicalExpression(expression: Expression, operator: SingleLogica
   * @param operator the operator to apply.
   * @param expression2 the second expression.
   */
-case class TupledLogicalExpression(expression1: Expression, operator: TupledLogicalOperator, expression2: Expression)
+final case class TupledLogicalExpression(expression1: Expression,
+                                         operator: TupledLogicalOperator,
+                                         expression2: Expression)
     extends Expression
 
 /**
@@ -66,7 +68,7 @@ case class TupledLogicalExpression(expression1: Expression, operator: TupledLogi
   * @param comparison comparison operator (e.g. >, >=, <, <=).
   * @param value the value to compare the dimension with.
   */
-case class ComparisonExpression[T](dimension: String, comparison: ComparisonOperator, value: ComparisonValue[T])
+final case class ComparisonExpression[T](dimension: String, comparison: ComparisonOperator, value: ComparisonValue[T])
     extends Expression
 
 /**
@@ -75,7 +77,7 @@ case class ComparisonExpression[T](dimension: String, comparison: ComparisonOper
   * @param value1 lower boundary.
   * @param value2 upper boundary.
   */
-case class RangeExpression[T](dimension: String, value1: ComparisonValue[T], value2: ComparisonValue[T])
+final case class RangeExpression[T](dimension: String, value1: ComparisonValue[T], value2: ComparisonValue[T])
     extends Expression
 
 /**
@@ -83,20 +85,20 @@ case class RangeExpression[T](dimension: String, value1: ComparisonValue[T], val
   * @param dimension dimension name.
   * @param value value to check the equality with.
   */
-case class EqualityExpression[T](dimension: String, value: ComparisonValue[T]) extends Expression
+final case class EqualityExpression[T](dimension: String, value: ComparisonValue[T]) extends Expression
 
 /**
   * Simple like expression for varchar dimensions e.g. dimension like value.
   * @param dimension dimension name.
   * @param value string value with wildcards.
   */
-case class LikeExpression(dimension: String, value: String) extends Expression
+final case class LikeExpression(dimension: String, value: String) extends Expression
 
 /**
   * Simple nullable expression e.g. dimension is null.
   * @param dimension dimension name.
   */
-case class NullableExpression(dimension: String) extends Expression
+final case class NullableExpression(dimension: String) extends Expression
 
 /**
   * Logical operators that can be applied to 1 or 2 expressions.
@@ -140,14 +142,14 @@ case object SumAggregation   extends Aggregation
 sealed trait OrderOperator {
   def dimension: String
 }
-case class AscOrderOperator(override val dimension: String)  extends OrderOperator
-case class DescOrderOperator(override val dimension: String) extends OrderOperator
+final case class AscOrderOperator(override val dimension: String)  extends OrderOperator
+final case class DescOrderOperator(override val dimension: String) extends OrderOperator
 
 /**
   * Limit operator used to limit the size of search results.
   * @param value the maximum number of results
   */
-case class LimitOperator(value: Int)
+final case class LimitOperator(value: Int)
 
 /**
   * Comparison value to wrap values for tracking relative and absolute (mainly for relative timestamp)
@@ -184,7 +186,7 @@ sealed trait GroupByAggregation {
   * Class that represent a simple Group By clause.
   * @param dimension the dimension to apply the aggregation to
   */
-case class SimpleGroupByAggregation(dimension: String) extends GroupByAggregation
+final case class SimpleGroupByAggregation(dimension: String) extends GroupByAggregation
 
 /**
   * Temporal aggregation.
@@ -192,7 +194,8 @@ case class SimpleGroupByAggregation(dimension: String) extends GroupByAggregatio
   * @param quantity The quantity for unitMeasure
   * @param unitMeasure identifier for time measure (s, m, h, d)
   */
-case class TemporalGroupByAggregation(interval: Long, quantity: Long, unitMeasure: String) extends GroupByAggregation {
+final case class TemporalGroupByAggregation(interval: Long, quantity: Long, unitMeasure: String)
+    extends GroupByAggregation {
   override val dimension: String = "timestamp"
 }
 
@@ -218,15 +221,15 @@ sealed trait SQLStatement extends NSDBStatement {
   * @param order present if the query includes a order clause. See [[OrderOperator]].
   * @param limit present if the query includes a limit clause. See [[LimitOperator]].
   */
-case class SelectSQLStatement(override val db: String,
-                              override val namespace: String,
-                              override val metric: String,
-                              distinct: Boolean,
-                              fields: SelectedFields,
-                              condition: Option[Condition] = None,
-                              groupBy: Option[GroupByAggregation] = None,
-                              order: Option[OrderOperator] = None,
-                              limit: Option[LimitOperator] = None)
+final case class SelectSQLStatement(override val db: String,
+                                    override val namespace: String,
+                                    override val metric: String,
+                                    distinct: Boolean,
+                                    fields: SelectedFields,
+                                    condition: Option[Condition] = None,
+                                    groupBy: Option[GroupByAggregation] = None,
+                                    order: Option[OrderOperator] = None,
+                                    limit: Option[LimitOperator] = None)
     extends SQLStatement
     with LazyLogging {
 
@@ -280,7 +283,7 @@ case class SelectSQLStatement(override val db: String,
     */
   def addConditions(filters: Seq[(String, Option[JSerializable], String)]): SelectSQLStatement = {
     val expressions: Seq[Expression] =
-      filters.flatMap(f => filterToExpression(f._1, f._2, f._3))
+      filters.flatMap { case (dimension, value, operator) => filterToExpression(dimension, value, operator) }
     val filtersExpression =
       expressions.reduce((prevExpr, expr) => TupledLogicalExpression(prevExpr, AndOperator, expr))
     val newCondition: Condition = this.condition match {
@@ -312,13 +315,13 @@ case class SelectSQLStatement(override val db: String,
   * @param tags the tags to be inserted.
   * @param value the value to be inserted.
   */
-case class InsertSQLStatement(override val db: String,
-                              override val namespace: String,
-                              override val metric: String,
-                              timestamp: Option[Long],
-                              dimensions: Option[ListAssignment],
-                              tags: Option[ListAssignment],
-                              value: JSerializable)
+final case class InsertSQLStatement(override val db: String,
+                                    override val namespace: String,
+                                    override val metric: String,
+                                    timestamp: Option[Long],
+                                    dimensions: Option[ListAssignment],
+                                    tags: Option[ListAssignment],
+                                    value: JSerializable)
     extends SQLStatement
 
 /**
@@ -328,11 +331,11 @@ case class InsertSQLStatement(override val db: String,
   * @param metric the metric.
   * @param condition the condition to filter records to delete.
   */
-case class DeleteSQLStatement(override val db: String,
-                              override val namespace: String,
-                              override val metric: String,
-                              condition: Condition)
+final case class DeleteSQLStatement(override val db: String,
+                                    override val namespace: String,
+                                    override val metric: String,
+                                    condition: Condition)
     extends SQLStatement
 
-case class DropSQLStatement(override val db: String, override val namespace: String, override val metric: String)
+final case class DropSQLStatement(override val db: String, override val namespace: String, override val metric: String)
     extends SQLStatement

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -150,7 +150,7 @@ case class DescOrderOperator(override val dimension: String) extends OrderOperat
 case class LimitOperator(value: Int)
 
 /**
-  * Timestamp to wrap timestamp value for tracking relative timestamp
+  * Comparison value to wrap values for tracking relative and absolute (mainly for relative timestamp)
   */
 sealed trait ComparisonValue[+T] {
   def value: T

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializer.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializer.scala
@@ -129,8 +129,8 @@ class StandardCommitLogSerializer extends CommitLogSerializer with TypeSupport {
         val upperBoundType  = readByteBuffer.read
         val upperBoundValue = argument(upperBoundType)
         clazz
-          .getConstructor(classOf[String], classOf[AnyRef], classOf[AnyRef])
-          .newInstance(dim, lowerBoundValue, upperBoundValue)
+          .getConstructor(classOf[String], classOf[ComparisonValue[_]], classOf[ComparisonValue[_]])
+          .newInstance(dim, AbsoluteComparisonValue(lowerBoundValue), AbsoluteComparisonValue(upperBoundValue))
 
       case `comparisonExpressionClassName` =>
         val dim       = readByteBuffer.read
@@ -140,16 +140,16 @@ class StandardCommitLogSerializer extends CommitLogSerializer with TypeSupport {
         val valueType = readByteBuffer.read
         val value     = argument(valueType)
         clazz
-          .getConstructor(classOf[String], classOf[ComparisonOperator], classOf[AnyRef])
-          .newInstance(dim, operator, value)
+          .getConstructor(classOf[String], classOf[ComparisonOperator], classOf[ComparisonValue[_]])
+          .newInstance(dim, operator, AbsoluteComparisonValue(value))
 
       case `equalityExpressionClassName` =>
         val dim       = readByteBuffer.read
         val valueType = readByteBuffer.read
         val value     = argument(valueType)
         clazz
-          .getConstructor(classOf[String], classOf[AnyRef])
-          .newInstance(dim, value)
+          .getConstructor(classOf[String], classOf[ComparisonValue[_]])
+          .newInstance(dim, AbsoluteComparisonValue(value))
 
       case `likeExpressionClassName` =>
         val dim       = readByteBuffer.read
@@ -203,18 +203,18 @@ class StandardCommitLogSerializer extends CommitLogSerializer with TypeSupport {
     writeBuffer.write(clazzName)
 
     expression match {
-      case ComparisonExpression(dimension, comparisonOperator, value) =>
+      case ComparisonExpression(dimension, comparisonOperator, ComparisonValue(value)) =>
         writeBuffer.write(dimension)
         writeBuffer.write(comparisonOperator.getClass.getCanonicalName)
         writeBuffer.write(value.getClass.getCanonicalName)
         writeBuffer.write(value.toString)
-      case RangeExpression(dimension, value1, value2) =>
+      case RangeExpression(dimension, ComparisonValue(value1), ComparisonValue(value2)) =>
         writeBuffer.write(dimension)
         writeBuffer.write(value1.getClass.getCanonicalName)
         writeBuffer.write(value1.toString)
         writeBuffer.write(value2.getClass.getCanonicalName)
         writeBuffer.write(value2.toString)
-      case EqualityExpression(dimension, value) =>
+      case EqualityExpression(dimension, ComparisonValue(value)) =>
         writeBuffer.write(dimension)
         writeBuffer.write(value.getClass.getCanonicalName)
         writeBuffer.write(value.toString)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -39,7 +39,7 @@ package object post_proc {
     chainedResults.map {
       case Right(seq) =>
         statement.groupBy match {
-          case Some(TemporalGroupByAggregation(_)) =>
+          case Some(TemporalGroupByAggregation(_, _, _)) =>
             val sortedResults = seq.sortBy(_.timestamp)
             statement.limit.map(_.value).map(v => Right(sortedResults.takeRight(v))) getOrElse Right(sortedResults)
           case _ =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
@@ -40,32 +40,12 @@ object ExpressionParser {
     val q = exp match {
       case Some(NullableExpression(dimension)) => nullableExpression(schema, dimension)
 
-      case Some(EqualityExpression(dimension, value)) =>
-        value match {
-          case AbsoluteComparisonValue(value)          => equalityExpression(schema, dimension, value)
-          case RelativeComparisonValue(value, _, _, _) => equalityExpression(schema, dimension, value)
-        }
-
-      case Some(LikeExpression(dimension, value)) => likeExpression(schema, dimension, value)
-
-      case Some(ComparisonExpression(dimension, operator: ComparisonOperator, value)) =>
-        value match {
-          case AbsoluteComparisonValue(value) => comparisonExpression(schema, dimension, operator, value)
-          case RelativeComparisonValue(value, _, _, _) =>
-            comparisonExpression(schema, dimension, operator, value)
-        }
-
-      case Some(RangeExpression(dimension, p1, p2)) =>
-        (p1, p2) match {
-          case (RelativeComparisonValue(value1, _, _, _), RelativeComparisonValue(value2, _, _, _)) =>
-            rangeExpression(schema, dimension, value1, value2)
-          case (RelativeComparisonValue(value1, _, _, _), AbsoluteComparisonValue(value2)) =>
-            rangeExpression(schema, dimension, value1, value2)
-          case (AbsoluteComparisonValue(value1), RelativeComparisonValue(value2, _, _, _)) =>
-            rangeExpression(schema, dimension, value1, value2)
-          case (AbsoluteComparisonValue(value1), AbsoluteComparisonValue(value2)) =>
-            rangeExpression(schema, dimension, value1, value2)
-        }
+      case Some(EqualityExpression(dimension, ComparisonValue(value))) => equalityExpression(schema, dimension, value)
+      case Some(LikeExpression(dimension, value))                      => likeExpression(schema, dimension, value)
+      case Some(ComparisonExpression(dimension, operator: ComparisonOperator, ComparisonValue(value))) =>
+        comparisonExpression(schema, dimension, operator, value)
+      case Some(RangeExpression(dimension, ComparisonValue(value1), ComparisonValue(value2))) =>
+        rangeExpression(schema, dimension, value1, value2)
 
       case Some(UnaryLogicalExpression(expression, _)) => unaryLogicalExpression(schema, expression)
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
@@ -42,25 +42,24 @@ object ExpressionParser {
 
       case Some(EqualityExpression(dimension, value)) =>
         value match {
-
-          case RelativeTimestampValue(timestamp, _, _) => equalityExpression(schema, dimension, timestamp)
-          case AbsoluteTimestampValue(timestamp)       => equalityExpression(schema, dimension, timestamp)
-          case _                                       => equalityExpression(schema, dimension, value)
-
+          case RelativeTimestampValue(timestamp, _, _, _) => equalityExpression(schema, dimension, timestamp)
+          case AbsoluteTimestampValue(timestamp)          => equalityExpression(schema, dimension, timestamp)
+          case _                                          => equalityExpression(schema, dimension, value)
         }
 
       case Some(LikeExpression(dimension, value)) => likeExpression(schema, dimension, value)
 
       case Some(ComparisonExpression(dimension, operator: ComparisonOperator, value)) =>
         value match {
-          case RelativeTimestampValue(timestamp, _, _) => comparisonExpression(schema, dimension, operator, timestamp)
-          case AbsoluteTimestampValue(timestamp)       => comparisonExpression(schema, dimension, operator, timestamp)
-          case _                                       => comparisonExpression(schema, dimension, operator, value)
+          case RelativeTimestampValue(timestamp, _, _, _) =>
+            comparisonExpression(schema, dimension, operator, timestamp)
+          case AbsoluteTimestampValue(timestamp) => comparisonExpression(schema, dimension, operator, timestamp)
+          case _                                 => comparisonExpression(schema, dimension, operator, value)
         }
 
       case Some(RangeExpression(dimension, p1, p2)) =>
         (p1, p2) match {
-          case (RelativeTimestampValue(timestamp1, _, _), RelativeTimestampValue(timestamp2, _, _)) =>
+          case (RelativeTimestampValue(timestamp1, _, _, _), RelativeTimestampValue(timestamp2, _, _, _)) =>
             rangeExpression(schema, dimension, timestamp1, timestamp2)
           case (AbsoluteTimestampValue(timestamp1), AbsoluteTimestampValue(timestamp2)) =>
             rangeExpression(schema, dimension, timestamp1, timestamp2)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
@@ -43,7 +43,6 @@ object ExpressionParser {
       case Some(EqualityExpression(dimension, value)) =>
         value match {
           case RelativeTimestampValue(timestamp, _, _, _) => equalityExpression(schema, dimension, timestamp)
-          case AbsoluteTimestampValue(timestamp)          => equalityExpression(schema, dimension, timestamp)
           case _                                          => equalityExpression(schema, dimension, value)
         }
 
@@ -53,15 +52,12 @@ object ExpressionParser {
         value match {
           case RelativeTimestampValue(timestamp, _, _, _) =>
             comparisonExpression(schema, dimension, operator, timestamp)
-          case AbsoluteTimestampValue(timestamp) => comparisonExpression(schema, dimension, operator, timestamp)
           case _                                 => comparisonExpression(schema, dimension, operator, value)
         }
 
       case Some(RangeExpression(dimension, p1, p2)) =>
         (p1, p2) match {
           case (RelativeTimestampValue(timestamp1, _, _, _), RelativeTimestampValue(timestamp2, _, _, _)) =>
-            rangeExpression(schema, dimension, timestamp1, timestamp2)
-          case (AbsoluteTimestampValue(timestamp1), AbsoluteTimestampValue(timestamp2)) =>
             rangeExpression(schema, dimension, timestamp1, timestamp2)
           case _ => rangeExpression(schema, dimension, p1, p2)
         }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
@@ -42,24 +42,31 @@ object ExpressionParser {
 
       case Some(EqualityExpression(dimension, value)) =>
         value match {
-          case RelativeTimestampValue(timestamp, _, _, _) => equalityExpression(schema, dimension, timestamp)
-          case _                                          => equalityExpression(schema, dimension, value)
+          case AbsoluteComparisonValue(value)          => equalityExpression(schema, dimension, value)
+          case RelativeComparisonValue(value, _, _, _) => equalityExpression(schema, dimension, value)
+          // case _                                          => equalityExpression(schema, dimension, value)
         }
 
       case Some(LikeExpression(dimension, value)) => likeExpression(schema, dimension, value)
 
       case Some(ComparisonExpression(dimension, operator: ComparisonOperator, value)) =>
         value match {
-          case RelativeTimestampValue(timestamp, _, _, _) =>
-            comparisonExpression(schema, dimension, operator, timestamp)
-          case _                                 => comparisonExpression(schema, dimension, operator, value)
+          case AbsoluteComparisonValue(value) => comparisonExpression(schema, dimension, operator, value)
+          case RelativeComparisonValue(value, _, _, _) =>
+            comparisonExpression(schema, dimension, operator, value)
+          // case _ => comparisonExpression(schema, dimension, operator, value)
         }
 
       case Some(RangeExpression(dimension, p1, p2)) =>
         (p1, p2) match {
-          case (RelativeTimestampValue(timestamp1, _, _, _), RelativeTimestampValue(timestamp2, _, _, _)) =>
-            rangeExpression(schema, dimension, timestamp1, timestamp2)
-          case _ => rangeExpression(schema, dimension, p1, p2)
+          case (RelativeComparisonValue(value1, _, _, _), RelativeComparisonValue(value2, _, _, _)) =>
+            rangeExpression(schema, dimension, value1, value2)
+          case (RelativeComparisonValue(value1, _, _, _), AbsoluteComparisonValue(value2)) =>
+            rangeExpression(schema, dimension, value1, value2)
+          case (AbsoluteComparisonValue(value1), RelativeComparisonValue(value2, _, _, _)) =>
+            rangeExpression(schema, dimension, value1, value2)
+          case (AbsoluteComparisonValue(value1), AbsoluteComparisonValue(value2)) =>
+            rangeExpression(schema, dimension, value1, value2)
         }
 
       case Some(UnaryLogicalExpression(expression, _)) => unaryLogicalExpression(schema, expression)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
@@ -44,7 +44,6 @@ object ExpressionParser {
         value match {
           case AbsoluteComparisonValue(value)          => equalityExpression(schema, dimension, value)
           case RelativeComparisonValue(value, _, _, _) => equalityExpression(schema, dimension, value)
-          // case _                                          => equalityExpression(schema, dimension, value)
         }
 
       case Some(LikeExpression(dimension, value)) => likeExpression(schema, dimension, value)
@@ -54,7 +53,6 @@ object ExpressionParser {
           case AbsoluteComparisonValue(value) => comparisonExpression(schema, dimension, operator, value)
           case RelativeComparisonValue(value, _, _, _) =>
             comparisonExpression(schema, dimension, operator, value)
-          // case _ => comparisonExpression(schema, dimension, operator, value)
         }
 
       case Some(RangeExpression(dimension, p1, p2)) =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
@@ -107,8 +107,9 @@ object StatementParser {
               if sortOpt.isDefined && !Seq("value", group.dimension).contains(sortOpt.get.getSort.head.getField) =>
             Left(StatementParserErrors.SORT_DIMENSION_NOT_IN_GROUP)
           // Match temporal count aggregation
-          case (false, Success(Seq(Field(fieldName, Some(aggregation)))), Some(TemporalGroupByAggregation(interval)))
-              if fieldName == "value" || fieldName == "*" =>
+          case (false,
+                Success(Seq(Field(fieldName, Some(aggregation)))),
+                Some(TemporalGroupByAggregation(interval, _, _))) if fieldName == "value" || fieldName == "*" =>
             Right(
               ParsedTemporalAggregatedQuery(
                 statement.namespace,

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/TimeRangeManager.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/TimeRangeManager.scala
@@ -31,16 +31,17 @@ object TimeRangeManager {
 
   def extractTimeRange(exp: Option[Expression]): List[Interval[Long]] = {
     exp match {
-      case Some(EqualityExpression("timestamp", value: Long)) => List(Interval.point(value))
-      case Some(ComparisonExpression("timestamp", operator: ComparisonOperator, value: Long)) =>
+      case Some(EqualityExpression("timestamp", ComparisonValue(value: Long))) => List(Interval.point(value))
+      case Some(ComparisonExpression("timestamp", operator: ComparisonOperator, ComparisonValue(value: Long))) =>
         operator match {
           case GreaterThanOperator      => List(Interval.fromBounds(Open(value), Unbound()))
           case GreaterOrEqualToOperator => List(Interval.fromBounds(Closed(value), Unbound()))
           case LessThanOperator         => List(Interval.openUpper(0, value))
           case LessOrEqualToOperator    => List(Interval.closed(0, value))
         }
-      case Some(RangeExpression("timestamp", v1: Long, v2: Long)) => List(Interval.closed(v1, v2))
-      case Some(UnaryLogicalExpression(expression, _))            => extractTimeRange(Some(expression)).flatMap(i => ~i)
+      case Some(RangeExpression("timestamp", ComparisonValue(v1: Long), ComparisonValue(v2: Long))) =>
+        List(Interval.closed(v1, v2))
+      case Some(UnaryLogicalExpression(expression, _)) => extractTimeRange(Some(expression)).flatMap(i => ~i)
       case Some(TupledLogicalExpression(expression1, operator: TupledLogicalOperator, expression2: Expression)) =>
         val intervals = extractTimeRange(Some(expression1)) ++ extractTimeRange(Some(expression2))
         if (intervals.isEmpty)

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -59,7 +59,10 @@ class PublisherActorSpec
     distinct = false,
     fields = AllFields,
     condition = Some(
-      Condition(ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 10L))),
+      Condition(
+        ComparisonExpression(dimension = "timestamp",
+                             comparison = GreaterOrEqualToOperator,
+                             value = AbsoluteComparisonValue(10L)))),
     limit = Some(LimitOperator(4))
   )
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializerSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializerSpec.scala
@@ -14,361 +14,345 @@
  * limitations under the License.
  */
 
-///*
-// * Copyright 2018 Radicalbit S.r.l.
-// *
-// * Licensed under the Apache License, Version 2.0 (the "License");
-// * you may not use this file except in compliance with the License.
-// * You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//
-//package io.radicalbit.nsdb.commit_log
-//
-//import io.radicalbit.nsdb.commit_log.CommitLogWriterActor._
-//import io.radicalbit.nsdb.common.JSerializable
-//import io.radicalbit.nsdb.common.protocol.Bit
-//import io.radicalbit.nsdb.common.statement._
-//import org.scalatest.{Matchers, WordSpec}
-//
-//class StandardCommitLogSerializerSpec extends WordSpec with Matchers {
-//
-//  "A CommitLogEntry" when {
-//    val entryService = new StandardCommitLogSerializer
-//
-//    "has got a single dimension" should {
-//      "be created correctly" in {
-//
-//        val db        = "test-db"
-//        val namespace = "test-namespace"
-//        val ts        = 1500909299161L
-//        val metric    = "test-metric"
-//        val bit       = Bit(ts, 0, Map("dimension1" -> "value1"), Map("tag1" -> "tag1"))
-//        val id        = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
-//        val originalEntry =
-//          ReceivedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//    }
-//
-//    "has got few dimensions" should {
-//      "be created correctly if ReceivedEntry" in {
-//
-//        val db        = "test1-db"
-//        val namespace = "test1-namespace"
-//        val ts        = 1500909299165L
-//        val metric    = "test1-metric"
-//        val dimensions: Map[String, JSerializable] =
-//          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
-//        val tags: Map[String, JSerializable] =
-//          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
-//        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
-//        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
-//        val originalEntry =
-//          ReceivedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//
-//      "be created correctly if AccumulatedEntry" in {
-//
-//        val db        = "test1-db"
-//        val namespace = "test1-namespace"
-//        val ts        = 1500909299165L
-//        val metric    = "test1-metric"
-//        val dimensions: Map[String, JSerializable] =
-//          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
-//        val tags: Map[String, JSerializable] =
-//          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
-//        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
-//        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
-//        val originalEntry =
-//          AccumulatedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//
-//      "be created correctly if PersistedEntry" in {
-//
-//        val db        = "test1-db"
-//        val namespace = "test1-namespace"
-//        val ts        = 1500909299165L
-//        val metric    = "test1-metric"
-//        val dimensions: Map[String, JSerializable] =
-//          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
-//        val tags: Map[String, JSerializable] =
-//          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
-//        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
-//        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
-//        val originalEntry =
-//          PersistedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//
-//      "be created correctly if RejectedEntry" in {
-//
-//        val db        = "test1-db"
-//        val namespace = "test1-namespace"
-//        val ts        = 1500909299165L
-//        val metric    = "test1-metric"
-//        val dimensions: Map[String, JSerializable] =
-//          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
-//        val tags: Map[String, JSerializable] =
-//          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
-//        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
-//        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
-//        val originalEntry =
-//          RejectedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//    }
-//    "for deletion by query" should {
-//      "be created correctly with RangeExpression for Long" in {
-//        val db         = "test-db"
-//        val namespace  = "test-namespace"
-//        val ts         = 1500909299161L
-//        val metric     = "test-metric"
-//        val expression = RangeExpression("dimension", AbsoluteComparisonValue(10L), AbsoluteComparisonValue(11L))
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with RangeExpression for Double" in {
-//        val db         = "test-db"
-//        val namespace  = "test-namespace"
-//        val ts         = 1500909299161L
-//        val metric     = "test-metric"
-//        val expression = RangeExpression("dimension", AbsoluteComparisonValue(10.0), AbsoluteComparisonValue(11.0))
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with RangeExpression for Integer" in {
-//        val db         = "test-db"
-//        val namespace  = "test-namespace"
-//        val ts         = 1500909299161L
-//        val metric     = "test-metric"
-//        val expression = RangeExpression("dimension", AbsoluteComparisonValue(10), AbsoluteComparisonValue(11))
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with ComparisonExpression for Integer" in {
-//        val db         = "test-db"
-//        val namespace  = "test-namespace"
-//        val ts         = 1500909299161L
-//        val metric     = "test-metric"
-//        val expression = ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue(11))
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with ComparisonExpression for Long" in {
-//        val db         = "test-db"
-//        val namespace  = "test-namespace"
-//        val ts         = 1500909299161L
-//        val metric     = "test-metric"
-//        val expression = ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue(11L))
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with ComparisonExpression for Double" in {
-//        val db         = "test-db"
-//        val namespace  = "test-namespace"
-//        val ts         = 1500909299161L
-//        val metric     = "test-metric"
-//        val expression = ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue(11.0))
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with ComparisonExpression for String" in {
-//        val db        = "test-db"
-//        val namespace = "test-namespace"
-//        val ts        = 1500909299161L
-//        val metric    = "test-metric"
-//        val expression =
-//          ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue("dimValue"))
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with EqualityExpression for String" in {
-//        val db         = "test-db"
-//        val namespace  = "test-namespace"
-//        val ts         = 1500909299161L
-//        val metric     = "test-metric"
-//        val expression = EqualityExpression("dimension", AbsoluteComparisonValue("dimValue"))
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with EqualityExpression for Integer" in {
-//        val db         = "test-db"
-//        val namespace  = "test-namespace"
-//        val ts         = 1500909299161L
-//        val metric     = "test-metric"
-//        val expression = EqualityExpression("dimension", AbsoluteComparisonValue(1))
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with EqualityExpression for Long" in {
-//        val db         = "test-db"
-//        val namespace  = "test-namespace"
-//        val ts         = 1500909299161L
-//        val metric     = "test-metric"
-//        val expression = EqualityExpression("dimension", AbsoluteComparisonValue(1L))
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with EqualityExpression for Double" in {
-//        val db         = "test-db"
-//        val namespace  = "test-namespace"
-//        val ts         = 1500909299161L
-//        val metric     = "test-metric"
-//        val expression = EqualityExpression("dimension", AbsoluteComparisonValue(1.0))
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with LikeExpression for String" in {
-//        val db         = "test-db"
-//        val namespace  = "test-namespace"
-//        val ts         = 1500909299161L
-//        val metric     = "test-metric"
-//        val expression = LikeExpression("dimension", "v")
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with NullableExpression" in {
-//        val db         = "test-db"
-//        val namespace  = "test-namespace"
-//        val ts         = 1500909299161L
-//        val metric     = "test-metric"
-//        val expression = NullableExpression("dimension")
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with UnaryLogicalExpression" in {
-//        val db        = "test-db"
-//        val namespace = "test-namespace"
-//        val ts        = 1500909299161L
-//        val metric    = "test-metric"
-//        val expression =
-//          UnaryLogicalExpression(ComparisonExpression("dimension",
-//                                                      GreaterOrEqualToOperator,
-//                                                      AbsoluteComparisonValue("dimValue")),
-//                                 NotOperator)
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//      "be created correctly with TupleLogicalExpression" in {
-//        val db        = "test-db"
-//        val namespace = "test-namespace"
-//        val ts        = 1500909299161L
-//        val metric    = "test-metric"
-//        val expression =
-//          TupledLogicalExpression(
-//            ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue("dimValue")),
-//            AndOperator,
-//            RangeExpression("timestamp", AbsoluteComparisonValue(10L), AbsoluteComparisonValue(11L))
-//          )
-//        val originalEntry =
-//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-//
-//        val serByteArray = entryService.serialize(originalEntry)
-//        val desEntry     = entryService.deserialize(serByteArray)
-//
-//        desEntry should be(Some(originalEntry))
-//      }
-//    }
-//  }
-//
-//}
+package io.radicalbit.nsdb.commit_log
+
+import io.radicalbit.nsdb.commit_log.CommitLogWriterActor._
+import io.radicalbit.nsdb.common.JSerializable
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.common.statement._
+import org.scalatest.{Matchers, WordSpec}
+
+class StandardCommitLogSerializerSpec extends WordSpec with Matchers {
+
+  "A CommitLogEntry" when {
+    val entryService = new StandardCommitLogSerializer
+
+    "has got a single dimension" should {
+      "be created correctly" in {
+
+        val db        = "test-db"
+        val namespace = "test-namespace"
+        val ts        = 1500909299161L
+        val metric    = "test-metric"
+        val bit       = Bit(ts, 0, Map("dimension1" -> "value1"), Map("tag1" -> "tag1"))
+        val id        = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
+        val originalEntry =
+          ReceivedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+    }
+
+    "has got few dimensions" should {
+      "be created correctly if ReceivedEntry" in {
+
+        val db        = "test1-db"
+        val namespace = "test1-namespace"
+        val ts        = 1500909299165L
+        val metric    = "test1-metric"
+        val dimensions: Map[String, JSerializable] =
+          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
+        val tags: Map[String, JSerializable] =
+          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
+        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
+        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
+        val originalEntry =
+          ReceivedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+
+      "be created correctly if AccumulatedEntry" in {
+
+        val db        = "test1-db"
+        val namespace = "test1-namespace"
+        val ts        = 1500909299165L
+        val metric    = "test1-metric"
+        val dimensions: Map[String, JSerializable] =
+          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
+        val tags: Map[String, JSerializable] =
+          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
+        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
+        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
+        val originalEntry =
+          AccumulatedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+
+      "be created correctly if PersistedEntry" in {
+
+        val db        = "test1-db"
+        val namespace = "test1-namespace"
+        val ts        = 1500909299165L
+        val metric    = "test1-metric"
+        val dimensions: Map[String, JSerializable] =
+          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
+        val tags: Map[String, JSerializable] =
+          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
+        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
+        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
+        val originalEntry =
+          PersistedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+
+      "be created correctly if RejectedEntry" in {
+
+        val db        = "test1-db"
+        val namespace = "test1-namespace"
+        val ts        = 1500909299165L
+        val metric    = "test1-metric"
+        val dimensions: Map[String, JSerializable] =
+          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
+        val tags: Map[String, JSerializable] =
+          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
+        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
+        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
+        val originalEntry =
+          RejectedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+    }
+    "for deletion by query" should {
+      "be created correctly with RangeExpression for Long" in {
+        val db         = "test-db"
+        val namespace  = "test-namespace"
+        val ts         = 1500909299161L
+        val metric     = "test-metric"
+        val expression = RangeExpression("dimension", AbsoluteComparisonValue(10L), AbsoluteComparisonValue(11L))
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with RangeExpression for Double" in {
+        val db         = "test-db"
+        val namespace  = "test-namespace"
+        val ts         = 1500909299161L
+        val metric     = "test-metric"
+        val expression = RangeExpression("dimension", AbsoluteComparisonValue(10.0), AbsoluteComparisonValue(11.0))
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with RangeExpression for Integer" in {
+        val db         = "test-db"
+        val namespace  = "test-namespace"
+        val ts         = 1500909299161L
+        val metric     = "test-metric"
+        val expression = RangeExpression("dimension", AbsoluteComparisonValue(10), AbsoluteComparisonValue(11))
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with ComparisonExpression for Integer" in {
+        val db         = "test-db"
+        val namespace  = "test-namespace"
+        val ts         = 1500909299161L
+        val metric     = "test-metric"
+        val expression = ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue(11))
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with ComparisonExpression for Long" in {
+        val db         = "test-db"
+        val namespace  = "test-namespace"
+        val ts         = 1500909299161L
+        val metric     = "test-metric"
+        val expression = ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue(11L))
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with ComparisonExpression for Double" in {
+        val db         = "test-db"
+        val namespace  = "test-namespace"
+        val ts         = 1500909299161L
+        val metric     = "test-metric"
+        val expression = ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue(11.0))
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with ComparisonExpression for String" in {
+        val db        = "test-db"
+        val namespace = "test-namespace"
+        val ts        = 1500909299161L
+        val metric    = "test-metric"
+        val expression =
+          ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue("dimValue"))
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with EqualityExpression for String" in {
+        val db         = "test-db"
+        val namespace  = "test-namespace"
+        val ts         = 1500909299161L
+        val metric     = "test-metric"
+        val expression = EqualityExpression("dimension", AbsoluteComparisonValue("dimValue"))
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with EqualityExpression for Integer" in {
+        val db         = "test-db"
+        val namespace  = "test-namespace"
+        val ts         = 1500909299161L
+        val metric     = "test-metric"
+        val expression = EqualityExpression("dimension", AbsoluteComparisonValue(1))
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with EqualityExpression for Long" in {
+        val db         = "test-db"
+        val namespace  = "test-namespace"
+        val ts         = 1500909299161L
+        val metric     = "test-metric"
+        val expression = EqualityExpression("dimension", AbsoluteComparisonValue(1L))
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with EqualityExpression for Double" in {
+        val db         = "test-db"
+        val namespace  = "test-namespace"
+        val ts         = 1500909299161L
+        val metric     = "test-metric"
+        val expression = EqualityExpression("dimension", AbsoluteComparisonValue(1.0))
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with LikeExpression for String" in {
+        val db         = "test-db"
+        val namespace  = "test-namespace"
+        val ts         = 1500909299161L
+        val metric     = "test-metric"
+        val expression = LikeExpression("dimension", "v")
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with NullableExpression" in {
+        val db         = "test-db"
+        val namespace  = "test-namespace"
+        val ts         = 1500909299161L
+        val metric     = "test-metric"
+        val expression = NullableExpression("dimension")
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with UnaryLogicalExpression" in {
+        val db        = "test-db"
+        val namespace = "test-namespace"
+        val ts        = 1500909299161L
+        val metric    = "test-metric"
+        val expression =
+          UnaryLogicalExpression(ComparisonExpression("dimension",
+                                                      GreaterOrEqualToOperator,
+                                                      AbsoluteComparisonValue("dimValue")),
+                                 NotOperator)
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+      "be created correctly with TupleLogicalExpression" in {
+        val db        = "test-db"
+        val namespace = "test-namespace"
+        val ts        = 1500909299161L
+        val metric    = "test-metric"
+        val expression =
+          TupledLogicalExpression(
+            ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue("dimValue")),
+            AndOperator,
+            RangeExpression("timestamp", AbsoluteComparisonValue(10L), AbsoluteComparisonValue(11L))
+          )
+        val originalEntry =
+          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+
+        val serByteArray = entryService.serialize(originalEntry)
+        val desEntry     = entryService.deserialize(serByteArray)
+
+        desEntry should be(Some(originalEntry))
+      }
+    }
+  }
+
+}

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializerSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializerSpec.scala
@@ -14,339 +14,361 @@
  * limitations under the License.
  */
 
-package io.radicalbit.nsdb.commit_log
-
-import io.radicalbit.nsdb.commit_log.CommitLogWriterActor._
-import io.radicalbit.nsdb.common.JSerializable
-import io.radicalbit.nsdb.common.protocol.Bit
-import io.radicalbit.nsdb.common.statement._
-import org.scalatest.{Matchers, WordSpec}
-
-class StandardCommitLogSerializerSpec extends WordSpec with Matchers {
-
-  "A CommitLogEntry" when {
-    val entryService = new StandardCommitLogSerializer
-
-    "has got a single dimension" should {
-      "be created correctly" in {
-
-        val db        = "test-db"
-        val namespace = "test-namespace"
-        val ts        = 1500909299161L
-        val metric    = "test-metric"
-        val bit       = Bit(ts, 0, Map("dimension1" -> "value1"), Map("tag1" -> "tag1"))
-        val id        = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
-        val originalEntry =
-          ReceivedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-    }
-
-    "has got few dimensions" should {
-      "be created correctly if ReceivedEntry" in {
-
-        val db        = "test1-db"
-        val namespace = "test1-namespace"
-        val ts        = 1500909299165L
-        val metric    = "test1-metric"
-        val dimensions: Map[String, JSerializable] =
-          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
-        val tags: Map[String, JSerializable] =
-          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
-        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
-        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
-        val originalEntry =
-          ReceivedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-
-      "be created correctly if AccumulatedEntry" in {
-
-        val db        = "test1-db"
-        val namespace = "test1-namespace"
-        val ts        = 1500909299165L
-        val metric    = "test1-metric"
-        val dimensions: Map[String, JSerializable] =
-          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
-        val tags: Map[String, JSerializable] =
-          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
-        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
-        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
-        val originalEntry =
-          AccumulatedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-
-      "be created correctly if PersistedEntry" in {
-
-        val db        = "test1-db"
-        val namespace = "test1-namespace"
-        val ts        = 1500909299165L
-        val metric    = "test1-metric"
-        val dimensions: Map[String, JSerializable] =
-          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
-        val tags: Map[String, JSerializable] =
-          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
-        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
-        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
-        val originalEntry =
-          PersistedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-
-      "be created correctly if RejectedEntry" in {
-
-        val db        = "test1-db"
-        val namespace = "test1-namespace"
-        val ts        = 1500909299165L
-        val metric    = "test1-metric"
-        val dimensions: Map[String, JSerializable] =
-          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
-        val tags: Map[String, JSerializable] =
-          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
-        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
-        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
-        val originalEntry =
-          RejectedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-    }
-    "for deletion by query" should {
-      "be created correctly with RangeExpression for Long" in {
-        val db         = "test-db"
-        val namespace  = "test-namespace"
-        val ts         = 1500909299161L
-        val metric     = "test-metric"
-        val expression = RangeExpression("dimension", 10L, 11L)
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with RangeExpression for Double" in {
-        val db         = "test-db"
-        val namespace  = "test-namespace"
-        val ts         = 1500909299161L
-        val metric     = "test-metric"
-        val expression = RangeExpression("dimension", 10.0, 11.0)
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with RangeExpression for Integer" in {
-        val db         = "test-db"
-        val namespace  = "test-namespace"
-        val ts         = 1500909299161L
-        val metric     = "test-metric"
-        val expression = RangeExpression("dimension", 10, 11)
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with ComparisonExpression for Integer" in {
-        val db         = "test-db"
-        val namespace  = "test-namespace"
-        val ts         = 1500909299161L
-        val metric     = "test-metric"
-        val expression = ComparisonExpression("dimension", GreaterOrEqualToOperator, 11)
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with ComparisonExpression for Long" in {
-        val db         = "test-db"
-        val namespace  = "test-namespace"
-        val ts         = 1500909299161L
-        val metric     = "test-metric"
-        val expression = ComparisonExpression("dimension", GreaterOrEqualToOperator, 11L)
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with ComparisonExpression for Double" in {
-        val db         = "test-db"
-        val namespace  = "test-namespace"
-        val ts         = 1500909299161L
-        val metric     = "test-metric"
-        val expression = ComparisonExpression("dimension", GreaterOrEqualToOperator, 11.0)
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with ComparisonExpression for String" in {
-        val db         = "test-db"
-        val namespace  = "test-namespace"
-        val ts         = 1500909299161L
-        val metric     = "test-metric"
-        val expression = ComparisonExpression("dimension", GreaterOrEqualToOperator, "dimValue")
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with EqualityExpression for String" in {
-        val db         = "test-db"
-        val namespace  = "test-namespace"
-        val ts         = 1500909299161L
-        val metric     = "test-metric"
-        val expression = EqualityExpression("dimension", "dimValue")
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with EqualityExpression for Integer" in {
-        val db         = "test-db"
-        val namespace  = "test-namespace"
-        val ts         = 1500909299161L
-        val metric     = "test-metric"
-        val expression = EqualityExpression("dimension", 1)
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with EqualityExpression for Long" in {
-        val db         = "test-db"
-        val namespace  = "test-namespace"
-        val ts         = 1500909299161L
-        val metric     = "test-metric"
-        val expression = EqualityExpression("dimension", 1L)
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with EqualityExpression for Double" in {
-        val db         = "test-db"
-        val namespace  = "test-namespace"
-        val ts         = 1500909299161L
-        val metric     = "test-metric"
-        val expression = EqualityExpression("dimension", 1.0)
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with LikeExpression for String" in {
-        val db         = "test-db"
-        val namespace  = "test-namespace"
-        val ts         = 1500909299161L
-        val metric     = "test-metric"
-        val expression = LikeExpression("dimension", "v")
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with NullableExpression" in {
-        val db         = "test-db"
-        val namespace  = "test-namespace"
-        val ts         = 1500909299161L
-        val metric     = "test-metric"
-        val expression = NullableExpression("dimension")
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with UnaryLogicalExpression" in {
-        val db        = "test-db"
-        val namespace = "test-namespace"
-        val ts        = 1500909299161L
-        val metric    = "test-metric"
-        val expression =
-          UnaryLogicalExpression(ComparisonExpression("dimension", GreaterOrEqualToOperator, "dimValue"), NotOperator)
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-      "be created correctly with TupleLogicalExpression" in {
-        val db        = "test-db"
-        val namespace = "test-namespace"
-        val ts        = 1500909299161L
-        val metric    = "test-metric"
-        val expression =
-          TupledLogicalExpression(ComparisonExpression("dimension", GreaterOrEqualToOperator, "dimValue"),
-                                  AndOperator,
-                                  RangeExpression("timestamp", 10L, 11L))
-        val originalEntry =
-          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
-
-        val serByteArray = entryService.serialize(originalEntry)
-        val desEntry     = entryService.deserialize(serByteArray)
-
-        desEntry should be(Some(originalEntry))
-      }
-    }
-  }
-
-}
+///*
+// * Copyright 2018 Radicalbit S.r.l.
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package io.radicalbit.nsdb.commit_log
+//
+//import io.radicalbit.nsdb.commit_log.CommitLogWriterActor._
+//import io.radicalbit.nsdb.common.JSerializable
+//import io.radicalbit.nsdb.common.protocol.Bit
+//import io.radicalbit.nsdb.common.statement._
+//import org.scalatest.{Matchers, WordSpec}
+//
+//class StandardCommitLogSerializerSpec extends WordSpec with Matchers {
+//
+//  "A CommitLogEntry" when {
+//    val entryService = new StandardCommitLogSerializer
+//
+//    "has got a single dimension" should {
+//      "be created correctly" in {
+//
+//        val db        = "test-db"
+//        val namespace = "test-namespace"
+//        val ts        = 1500909299161L
+//        val metric    = "test-metric"
+//        val bit       = Bit(ts, 0, Map("dimension1" -> "value1"), Map("tag1" -> "tag1"))
+//        val id        = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
+//        val originalEntry =
+//          ReceivedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//    }
+//
+//    "has got few dimensions" should {
+//      "be created correctly if ReceivedEntry" in {
+//
+//        val db        = "test1-db"
+//        val namespace = "test1-namespace"
+//        val ts        = 1500909299165L
+//        val metric    = "test1-metric"
+//        val dimensions: Map[String, JSerializable] =
+//          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
+//        val tags: Map[String, JSerializable] =
+//          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
+//        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
+//        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
+//        val originalEntry =
+//          ReceivedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//
+//      "be created correctly if AccumulatedEntry" in {
+//
+//        val db        = "test1-db"
+//        val namespace = "test1-namespace"
+//        val ts        = 1500909299165L
+//        val metric    = "test1-metric"
+//        val dimensions: Map[String, JSerializable] =
+//          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
+//        val tags: Map[String, JSerializable] =
+//          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
+//        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
+//        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
+//        val originalEntry =
+//          AccumulatedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//
+//      "be created correctly if PersistedEntry" in {
+//
+//        val db        = "test1-db"
+//        val namespace = "test1-namespace"
+//        val ts        = 1500909299165L
+//        val metric    = "test1-metric"
+//        val dimensions: Map[String, JSerializable] =
+//          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
+//        val tags: Map[String, JSerializable] =
+//          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
+//        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
+//        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
+//        val originalEntry =
+//          PersistedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//
+//      "be created correctly if RejectedEntry" in {
+//
+//        val db        = "test1-db"
+//        val namespace = "test1-namespace"
+//        val ts        = 1500909299165L
+//        val metric    = "test1-metric"
+//        val dimensions: Map[String, JSerializable] =
+//          Map("dimension1" -> "value1", "dimension2" -> 2, "dimension3" -> 3L, "dimension4" -> 3.0)
+//        val tags: Map[String, JSerializable] =
+//          Map("tag1" -> "value1", "tag2" -> 2, "tag3" -> 3L, "tag4" -> 3.0)
+//        val bit = Bit(timestamp = ts, dimensions = dimensions, tags = tags, value = 0)
+//        val id  = CommitLogBitEntry.bitIdentifier(db, namespace, metric, bit)
+//        val originalEntry =
+//          RejectedEntry(db = db, namespace = namespace, metric = metric, timestamp = bit.timestamp, bit = bit, id)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//    }
+//    "for deletion by query" should {
+//      "be created correctly with RangeExpression for Long" in {
+//        val db         = "test-db"
+//        val namespace  = "test-namespace"
+//        val ts         = 1500909299161L
+//        val metric     = "test-metric"
+//        val expression = RangeExpression("dimension", AbsoluteComparisonValue(10L), AbsoluteComparisonValue(11L))
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with RangeExpression for Double" in {
+//        val db         = "test-db"
+//        val namespace  = "test-namespace"
+//        val ts         = 1500909299161L
+//        val metric     = "test-metric"
+//        val expression = RangeExpression("dimension", AbsoluteComparisonValue(10.0), AbsoluteComparisonValue(11.0))
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with RangeExpression for Integer" in {
+//        val db         = "test-db"
+//        val namespace  = "test-namespace"
+//        val ts         = 1500909299161L
+//        val metric     = "test-metric"
+//        val expression = RangeExpression("dimension", AbsoluteComparisonValue(10), AbsoluteComparisonValue(11))
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with ComparisonExpression for Integer" in {
+//        val db         = "test-db"
+//        val namespace  = "test-namespace"
+//        val ts         = 1500909299161L
+//        val metric     = "test-metric"
+//        val expression = ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue(11))
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with ComparisonExpression for Long" in {
+//        val db         = "test-db"
+//        val namespace  = "test-namespace"
+//        val ts         = 1500909299161L
+//        val metric     = "test-metric"
+//        val expression = ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue(11L))
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with ComparisonExpression for Double" in {
+//        val db         = "test-db"
+//        val namespace  = "test-namespace"
+//        val ts         = 1500909299161L
+//        val metric     = "test-metric"
+//        val expression = ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue(11.0))
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with ComparisonExpression for String" in {
+//        val db        = "test-db"
+//        val namespace = "test-namespace"
+//        val ts        = 1500909299161L
+//        val metric    = "test-metric"
+//        val expression =
+//          ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue("dimValue"))
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with EqualityExpression for String" in {
+//        val db         = "test-db"
+//        val namespace  = "test-namespace"
+//        val ts         = 1500909299161L
+//        val metric     = "test-metric"
+//        val expression = EqualityExpression("dimension", AbsoluteComparisonValue("dimValue"))
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with EqualityExpression for Integer" in {
+//        val db         = "test-db"
+//        val namespace  = "test-namespace"
+//        val ts         = 1500909299161L
+//        val metric     = "test-metric"
+//        val expression = EqualityExpression("dimension", AbsoluteComparisonValue(1))
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with EqualityExpression for Long" in {
+//        val db         = "test-db"
+//        val namespace  = "test-namespace"
+//        val ts         = 1500909299161L
+//        val metric     = "test-metric"
+//        val expression = EqualityExpression("dimension", AbsoluteComparisonValue(1L))
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with EqualityExpression for Double" in {
+//        val db         = "test-db"
+//        val namespace  = "test-namespace"
+//        val ts         = 1500909299161L
+//        val metric     = "test-metric"
+//        val expression = EqualityExpression("dimension", AbsoluteComparisonValue(1.0))
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with LikeExpression for String" in {
+//        val db         = "test-db"
+//        val namespace  = "test-namespace"
+//        val ts         = 1500909299161L
+//        val metric     = "test-metric"
+//        val expression = LikeExpression("dimension", "v")
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with NullableExpression" in {
+//        val db         = "test-db"
+//        val namespace  = "test-namespace"
+//        val ts         = 1500909299161L
+//        val metric     = "test-metric"
+//        val expression = NullableExpression("dimension")
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with UnaryLogicalExpression" in {
+//        val db        = "test-db"
+//        val namespace = "test-namespace"
+//        val ts        = 1500909299161L
+//        val metric    = "test-metric"
+//        val expression =
+//          UnaryLogicalExpression(ComparisonExpression("dimension",
+//                                                      GreaterOrEqualToOperator,
+//                                                      AbsoluteComparisonValue("dimValue")),
+//                                 NotOperator)
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//      "be created correctly with TupleLogicalExpression" in {
+//        val db        = "test-db"
+//        val namespace = "test-namespace"
+//        val ts        = 1500909299161L
+//        val metric    = "test-metric"
+//        val expression =
+//          TupledLogicalExpression(
+//            ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue("dimValue")),
+//            AndOperator,
+//            RangeExpression("timestamp", AbsoluteComparisonValue(10L), AbsoluteComparisonValue(11L))
+//          )
+//        val originalEntry =
+//          DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
+//
+//        val serByteArray = entryService.serialize(originalEntry)
+//        val desEntry     = entryService.deserialize(serByteArray)
+//
+//        desEntry should be(Some(originalEntry))
+//      }
+//    }
+//  }
+//
+//}

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
@@ -220,7 +220,11 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 4L))),
+            condition = Some(
+              Condition(
+                RangeExpression(dimension = "timestamp",
+                                value1 = AbsoluteComparisonValue(2L),
+                                value2 = AbsoluteComparisonValue(4L)))),
             limit = Some(LimitOperator(4))
           ),
           schema
@@ -247,7 +251,8 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(EqualityExpression(dimension = "timestamp", value = 10L))),
+            condition =
+              Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(10L)))),
             limit = Some(LimitOperator(4))
           ),
           schema
@@ -271,7 +276,8 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(EqualityExpression(dimension = "name", value = "TestString"))),
+            condition =
+              Some(Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("TestString")))),
             limit = Some(LimitOperator(4))
           ),
           schema
@@ -295,7 +301,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("amount", None))),
-            condition = Some(Condition(EqualityExpression(dimension = "amount", value = 0))),
+            condition = Some(Condition(EqualityExpression(dimension = "amount", value = AbsoluteComparisonValue(0)))),
             limit = Some(LimitOperator(4))
           ),
           schema
@@ -319,7 +325,8 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(EqualityExpression(dimension = "creationDate", value = 0.5))),
+            condition =
+              Some(Condition(EqualityExpression(dimension = "creationDate", value = AbsoluteComparisonValue(0.5)))),
             limit = Some(LimitOperator(4))
           ),
           schema
@@ -334,7 +341,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(EqualityExpression(dimension = "name", value = 0))),
+            condition = Some(Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue(0)))),
             limit = Some(LimitOperator(4))
           ),
           schema
@@ -361,8 +368,11 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(
-              ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 10L))),
+            condition = Some(
+              Condition(
+                ComparisonExpression(dimension = "timestamp",
+                                     comparison = GreaterOrEqualToOperator,
+                                     value = AbsoluteComparisonValue(10L)))),
             limit = Some(LimitOperator(4))
           ),
           schema
@@ -386,8 +396,11 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("amount", None))),
-            condition = Some(Condition(
-              ComparisonExpression(dimension = "amount", comparison = GreaterOrEqualToOperator, value = 10L))),
+            condition = Some(
+              Condition(
+                ComparisonExpression(dimension = "amount",
+                                     comparison = GreaterOrEqualToOperator,
+                                     value = AbsoluteComparisonValue(10L)))),
             limit = Some(LimitOperator(4))
           ),
           schema
@@ -411,7 +424,8 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(EqualityExpression(dimension = "creationDate", value = 0.5))),
+            condition =
+              Some(Condition(EqualityExpression(dimension = "creationDate", value = AbsoluteComparisonValue(0.5)))),
             limit = Some(LimitOperator(4))
           ),
           schema
@@ -430,10 +444,13 @@ class StatementParserSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp", comparison = GreaterThanOperator, value = 2L),
+              expression1 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterThanOperator,
+                                                 value = AbsoluteComparisonValue(2L)),
               operator = AndOperator,
-              expression2 =
-                ComparisonExpression(dimension = "timestamp", comparison = LessOrEqualToOperator, value = 4l)
+              expression2 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = LessOrEqualToOperator,
+                                                 value = AbsoluteComparisonValue(4L))
             ))),
             limit = Some(LimitOperator(4))
           ),
@@ -466,10 +483,13 @@ class StatementParserSpec extends WordSpec with Matchers {
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(UnaryLogicalExpression(
               expression = TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
                 operator = OrOperator,
-                expression2 = ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = 4L)
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessThanOperator,
+                                                   value = AbsoluteComparisonValue(4L))
               ),
               operator = NotOperator
             ))),
@@ -511,10 +531,11 @@ class StatementParserSpec extends WordSpec with Matchers {
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(UnaryLogicalExpression(
               expression = TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
                 operator = OrOperator,
-                expression2 = EqualityExpression(dimension = "name", value = "$john$")
+                expression2 = EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("$john$"))
               ),
               operator = NotOperator
             ))),
@@ -556,8 +577,9 @@ class StatementParserSpec extends WordSpec with Matchers {
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(UnaryLogicalExpression(
               expression = TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
                 operator = OrOperator,
                 expression2 = LikeExpression(dimension = "name", value = "$john$")
               ),
@@ -651,7 +673,11 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 4L))),
+            condition = Some(
+              Condition(
+                RangeExpression(dimension = "timestamp",
+                                value1 = AbsoluteComparisonValue(2L),
+                                value2 = AbsoluteComparisonValue(4L)))),
             order = Some(DescOrderOperator(dimension = "creationDate")),
             limit = Some(LimitOperator(5))
           ),
@@ -695,7 +721,11 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("value", Some(SqlSumAggregation)))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 4L))),
+            condition = Some(
+              Condition(
+                RangeExpression(dimension = "timestamp",
+                                value1 = AbsoluteComparisonValue(2L),
+                                value2 = AbsoluteComparisonValue(4L)))),
             groupBy = Some(SimpleGroupByAggregation("name"))
           ),
           schema
@@ -717,7 +747,11 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("*", Some(SqlSumAggregation)))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 4L))),
+            condition = Some(
+              Condition(
+                RangeExpression(dimension = "timestamp",
+                                value1 = AbsoluteComparisonValue(2L),
+                                value2 = AbsoluteComparisonValue(4L)))),
             groupBy = Some(SimpleGroupByAggregation("name"))
           ),
           schema
@@ -742,7 +776,11 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("value", Some(MaxAggregation)))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 4L))),
+            condition = Some(
+              Condition(
+                RangeExpression(dimension = "timestamp",
+                                value1 = AbsoluteComparisonValue(2L),
+                                value2 = AbsoluteComparisonValue(4L)))),
             groupBy = Some(SimpleGroupByAggregation("name")),
             order = Some(DescOrderOperator(dimension = "value")),
             limit = Some(LimitOperator(5))

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
@@ -1022,7 +1022,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("*", Some(CountAggregation)))),
             condition = None,
-            groupBy = Some(TemporalGroupByAggregation(1)),
+            groupBy = Some(TemporalGroupByAggregation(1, 1, "ms")),
             limit = None
           ),
           schema
@@ -1048,7 +1048,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("*", Some(SqlSumAggregation)))),
             condition = None,
-            groupBy = Some(TemporalGroupByAggregation(1)),
+            groupBy = Some(TemporalGroupByAggregation(1, 1, "ms")),
             limit = None
           ),
           schema
@@ -1074,7 +1074,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("*", Some(MinAggregation)))),
             condition = None,
-            groupBy = Some(TemporalGroupByAggregation(1)),
+            groupBy = Some(TemporalGroupByAggregation(1, 1, "ms")),
             limit = None
           ),
           schema
@@ -1097,7 +1097,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("*", Some(MaxAggregation)))),
             condition = None,
-            groupBy = Some(TemporalGroupByAggregation(1)),
+            groupBy = Some(TemporalGroupByAggregation(1, 1, "ms")),
             limit = None
           ),
           schema

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
@@ -1022,7 +1022,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("*", Some(CountAggregation)))),
             condition = None,
-            groupBy = Some(TemporalGroupByAggregation(1, 1, "ms")),
+            groupBy = Some(TemporalGroupByAggregation(1000, 1, "s")),
             limit = None
           ),
           schema
@@ -1032,7 +1032,33 @@ class StatementParserSpec extends WordSpec with Matchers {
               "registry",
               "people",
               new MatchAllDocsQuery(),
-              1,
+              1000,
+              InternalCountTemporalAggregation,
+              None
+            ))
+        )
+      }
+
+      "parse it when count aggregation is provided with different interval" in {
+        StatementParser.parseStatement(
+          SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("*", Some(CountAggregation)))),
+            condition = None,
+            groupBy = Some(TemporalGroupByAggregation(86400000, 1, "d")),
+            limit = None
+          ),
+          schema
+        ) should be(
+          Right(
+            ParsedTemporalAggregatedQuery(
+              "registry",
+              "people",
+              new MatchAllDocsQuery(),
+              86400000,
               InternalCountTemporalAggregation,
               None
             ))
@@ -1048,7 +1074,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("*", Some(SqlSumAggregation)))),
             condition = None,
-            groupBy = Some(TemporalGroupByAggregation(1, 1, "ms")),
+            groupBy = Some(TemporalGroupByAggregation(1000, 1, "s")),
             limit = None
           ),
           schema
@@ -1058,7 +1084,7 @@ class StatementParserSpec extends WordSpec with Matchers {
               "registry",
               "people",
               new MatchAllDocsQuery(),
-              1,
+              1000,
               InternalSumTemporalAggregation,
               None
             ))
@@ -1074,7 +1100,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("*", Some(MinAggregation)))),
             condition = None,
-            groupBy = Some(TemporalGroupByAggregation(1, 1, "ms")),
+            groupBy = Some(TemporalGroupByAggregation(1000, 1, "s")),
             limit = None
           ),
           schema
@@ -1084,7 +1110,7 @@ class StatementParserSpec extends WordSpec with Matchers {
               "registry",
               "people",
               new MatchAllDocsQuery(),
-              1,
+              1000,
               InternalMinTemporalAggregation,
               None
             ))
@@ -1097,7 +1123,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("*", Some(MaxAggregation)))),
             condition = None,
-            groupBy = Some(TemporalGroupByAggregation(1, 1, "ms")),
+            groupBy = Some(TemporalGroupByAggregation(1000, 1, "s")),
             limit = None
           ),
           schema
@@ -1106,7 +1132,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             "registry",
             "people",
             new MatchAllDocsQuery(),
-            1,
+            1000,
             InternalMaxTemporalAggregation,
             None
           ))

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
@@ -58,7 +58,9 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
       "parse it successfully" in {
         TimeRangeManager.extractTimeRange(
           Some(
-            RangeExpression(dimension = "other", value1 = 2L, value2 = 4L)
+            RangeExpression(dimension = "other",
+                            value1 = AbsoluteComparisonValue(2L),
+                            value2 = AbsoluteComparisonValue(4L))
           )) shouldBe List.empty
       }
 
@@ -66,9 +68,13 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
         TimeRangeManager.extractTimeRange(
           Some(
             TupledLogicalExpression(
-              expression1 = RangeExpression(dimension = "other", value1 = 2L, value2 = 4L),
+              expression1 = RangeExpression(dimension = "other",
+                                            value1 = AbsoluteComparisonValue(2L),
+                                            value2 = AbsoluteComparisonValue(4L)),
               operator = AndOperator,
-              expression2 = RangeExpression(dimension = "other2", value1 = 2L, value2 = 4L)
+              expression2 = RangeExpression(dimension = "other2",
+                                            value1 = AbsoluteComparisonValue(2L),
+                                            value2 = AbsoluteComparisonValue(4L))
             )
           )) shouldBe List.empty
       }
@@ -77,9 +83,13 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
         TimeRangeManager.extractTimeRange(
           Some(
             TupledLogicalExpression(
-              expression1 = RangeExpression(dimension = "other", value1 = 2L, value2 = 4L),
+              expression1 = RangeExpression(dimension = "other",
+                                            value1 = AbsoluteComparisonValue(2L),
+                                            value2 = AbsoluteComparisonValue(4L)),
               operator = OrOperator,
-              expression2 = RangeExpression(dimension = "other2", value1 = 2L, value2 = 4L)
+              expression2 = RangeExpression(dimension = "other2",
+                                            value1 = AbsoluteComparisonValue(2L),
+                                            value2 = AbsoluteComparisonValue(4L))
             )
           )) shouldBe List.empty
       }
@@ -89,7 +99,9 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
       "parse it successfully in case of a range selection" in {
         TimeRangeManager.extractTimeRange(
           Some(
-            RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 4L)
+            RangeExpression(dimension = "timestamp",
+                            value1 = AbsoluteComparisonValue(2L),
+                            value2 = AbsoluteComparisonValue(4L))
           )) shouldBe List(
           Interval.closed(2L, 4L)
         )
@@ -97,7 +109,10 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
 
       "parse it successfully in case of a GTE selection" in {
         TimeRangeManager.extractTimeRange(
-          Some(ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 10L))
+          Some(
+            ComparisonExpression(dimension = "timestamp",
+                                 comparison = GreaterOrEqualToOperator,
+                                 value = AbsoluteComparisonValue(10L)))
         ) shouldBe List(
           Interval.fromBounds(Closed(10L), Unbound())
         )
@@ -107,10 +122,13 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
         TimeRangeManager.extractTimeRange(
           Some(
             TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp", comparison = GreaterThanOperator, value = 2L),
+              expression1 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterThanOperator,
+                                                 value = AbsoluteComparisonValue(2L)),
               operator = AndOperator,
-              expression2 =
-                ComparisonExpression(dimension = "timestamp", comparison = LessOrEqualToOperator, value = 4l)
+              expression2 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = LessOrEqualToOperator,
+                                                 value = AbsoluteComparisonValue(4L))
             )
           )) shouldBe List(
           Interval.openLower(2, 4)
@@ -121,7 +139,9 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
         TimeRangeManager.extractTimeRange(
           Some(
             UnaryLogicalExpression(
-              expression = ComparisonExpression(dimension = "timestamp", comparison = GreaterThanOperator, value = 2L),
+              expression = ComparisonExpression(dimension = "timestamp",
+                                                comparison = GreaterThanOperator,
+                                                value = AbsoluteComparisonValue(2L)),
               operator = NotOperator
             )
           )) shouldBe List(
@@ -131,7 +151,7 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
         TimeRangeManager.extractTimeRange(
           Some(
             UnaryLogicalExpression(
-              expression = RangeExpression("timestamp", 2L, 4L),
+              expression = RangeExpression("timestamp", AbsoluteComparisonValue(2L), AbsoluteComparisonValue(4L)),
               operator = NotOperator
             )
           )) shouldBe List(
@@ -145,10 +165,13 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
           Some(
             UnaryLogicalExpression(
               expression = TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
                 operator = OrOperator,
-                expression2 = ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = 4L)
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessThanOperator,
+                                                   value = AbsoluteComparisonValue(4L))
               ),
               operator = NotOperator
             )
@@ -163,10 +186,11 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
         TimeRangeManager.extractTimeRange(
           Some(
             TupledLogicalExpression(
-              expression1 =
-                ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+              expression1 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterOrEqualToOperator,
+                                                 value = AbsoluteComparisonValue(2L)),
               operator = OrOperator,
-              expression2 = EqualityExpression(dimension = "name", value = "john")
+              expression2 = EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("john"))
             )
           )) shouldBe List(
           Interval.fromBounds(Closed(2l), Unbound())
@@ -175,10 +199,11 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
         TimeRangeManager.extractTimeRange(
           Some(
             TupledLogicalExpression(
-              expression1 =
-                ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+              expression1 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterOrEqualToOperator,
+                                                 value = AbsoluteComparisonValue(2L)),
               operator = AndOperator,
-              expression2 = EqualityExpression(dimension = "name", value = "john")
+              expression2 = EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("john"))
             )
           )) shouldBe List(
           Interval.fromBounds(Closed(2L), Unbound())
@@ -210,7 +235,11 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
           10L,
           0L,
           5L,
-          Some(Condition(RangeExpression(dimension = "timestamp", value1 = 0L, value2 = 5L))))
+          Some(
+            Condition(
+              RangeExpression(dimension = "timestamp",
+                              value1 = AbsoluteComparisonValue(0L),
+                              value2 = AbsoluteComparisonValue(5L)))))
         res shouldBe Seq(TimeRange(0, 5, true, true))
       }
 
@@ -221,7 +250,9 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
           5L,
           Some(
             Condition(
-              ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 50L))))
+              ComparisonExpression(dimension = "timestamp",
+                                   comparison = GreaterOrEqualToOperator,
+                                   value = AbsoluteComparisonValue(50L)))))
 
         res shouldBe Seq(
           TimeRange(95, 100, false, true),
@@ -243,7 +274,10 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
           0L,
           5L,
           Some(
-            Condition(ComparisonExpression(dimension = "timestamp", comparison = LessOrEqualToOperator, value = 50L))))
+            Condition(
+              ComparisonExpression(dimension = "timestamp",
+                                   comparison = LessOrEqualToOperator,
+                                   value = AbsoluteComparisonValue(50L)))))
 
         res shouldBe Seq(
           TimeRange(45, 50, false, true),
@@ -266,9 +300,13 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
           5L,
           Some(
             Condition(TupledLogicalExpression(
-              ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 70L),
+              ComparisonExpression(dimension = "timestamp",
+                                   comparison = GreaterOrEqualToOperator,
+                                   value = AbsoluteComparisonValue(70L)),
               AndOperator,
-              ComparisonExpression(dimension = "timestamp", comparison = LessOrEqualToOperator, value = 90L)
+              ComparisonExpression(dimension = "timestamp",
+                                   comparison = LessOrEqualToOperator,
+                                   value = AbsoluteComparisonValue(90L))
             )))
         )
 
@@ -287,9 +325,13 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
           5L,
           Some(
             Condition(TupledLogicalExpression(
-              ComparisonExpression(dimension = "timestamp", comparison = GreaterThanOperator, value = 70L),
+              ComparisonExpression(dimension = "timestamp",
+                                   comparison = GreaterThanOperator,
+                                   value = AbsoluteComparisonValue(70L)),
               AndOperator,
-              ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = 90L)
+              ComparisonExpression(dimension = "timestamp",
+                                   comparison = LessThanOperator,
+                                   value = AbsoluteComparisonValue(90L))
             )))
         )
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/actor/FakeReadCoordinator.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/actor/FakeReadCoordinator.scala
@@ -57,7 +57,7 @@ class FakeReadCoordinator extends Actor {
         Schema("metric", bits.head).getOrElse(Schema("metric", Map.empty[String, SchemaField]))) match {
         case Right(_) =>
           val e = statement.condition.get.expression.asInstanceOf[RangeExpression[Long]]
-          sender ! SelectStatementExecuted(statement, bitsParametrized(e.value1, e.value2))
+          sender ! SelectStatementExecuted(statement, bitsParametrized(e.value1.value, e.value2.value))
         case Left(_) => sender ! SelectStatementFailed(statement, "statement not valid")
       }
     case ExecuteStatement(statement) =>

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryEnrichmentTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryEnrichmentTest.scala
@@ -40,15 +40,17 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
-          SelectSQLStatement("db",
-                             "namespace",
-                             "people",
-                             false,
-                             ListFields(List(Field("name", None))),
-                             Some(Condition(EqualityExpression("age", 1L))),
-                             None,
-                             None,
-                             Some(LimitOperator(1)))
+          SelectSQLStatement(
+            "db",
+            "namespace",
+            "people",
+            false,
+            ListFields(List(Field("name", None))),
+            Some(Condition(EqualityExpression("age", AbsoluteComparisonValue(1L)))),
+            None,
+            None,
+            Some(LimitOperator(1))
+          )
       }
       "be correctly converted with GT operator" in {
         val filters = Seq(FilterByValue("age", 1L, FilterOperators.GreaterThan))
@@ -71,7 +73,7 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
             "people",
             false,
             ListFields(List(Field("name", None))),
-            Some(Condition(ComparisonExpression("age", GreaterThanOperator, 1L))),
+            Some(Condition(ComparisonExpression("age", GreaterThanOperator, AbsoluteComparisonValue(1L)))),
             None,
             None,
             Some(LimitOperator(1))
@@ -98,7 +100,7 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
             "people",
             false,
             ListFields(List(Field("name", None))),
-            Some(Condition(ComparisonExpression("age", GreaterOrEqualToOperator, 1L))),
+            Some(Condition(ComparisonExpression("age", GreaterOrEqualToOperator, AbsoluteComparisonValue(1L)))),
             None,
             None,
             Some(LimitOperator(1))
@@ -125,7 +127,7 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
             "people",
             false,
             ListFields(List(Field("name", None))),
-            Some(Condition(ComparisonExpression("age", LessThanOperator, 1L))),
+            Some(Condition(ComparisonExpression("age", LessThanOperator, AbsoluteComparisonValue(1L)))),
             None,
             None,
             Some(LimitOperator(1))
@@ -152,7 +154,7 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
             "people",
             false,
             ListFields(List(Field("name", None))),
-            Some(Condition(ComparisonExpression("age", LessOrEqualToOperator, 1L))),
+            Some(Condition(ComparisonExpression("age", LessOrEqualToOperator, AbsoluteComparisonValue(1L)))),
             None,
             None,
             Some(LimitOperator(1))
@@ -182,7 +184,7 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
             "people",
             false,
             ListFields(List(Field("name", None))),
-            Some(Condition(EqualityExpression("surname", "Poe"))),
+            Some(Condition(EqualityExpression("surname", AbsoluteComparisonValue("Poe")))),
             None,
             None,
             Some(LimitOperator(1))
@@ -240,8 +242,11 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
             "people",
             false,
             ListFields(List(Field("name", None))),
-            Some(Condition(
-              TupledLogicalExpression(EqualityExpression("age", 1L), AndOperator, EqualityExpression("height", 100L)))),
+            Some(
+              Condition(
+                TupledLogicalExpression(EqualityExpression("age", AbsoluteComparisonValue(1L)),
+                                        AndOperator,
+                                        EqualityExpression("height", AbsoluteComparisonValue(100L))))),
             None,
             None,
             Some(LimitOperator(1))
@@ -256,7 +261,7 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
           "people",
           false,
           ListFields(List(Field("name", None))),
-          Some(Condition(EqualityExpression("surname", "poe"))),
+          Some(Condition(EqualityExpression("surname", AbsoluteComparisonValue("poe")))),
           None,
           None,
           Some(LimitOperator(1))
@@ -274,12 +279,12 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
             Some(
               Condition(
                 TupledLogicalExpression(
-                  EqualityExpression("surname", "poe"),
+                  EqualityExpression("surname", AbsoluteComparisonValue("poe")),
                   AndOperator,
                   TupledLogicalExpression(
-                    EqualityExpression("age", 1L),
+                    EqualityExpression("age", AbsoluteComparisonValue(1L)),
                     AndOperator,
-                    EqualityExpression("height", 100L)
+                    EqualityExpression("height", AbsoluteComparisonValue(100L))
                   )
                 )
               )),
@@ -319,9 +324,9 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
                   LikeExpression("surname", "poe"),
                   AndOperator,
                   TupledLogicalExpression(
-                    ComparisonExpression("age", GreaterThanOperator, 1L),
+                    ComparisonExpression("age", GreaterThanOperator, AbsoluteComparisonValue(1L)),
                     AndOperator,
-                    ComparisonExpression("height", LessOrEqualToOperator, 100L)
+                    ComparisonExpression("height", LessOrEqualToOperator, AbsoluteComparisonValue(100L))
                   )
                 )
               )),
@@ -340,8 +345,11 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
           "people",
           false,
           ListFields(List(Field("name", None))),
-          Some(Condition(
-            TupledLogicalExpression(LikeExpression("surname", "poe"), OrOperator, EqualityExpression("number", 1.0)))),
+          Some(
+            Condition(
+              TupledLogicalExpression(LikeExpression("surname", "poe"),
+                                      OrOperator,
+                                      EqualityExpression("number", AbsoluteComparisonValue(1.0))))),
           None,
           None,
           Some(LimitOperator(1))
@@ -361,12 +369,12 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
                 TupledLogicalExpression(
                   TupledLogicalExpression(LikeExpression("surname", "poe"),
                                           OrOperator,
-                                          EqualityExpression("number", 1.0)),
+                                          EqualityExpression("number", AbsoluteComparisonValue(1.0))),
                   AndOperator,
                   TupledLogicalExpression(
-                    ComparisonExpression("age", GreaterThanOperator, 1L),
+                    ComparisonExpression("age", GreaterThanOperator, AbsoluteComparisonValue(1L)),
                     AndOperator,
-                    ComparisonExpression("height", LessOrEqualToOperator, 100L)
+                    ComparisonExpression("height", LessOrEqualToOperator, AbsoluteComparisonValue(100L))
                   )
                 )
               )),
@@ -389,7 +397,8 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
             Condition(
               TupledLogicalExpression(LikeExpression("surname", "poe"),
                                       OrOperator,
-                                      UnaryLogicalExpression(EqualityExpression("number", 1.0), NotOperator)))),
+                                      UnaryLogicalExpression(EqualityExpression("number", AbsoluteComparisonValue(1.0)),
+                                                             NotOperator)))),
           None,
           None,
           Some(LimitOperator(1))
@@ -407,14 +416,15 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
             Some(
               Condition(
                 TupledLogicalExpression(
-                  TupledLogicalExpression(LikeExpression("surname", "poe"),
-                                          OrOperator,
-                                          UnaryLogicalExpression(EqualityExpression("number", 1.0), NotOperator)),
+                  TupledLogicalExpression(
+                    LikeExpression("surname", "poe"),
+                    OrOperator,
+                    UnaryLogicalExpression(EqualityExpression("number", AbsoluteComparisonValue(1.0)), NotOperator)),
                   AndOperator,
                   TupledLogicalExpression(
-                    ComparisonExpression("age", GreaterThanOperator, 1L),
+                    ComparisonExpression("age", GreaterThanOperator, AbsoluteComparisonValue(1L)),
                     AndOperator,
-                    ComparisonExpression("height", LessOrEqualToOperator, 100L)
+                    ComparisonExpression("height", LessOrEqualToOperator, AbsoluteComparisonValue(100L))
                   )
                 )
               )),

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -129,9 +129,9 @@ final class SQLStatementParser extends RegexParsers with PackratParsers {
   // more than one "now - something" in the same query because "now" will be different for each condition
   private def delta: Parser[RelativeTimestampValue] = now ~> ("+" | "-") ~ longValue ~ timeMeasure ^^ {
     case "+" ~ v ~ ((unitMeasure, timeInterval)) =>
-      RelativeTimestampValue(System.currentTimeMillis() + v * timeInterval, v, unitMeasure)
+      RelativeTimestampValue(System.currentTimeMillis() + v * timeInterval, "+", v, unitMeasure)
     case "-" ~ v ~ ((unitMeasure, timeInterval)) =>
-      RelativeTimestampValue(System.currentTimeMillis() - v * timeInterval, v, unitMeasure)
+      RelativeTimestampValue(System.currentTimeMillis() - v * timeInterval, "-", v, unitMeasure)
   }
 
   private val comparisonTerm = delta | floatValue | longValue

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -135,8 +135,8 @@ final class SQLStatementParser extends RegexParsers with PackratParsers {
       RelativeComparisonValue(System.currentTimeMillis() - v * timeInterval, "-", v, unitMeasure)
   }
 
-  private val comparisonTerm =
-    delta | floatValue.map(AbsoluteComparisonValue(_)) | longValue.map(AbsoluteComparisonValue(_))
+  private val comparisonTerm = delta | floatValue.map(AbsoluteComparisonValue(_)) | longValue.map(
+    AbsoluteComparisonValue(_))
 
   private val selectFields = (Distinct ?) ~ (All | aggField | field) ~ rep(Comma ~> (aggField | field)) ^^ {
     case _ ~ f ~ fs =>
@@ -160,7 +160,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers {
 
   // Please don't change the order of the expressions, can cause infinite recursions
   private lazy val expression: PackratParser[Expression] =
-    unaryLogicalExpression | tupledLogicalExpression | nullableExpression | rangeExpression | comparisonExpression | equalityExpression | likeExpression | bracketedExpression
+    unaryLogicalExpression | tupledLogicalExpression | nullableExpression | rangeExpression | comparisonExpressionRule | equalityExpression | likeExpression | bracketedExpression
 
   private lazy val bracketedExpression: PackratParser[Expression] = OpenRoundBracket ~> expression <~ CloseRoundBracket
 
@@ -200,10 +200,10 @@ final class SQLStatementParser extends RegexParsers with PackratParsers {
       case dim ~ None ~ _    => NullableExpression(dim)
     }
 
-  lazy val comparisonExpression =
-    comparisonExpressionGT | comparisonExpressionGTE | comparisonExpressionLT | comparisonExpressionLTE
+  lazy val comparisonExpressionRule = comparisonExpressionGT | comparisonExpressionGTE | comparisonExpressionLT | comparisonExpressionLTE
 
-  private def comparisonExpression(operator: String, comparisonOperator: ComparisonOperator) =
+  private def comparisonExpression(operator: String,
+                                   comparisonOperator: ComparisonOperator): Parser[ComparisonExpression[AnyVal]] =
     (dimension <~ operator) ~ comparisonTerm ^^ {
       case d ~ v =>
         ComparisonExpression(d, comparisonOperator, v)

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -119,10 +119,10 @@ final class SQLStatementParser extends RegexParsers with PackratParsers {
 
   private val timeMeasure = ("d".ignoreCase | "h".ignoreCase | "m".ignoreCase | "s".ignoreCase)
     .map(_.toUpperCase()) ^^ {
-    case "D" => ("D", 24 * 3600 * 1000)
-    case "H" => ("H", 3600 * 1000)
-    case "M" => ("M", 60 * 1000)
-    case "S" => ("S", 1000)
+    case "D" => ("d", 24 * 3600 * 1000)
+    case "H" => ("h", 3600 * 1000)
+    case "M" => ("m", 60 * 1000)
+    case "S" => ("s", 1000)
   }
 
   // def instead val because timestamp should be calculated everytime but there is a problem with

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -101,8 +101,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers {
   private val numbers          = """([0-9]+)""".r
   private val intValue         = numbers ^^ { _.toInt }
   private val longValue        = numbers ^^ { _.toLong }
-  //TODO evaluate to change this name into something more consistent to its actual type
-  private val floatValue = """([0-9]+)\.([0-9]+)""".r ^^ { _.toDouble }
+  private val doubleValue      = """([0-9]+)\.([0-9]+)""".r ^^ { _.toDouble }
 
   private val field = digits ^^ { e =>
     Field(e, None)
@@ -135,7 +134,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers {
       RelativeComparisonValue(System.currentTimeMillis() - v * timeInterval, "-", v, unitMeasure)
   }
 
-  private val comparisonTerm = delta | floatValue.map(AbsoluteComparisonValue(_)) | longValue.map(
+  private val comparisonTerm = delta | doubleValue.map(AbsoluteComparisonValue(_)) | longValue.map(
     AbsoluteComparisonValue(_))
 
   private val selectFields = (Distinct ?) ~ (All | aggField | field) ~ rep(Comma ~> (aggField | field)) ^^ {
@@ -148,9 +147,9 @@ final class SQLStatementParser extends RegexParsers with PackratParsers {
 
   private val timestampAssignment = (Ts ~ Equal) ~> longValue
 
-  private val valueAssignment = (Val ~ Equal) ~> (floatValue | longValue)
+  private val valueAssignment = (Val ~ Equal) ~> (doubleValue | longValue)
 
-  private val assignment = (dimension <~ Equal) ~ (stringValue | floatValue | intValue) ^^ {
+  private val assignment = (dimension <~ Equal) ~ (stringValue | doubleValue | intValue) ^^ {
     case k ~ v => k -> v.asInstanceOf[JSerializable]
   }
 

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -234,8 +234,8 @@ final class SQLStatementParser extends RegexParsers with PackratParsers {
 
   lazy val temporalGroupBy
     : PackratParser[GroupByAggregation] = (group ~> temporalInterval ~> (intValue ?) ~ timeMeasure) ^^ {
-    case unit ~ conversion =>
-      TemporalGroupByAggregation(unit.getOrElse(1) * conversion._2, unit.getOrElse(1).toLong, conversion._1)
+    case unit ~ ((timeMeasure, quantity)) =>
+      TemporalGroupByAggregation(unit.getOrElse(1) * quantity, unit.getOrElse(1).toLong, timeMeasure)
   }
 
   lazy val order: PackratParser[OrderOperator] = (Order ~> dimension ~ (Desc ?)) ^^ {

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -234,7 +234,8 @@ final class SQLStatementParser extends RegexParsers with PackratParsers {
 
   lazy val temporalGroupBy
     : PackratParser[GroupByAggregation] = (group ~> temporalInterval ~> (intValue ?) ~ timeMeasure) ^^ {
-    case unit ~ conversion => TemporalGroupByAggregation(unit.getOrElse(1) * conversion._2)
+    case unit ~ conversion =>
+      TemporalGroupByAggregation(unit.getOrElse(1) * conversion._2, unit.getOrElse(1).toLong, conversion._1)
   }
 
   lazy val order: PackratParser[OrderOperator] = (Order ~> dimension ~ (Desc ?)) ^^ {

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -125,7 +125,9 @@ final class SQLStatementParser extends RegexParsers with PackratParsers {
     case "S" => ("S", 1000)
   }
 
-  private val delta: Parser[RelativeTimestampValue] = now ~> ("+" | "-") ~ longValue ~ timeMeasure ^^ {
+  // def instead val because timestamp should be calculated everytime but there is a problem with
+  // more than one "now - something" in the same query because "now" will be different for each condition
+  private def delta: Parser[RelativeTimestampValue] = now ~> ("+" | "-") ~ longValue ~ timeMeasure ^^ {
     case "+" ~ v ~ ((unitMeasure, timeInterval)) =>
       RelativeTimestampValue(System.currentTimeMillis() + v * timeInterval, v, unitMeasure)
     case "-" ~ v ~ ((unitMeasure, timeInterval)) =>

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
@@ -237,7 +237,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               fields = ListFields(List(Field("value", Some(CountAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(3000))
+              groupBy = Some(TemporalGroupByAggregation(3000, 3, "s"))
             )
           ))
       }
@@ -253,7 +253,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               fields = ListFields(List(Field("value", Some(CountAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(60000))
+              groupBy = Some(TemporalGroupByAggregation(60000, 1, "m"))
             )
           ))
       }
@@ -269,7 +269,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
           metric = "people",
           distinct = false,
           fields = ListFields(List(Field("value", Some(CountAggregation)))),
-          groupBy = Some(TemporalGroupByAggregation(86400000)),
+          groupBy = Some(TemporalGroupByAggregation(86400000, 1, "d")),
           limit = Some(LimitOperator(1))
         )))
     }
@@ -294,7 +294,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(CountAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000))
+              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, "d"))
             )
           ))
       }
@@ -318,7 +318,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(CountAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000))
+              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, "d"))
             )
           ))
       }
@@ -342,7 +342,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(SumAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000))
+              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, "d"))
             )
           ))
       }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
@@ -80,7 +80,9 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("value", Some(CountAggregation)))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 4L))),
+            condition = Some(Condition(RangeExpression(dimension = "timestamp",
+                                                       value1 = AbsoluteComparisonValue(2L),
+                                                       value2 = AbsoluteComparisonValue(4L)))),
             groupBy = Some(SimpleGroupByAggregation("name"))
           )))
       }
@@ -97,8 +99,9 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("value", Some(MinAggregation)))),
-            condition = Some(Condition(
-              ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 10L))),
+            condition = Some(Condition(ComparisonExpression(dimension = "timestamp",
+                                                            comparison = GreaterOrEqualToOperator,
+                                                            value = AbsoluteComparisonValue(10)))),
             groupBy = Some(SimpleGroupByAggregation("name"))
           )))
       }
@@ -117,10 +120,13 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("value", Some(MaxAggregation)))),
             condition = Some(Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp", comparison = GreaterThanOperator, value = 2L),
+              expression1 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterThanOperator,
+                                                 value = AbsoluteComparisonValue(2L)),
               operator = AndOperator,
-              expression2 =
-                ComparisonExpression(dimension = "timestamp", comparison = LessOrEqualToOperator, value = 4l)
+              expression2 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = LessOrEqualToOperator,
+                                                 value = AbsoluteComparisonValue(4L))
             ))),
             groupBy = Some(SimpleGroupByAggregation("name"))
           )))
@@ -177,8 +183,9 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("value", Some(CountAggregation)))),
             condition = Some(Condition(TupledLogicalExpression(
-              expression1 = EqualityExpression(dimension = "name", value = "b483a480-832b-473e-a999-5d1a5950858d"),
-              expression2 = EqualityExpression(dimension = "surname", value = "b483a480-832b"),
+              expression1 = EqualityExpression(dimension = "name",
+                                               value = AbsoluteComparisonValue("b483a480-832b-473e-a999-5d1a5950858d")),
+              expression2 = EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("b483a480-832b")),
               operator = AndOperator
             ))),
             groupBy = Some(SimpleGroupByAggregation("surname"))
@@ -209,11 +216,14 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
             fields = ListFields(List(Field("value", Some(CountAggregation)))),
             condition = Some(Condition(
               TupledLogicalExpression(
-                EqualityExpression("prediction", 1.0),
+                EqualityExpression(dimension = "prediction", value = AbsoluteComparisonValue(1.0)),
                 AndOperator,
-                TupledLogicalExpression(EqualityExpression("adoptedModel", "b483a480-832b-473e-a999-5d1a5950858d"),
-                                        AndOperator,
-                                        EqualityExpression("id", "c1234-56789"))
+                TupledLogicalExpression(
+                  EqualityExpression(dimension = "adoptedModel",
+                                     value = AbsoluteComparisonValue("b483a480-832b-473e-a999-5d1a5950858d")),
+                  AndOperator,
+                  EqualityExpression(dimension = "id", AbsoluteComparisonValue("c1234-56789"))
+                )
               )
             )),
             groupBy = Some(SimpleGroupByAggregation("id"))
@@ -287,10 +297,12 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               condition = Some(Condition(TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression[Long](dimension = "timestamp", comparison = GreaterThanOperator, value = 1),
-                expression2 =
-                  ComparisonExpression[Long](dimension = "timestamp", comparison = LessThanOperator, value = 100),
+                expression1 = ComparisonExpression[Long](dimension = "timestamp",
+                                                         comparison = GreaterThanOperator,
+                                                         value = AbsoluteComparisonValue(1)),
+                expression2 = ComparisonExpression[Long](dimension = "timestamp",
+                                                         comparison = LessThanOperator,
+                                                         value = AbsoluteComparisonValue(100)),
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(CountAggregation)))),
@@ -311,10 +323,12 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               condition = Some(Condition(TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression[Long](dimension = "timestamp", comparison = GreaterThanOperator, value = 1),
-                expression2 =
-                  ComparisonExpression[Long](dimension = "timestamp", comparison = LessThanOperator, value = 100),
+                expression1 = ComparisonExpression[Long](dimension = "timestamp",
+                                                         comparison = GreaterThanOperator,
+                                                         value = AbsoluteComparisonValue(1)),
+                expression2 = ComparisonExpression[Long](dimension = "timestamp",
+                                                         comparison = LessThanOperator,
+                                                         value = AbsoluteComparisonValue(100)),
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(CountAggregation)))),
@@ -335,10 +349,12 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               condition = Some(Condition(TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression[Long](dimension = "timestamp", comparison = GreaterThanOperator, value = 1),
-                expression2 =
-                  ComparisonExpression[Long](dimension = "timestamp", comparison = LessThanOperator, value = 100),
+                expression1 = ComparisonExpression[Long](dimension = "timestamp",
+                                                         comparison = GreaterThanOperator,
+                                                         value = AbsoluteComparisonValue(1)),
+                expression2 = ComparisonExpression[Long](dimension = "timestamp",
+                                                         comparison = LessThanOperator,
+                                                         value = AbsoluteComparisonValue(100)),
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(SumAggregation)))),

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
@@ -36,24 +36,26 @@ class DeleteSQLStatementSpec extends WordSpec with Matchers {
     "receive a delete containing a range selection" should {
       "parse it successfully" in {
         parser.parse(db = "db", namespace = "registry", input = "delete FROM people WHERE timestamp IN (2,4)") should be(
-          Success(
-            DeleteSQLStatement(
-              db = "db",
-              namespace = "registry",
-              metric = "people",
-              condition = Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 4L))
-            )))
+          Success(DeleteSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            condition = Condition(RangeExpression(dimension = "timestamp",
+                                                  value1 = AbsoluteComparisonValue(2L),
+                                                  value2 = AbsoluteComparisonValue(4L)))
+          )))
       }
 
       "parse it successfully ignoring case" in {
         parser.parse(db = "db", namespace = "registry", input = "delete FrOm people where timestamp in (2,4)") should be(
-          Success(
-            DeleteSQLStatement(
-              db = "db",
-              namespace = "registry",
-              metric = "people",
-              condition = Condition(RangeExpression(dimension = "timestamp", value1 = 2, value2 = 4))
-            )))
+          Success(DeleteSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            condition = Condition(RangeExpression(dimension = "timestamp",
+                                                  value1 = AbsoluteComparisonValue(2),
+                                                  value2 = AbsoluteComparisonValue(4)))
+          )))
       }
     }
 
@@ -64,8 +66,9 @@ class DeleteSQLStatementSpec extends WordSpec with Matchers {
             db = "db",
             namespace = "registry",
             metric = "people",
-            condition = Condition(
-              ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 10L))
+            condition = Condition(ComparisonExpression(dimension = "timestamp",
+                                                       comparison = GreaterOrEqualToOperator,
+                                                       value = AbsoluteComparisonValue(10L)))
           )))
       }
     }
@@ -80,10 +83,13 @@ class DeleteSQLStatementSpec extends WordSpec with Matchers {
             namespace = "registry",
             metric = "people",
             condition = Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp", comparison = GreaterThanOperator, value = 2L),
+              expression1 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterThanOperator,
+                                                 value = AbsoluteComparisonValue(2L)),
               operator = AndOperator,
-              expression2 =
-                ComparisonExpression(dimension = "timestamp", comparison = LessOrEqualToOperator, value = 4l)
+              expression2 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = LessOrEqualToOperator,
+                                                 value = AbsoluteComparisonValue(4L))
             ))
           )))
       }
@@ -100,10 +106,13 @@ class DeleteSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             condition = Condition(UnaryLogicalExpression(
               expression = TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
                 operator = OrOperator,
-                expression2 = ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = 4L)
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessThanOperator,
+                                                   value = AbsoluteComparisonValue(4L))
               ),
               operator = NotOperator
             ))

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.sql.parser
+
+import io.radicalbit.nsdb.common.statement._
+import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.TryValues._
+import org.scalatest.OptionValues._
+
+class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
+
+  private val parser = new SQLStatementParser
+
+  private val seconds = 1000L
+  private val minutes = 60 * seconds
+  private val hours = 60 * minutes
+  private val days = 24 * hours
+
+  private val timestampTolerance = 100L
+
+  "A SQL parser instance" when {
+
+    "receive a select with a relative timestamp value" should {
+
+      "parse it successfully using relative time in simple where equality condition" in {
+        val statement =
+          parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp = now - 10s")
+        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val expression =
+          selectSQLStatement.condition.value.expression.asInstanceOf[EqualityExpression[RelativeTimestampValue]]
+
+        val now = System.currentTimeMillis()
+
+        expression.value.timestamp shouldBe now - 10 * seconds +- timestampTolerance
+        expression.value.quantity shouldBe 10
+        expression.value.unitMeasure shouldBe "S"
+      }
+
+      "parse it successfully relative time in simple where comparison condition" in {
+        val statement =
+          parser.parse(db = "db",
+                       namespace = "registry",
+                       input = "SELECT name FROM people WHERE timestamp >= now - 10s")
+
+        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val expression =
+          selectSQLStatement.condition.value.expression.asInstanceOf[ComparisonExpression[RelativeTimestampValue]]
+
+        val now = System.currentTimeMillis()
+        expression.value.timestamp shouldBe now - 10 * seconds +- timestampTolerance
+        expression.value.quantity shouldBe 10
+        expression.value.unitMeasure shouldBe "S"
+      }
+
+      "parse it successfully using relative time in complex where condition" in {
+
+        val statement = parser.parse(db = "db",
+                                     namespace = "registry",
+                                     input =
+                                       "SELECT name FROM people WHERE timestamp < now + 5s and timestamp > now - 8d")
+        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
+
+        val now = System.currentTimeMillis()
+
+        val firstTimestamp  = expression.expression1.asInstanceOf[ComparisonExpression[RelativeTimestampValue]].value
+        val secondTimestamp = expression.expression2.asInstanceOf[ComparisonExpression[RelativeTimestampValue]].value
+
+        firstTimestamp.timestamp shouldBe now + 5 * seconds +- timestampTolerance
+        firstTimestamp.quantity shouldBe 5
+        firstTimestamp.unitMeasure shouldBe "S"
+
+        secondTimestamp.timestamp shouldBe now - 8 * days +- timestampTolerance
+        secondTimestamp.quantity shouldBe 8
+        secondTimestamp.unitMeasure shouldBe "D"
+      }
+
+      "parse it successfully using relative time in very complex where condition" in {
+
+        val statement = parser.parse(
+          db = "db",
+          namespace = "registry",
+          input =
+            "SELECT name FROM people WHERE timestamp < now + 30d and timestamp > now - 2h AND timestamp = now + 4m")
+        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
+
+        val now = System.currentTimeMillis()
+
+        val firstTimestamp   = expression.expression1.asInstanceOf[ComparisonExpression[RelativeTimestampValue]].value
+        val secondExpression = expression.expression2.asInstanceOf[TupledLogicalExpression]
+        val secondTimestamp =
+          secondExpression.expression1.asInstanceOf[ComparisonExpression[RelativeTimestampValue]].value
+        val thirdTimestamp = secondExpression.expression2.asInstanceOf[EqualityExpression[RelativeTimestampValue]].value
+
+        firstTimestamp.timestamp shouldBe now + 30 * days +- timestampTolerance
+        firstTimestamp.quantity shouldBe 30
+        firstTimestamp.unitMeasure shouldBe "D"
+
+        secondTimestamp.timestamp shouldBe now - 2 * hours +- timestampTolerance
+        secondTimestamp.quantity shouldBe 2
+        secondTimestamp.unitMeasure shouldBe "H"
+
+        thirdTimestamp.timestamp shouldBe now + 4 * minutes +- timestampTolerance
+        thirdTimestamp.quantity shouldBe 4
+        thirdTimestamp.unitMeasure shouldBe "M"
+      }
+
+      "parse it successfully using relative time in very complex where condition with brackets" in {
+
+        val statement = parser.parse(
+          db = "db",
+          namespace = "registry",
+          input =
+            "SELECT name FROM people WHERE (timestamp < now + 30d and timestamp > now - 2h) or timestamp = now + 4m")
+        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
+
+        val thirdTimestamp = expression.expression2.asInstanceOf[EqualityExpression[RelativeTimestampValue]].value
+
+        println(expression)
+
+        val now = System.currentTimeMillis()
+
+        val secondExpression = expression.expression1.asInstanceOf[TupledLogicalExpression]
+        val firstTimestamp =
+          secondExpression.expression1.asInstanceOf[ComparisonExpression[RelativeTimestampValue]].value
+        val secondTimestamp =
+          secondExpression.expression2.asInstanceOf[ComparisonExpression[RelativeTimestampValue]].value
+
+        firstTimestamp.timestamp shouldBe now + 30 * days +- timestampTolerance
+        firstTimestamp.quantity shouldBe 30
+        firstTimestamp.unitMeasure shouldBe "D"
+
+        secondTimestamp.timestamp shouldBe now - 2 * hours +- timestampTolerance
+        secondTimestamp.quantity shouldBe 2
+        secondTimestamp.unitMeasure shouldBe "H"
+
+        thirdTimestamp.timestamp shouldBe now + 4 * minutes +- timestampTolerance
+        thirdTimestamp.quantity shouldBe 4
+        thirdTimestamp.unitMeasure shouldBe "M"
+      }
+
+      "parse it successfully with a relative timestamp range condition" in {
+        val statement = parser.parse(db = "db",
+                                     namespace = "registry",
+                                     input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, now + 4 s)")
+
+        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val expression =
+          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[RelativeTimestampValue]]
+
+        val now = System.currentTimeMillis()
+        expression.dimension shouldBe "timestamp"
+        expression.value1.timestamp shouldBe now - 2 * seconds +- timestampTolerance
+        expression.value1.quantity shouldBe 2
+        expression.value1.unitMeasure shouldBe "S"
+        expression.value2.timestamp shouldBe now + 4 * seconds +- timestampTolerance
+        expression.value2.quantity shouldBe 4
+        expression.value2.unitMeasure shouldBe "S"
+      }
+
+      "parse it successfully with a relative timestamp range condition with unnecessary brackets" in {
+        val statement = parser.parse(db = "db",
+                                     namespace = "registry",
+                                     input = "SELECT name FROM people WHERE (timestamp IN (now - 2 s, now + 4 s))")
+
+        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val expression =
+          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[RelativeTimestampValue]]
+
+        val now = System.currentTimeMillis()
+        expression.dimension shouldBe "timestamp"
+        expression.value1.timestamp shouldBe now - 2 * seconds +- timestampTolerance
+        expression.value1.quantity shouldBe 2
+        expression.value1.unitMeasure shouldBe "S"
+        expression.value2.timestamp shouldBe now + 4 * seconds +- timestampTolerance
+        expression.value2.quantity shouldBe 4
+        expression.value2.unitMeasure shouldBe "S"
+      }
+
+      "parse it successfully with a mixed relative/absolute timestamp range condition" in {
+        val statement = parser.parse(db = "db",
+                                     namespace = "registry",
+                                     input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, 5)")
+
+        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val expression =
+          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[RelativeTimestampValue]]
+
+        val now = System.currentTimeMillis()
+        expression.dimension shouldBe "timestamp"
+        expression.value1.timestamp shouldBe now - 2 * seconds +- timestampTolerance
+        expression.value1.quantity shouldBe 2
+        expression.value1.unitMeasure shouldBe "S"
+        expression.value2 shouldBe 5
+      }
+
+    }
+
+  }
+
+}

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
@@ -44,11 +44,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
         val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
         val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[EqualityExpression[RelativeTimestampValue]]
+          selectSQLStatement.condition.value.expression.asInstanceOf[EqualityExpression[_]]
 
-        val firstTimestamp = expression.value
+        val firstTimestamp = expression.value.asInstanceOf[RelativeComparisonValue[Long]]
 
-        firstTimestamp.timestamp shouldBe now - 10 * seconds +- timestampTolerance
+        firstTimestamp.value shouldBe now - 10 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 10
         firstTimestamp.unitMeasure shouldBe "s"
@@ -65,11 +65,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
         val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
         val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[ComparisonExpression[RelativeTimestampValue]]
+          selectSQLStatement.condition.value.expression.asInstanceOf[ComparisonExpression[_]]
 
-        val firstTimestamp = expression.value
+        val firstTimestamp = expression.value.asInstanceOf[RelativeComparisonValue[Long]]
 
-        firstTimestamp.timestamp shouldBe now - 10 * seconds +- timestampTolerance
+        firstTimestamp.value shouldBe now - 10 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 10
         firstTimestamp.unitMeasure shouldBe "s"
@@ -87,15 +87,17 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
         val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
 
-        val firstTimestamp  = expression.expression1.asInstanceOf[ComparisonExpression[RelativeTimestampValue]].value
-        val secondTimestamp = expression.expression2.asInstanceOf[ComparisonExpression[RelativeTimestampValue]].value
+        val firstTimestamp =
+          expression.expression1.asInstanceOf[ComparisonExpression[_]].value.asInstanceOf[RelativeComparisonValue[Long]]
+        val secondTimestamp =
+          expression.expression2.asInstanceOf[ComparisonExpression[_]].value.asInstanceOf[RelativeComparisonValue[Long]]
 
-        firstTimestamp.timestamp shouldBe now + 5 * seconds +- timestampTolerance
+        firstTimestamp.value shouldBe now + 5 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "+"
         firstTimestamp.quantity shouldBe 5
         firstTimestamp.unitMeasure shouldBe "s"
 
-        secondTimestamp.timestamp shouldBe now - 8 * days +- timestampTolerance
+        secondTimestamp.value shouldBe now - 8 * days +- timestampTolerance
         secondTimestamp.operator shouldBe "-"
         secondTimestamp.quantity shouldBe 8
         secondTimestamp.unitMeasure shouldBe "d"
@@ -114,23 +116,30 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
         val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
 
-        val firstTimestamp   = expression.expression1.asInstanceOf[ComparisonExpression[RelativeTimestampValue]].value
+        val firstTimestamp =
+          expression.expression1.asInstanceOf[ComparisonExpression[_]].value.asInstanceOf[RelativeComparisonValue[Long]]
         val secondExpression = expression.expression2.asInstanceOf[TupledLogicalExpression]
         val secondTimestamp =
-          secondExpression.expression1.asInstanceOf[ComparisonExpression[RelativeTimestampValue]].value
-        val thirdTimestamp = secondExpression.expression2.asInstanceOf[EqualityExpression[RelativeTimestampValue]].value
+          secondExpression.expression1
+            .asInstanceOf[ComparisonExpression[_]]
+            .value
+            .asInstanceOf[RelativeComparisonValue[Long]]
+        val thirdTimestamp = secondExpression.expression2
+          .asInstanceOf[EqualityExpression[_]]
+          .value
+          .asInstanceOf[RelativeComparisonValue[Long]]
 
-        firstTimestamp.timestamp shouldBe now + 30 * days +- timestampTolerance
+        firstTimestamp.value shouldBe now + 30 * days +- timestampTolerance
         firstTimestamp.operator shouldBe "+"
         firstTimestamp.quantity shouldBe 30
         firstTimestamp.unitMeasure shouldBe "d"
 
-        secondTimestamp.timestamp shouldBe now - 2 * hours +- timestampTolerance
+        secondTimestamp.value shouldBe now - 2 * hours +- timestampTolerance
         secondTimestamp.operator shouldBe "-"
         secondTimestamp.quantity shouldBe 2
         secondTimestamp.unitMeasure shouldBe "h"
 
-        thirdTimestamp.timestamp shouldBe now + 4 * minutes +- timestampTolerance
+        thirdTimestamp.value shouldBe now + 4 * minutes +- timestampTolerance
         thirdTimestamp.operator shouldBe "+"
         thirdTimestamp.quantity shouldBe 4
         thirdTimestamp.unitMeasure shouldBe "m"
@@ -149,25 +158,32 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
         val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
 
-        val thirdTimestamp = expression.expression2.asInstanceOf[EqualityExpression[RelativeTimestampValue]].value
+        val thirdTimestamp =
+          expression.expression2.asInstanceOf[EqualityExpression[_]].value.asInstanceOf[RelativeComparisonValue[Long]]
 
         val secondExpression = expression.expression1.asInstanceOf[TupledLogicalExpression]
         val firstTimestamp =
-          secondExpression.expression1.asInstanceOf[ComparisonExpression[RelativeTimestampValue]].value
+          secondExpression.expression1
+            .asInstanceOf[ComparisonExpression[_]]
+            .value
+            .asInstanceOf[RelativeComparisonValue[Long]]
         val secondTimestamp =
-          secondExpression.expression2.asInstanceOf[ComparisonExpression[RelativeTimestampValue]].value
+          secondExpression.expression2
+            .asInstanceOf[ComparisonExpression[_]]
+            .value
+            .asInstanceOf[RelativeComparisonValue[Long]]
 
-        firstTimestamp.timestamp shouldBe now + 30 * days +- timestampTolerance
+        firstTimestamp.value shouldBe now + 30 * days +- timestampTolerance
         firstTimestamp.operator shouldBe "+"
         firstTimestamp.quantity shouldBe 30
         firstTimestamp.unitMeasure shouldBe "d"
 
-        secondTimestamp.timestamp shouldBe now - 2 * hours +- timestampTolerance
+        secondTimestamp.value shouldBe now - 2 * hours +- timestampTolerance
         secondTimestamp.operator shouldBe "-"
         secondTimestamp.quantity shouldBe 2
         secondTimestamp.unitMeasure shouldBe "h"
 
-        thirdTimestamp.timestamp shouldBe now + 4 * minutes +- timestampTolerance
+        thirdTimestamp.value shouldBe now + 4 * minutes +- timestampTolerance
         thirdTimestamp.operator shouldBe "+"
         thirdTimestamp.quantity shouldBe 4
         thirdTimestamp.unitMeasure shouldBe "m"
@@ -183,17 +199,17 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
         val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
         val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[RelativeTimestampValue]]
+          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[_]]
 
-        val firstTimestamp  = expression.value1
-        val secondTimestamp = expression.value2
+        val firstTimestamp  = expression.value1.asInstanceOf[RelativeComparisonValue[Long]]
+        val secondTimestamp = expression.value2.asInstanceOf[RelativeComparisonValue[Long]]
 
         expression.dimension shouldBe "timestamp"
-        firstTimestamp.timestamp shouldBe now - 2 * seconds +- timestampTolerance
+        firstTimestamp.value shouldBe now - 2 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 2
         firstTimestamp.unitMeasure shouldBe "s"
-        secondTimestamp.timestamp shouldBe now + 4 * seconds +- timestampTolerance
+        secondTimestamp.value shouldBe now + 4 * seconds +- timestampTolerance
         secondTimestamp.operator shouldBe "+"
         secondTimestamp.quantity shouldBe 4
         secondTimestamp.unitMeasure shouldBe "s"
@@ -209,17 +225,17 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
         val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
         val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[RelativeTimestampValue]]
+          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[_]]
 
-        val firstTimestamp  = expression.value1
-        val secondTimestamp = expression.value2
+        val firstTimestamp  = expression.value1.asInstanceOf[RelativeComparisonValue[Long]]
+        val secondTimestamp = expression.value2.asInstanceOf[RelativeComparisonValue[Long]]
 
         expression.dimension shouldBe "timestamp"
-        firstTimestamp.timestamp shouldBe now - 2 * seconds +- timestampTolerance
+        firstTimestamp.value shouldBe now - 2 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 2
         firstTimestamp.unitMeasure shouldBe "s"
-        secondTimestamp.timestamp shouldBe now + 4 * seconds +- timestampTolerance
+        secondTimestamp.value shouldBe now + 4 * seconds +- timestampTolerance
         secondTimestamp.operator shouldBe "+"
         secondTimestamp.quantity shouldBe 4
         secondTimestamp.unitMeasure shouldBe "s"
@@ -235,15 +251,15 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
         val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
         val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[RelativeTimestampValue]]
+          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[_]]
 
-        val firstTimestamp = expression.value1
+        val firstTimestamp = expression.value1.asInstanceOf[RelativeComparisonValue[Long]]
         expression.dimension shouldBe "timestamp"
-        firstTimestamp.timestamp shouldBe now - 2 * seconds +- timestampTolerance
+        firstTimestamp.value shouldBe now - 2 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 2
         firstTimestamp.unitMeasure shouldBe "s"
-        expression.value2 shouldBe 5
+        expression.value2 shouldBe AbsoluteComparisonValue(5)
       }
 
     }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
@@ -51,7 +51,7 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         firstTimestamp.timestamp shouldBe now - 10 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 10
-        firstTimestamp.unitMeasure shouldBe "S"
+        firstTimestamp.unitMeasure shouldBe "s"
       }
 
       "parse it successfully relative time in simple where comparison condition" in {
@@ -72,7 +72,7 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         firstTimestamp.timestamp shouldBe now - 10 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 10
-        firstTimestamp.unitMeasure shouldBe "S"
+        firstTimestamp.unitMeasure shouldBe "s"
       }
 
       "parse it successfully using relative time in complex where condition" in {
@@ -93,12 +93,12 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         firstTimestamp.timestamp shouldBe now + 5 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "+"
         firstTimestamp.quantity shouldBe 5
-        firstTimestamp.unitMeasure shouldBe "S"
+        firstTimestamp.unitMeasure shouldBe "s"
 
         secondTimestamp.timestamp shouldBe now - 8 * days +- timestampTolerance
         secondTimestamp.operator shouldBe "-"
         secondTimestamp.quantity shouldBe 8
-        secondTimestamp.unitMeasure shouldBe "D"
+        secondTimestamp.unitMeasure shouldBe "d"
       }
 
       "parse it successfully using relative time in very complex where condition" in {
@@ -123,17 +123,17 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         firstTimestamp.timestamp shouldBe now + 30 * days +- timestampTolerance
         firstTimestamp.operator shouldBe "+"
         firstTimestamp.quantity shouldBe 30
-        firstTimestamp.unitMeasure shouldBe "D"
+        firstTimestamp.unitMeasure shouldBe "d"
 
         secondTimestamp.timestamp shouldBe now - 2 * hours +- timestampTolerance
         secondTimestamp.operator shouldBe "-"
         secondTimestamp.quantity shouldBe 2
-        secondTimestamp.unitMeasure shouldBe "H"
+        secondTimestamp.unitMeasure shouldBe "h"
 
         thirdTimestamp.timestamp shouldBe now + 4 * minutes +- timestampTolerance
         thirdTimestamp.operator shouldBe "+"
         thirdTimestamp.quantity shouldBe 4
-        thirdTimestamp.unitMeasure shouldBe "M"
+        thirdTimestamp.unitMeasure shouldBe "m"
       }
 
       "parse it successfully using relative time in very complex where condition with brackets" in {
@@ -160,17 +160,17 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         firstTimestamp.timestamp shouldBe now + 30 * days +- timestampTolerance
         firstTimestamp.operator shouldBe "+"
         firstTimestamp.quantity shouldBe 30
-        firstTimestamp.unitMeasure shouldBe "D"
+        firstTimestamp.unitMeasure shouldBe "d"
 
         secondTimestamp.timestamp shouldBe now - 2 * hours +- timestampTolerance
         secondTimestamp.operator shouldBe "-"
         secondTimestamp.quantity shouldBe 2
-        secondTimestamp.unitMeasure shouldBe "H"
+        secondTimestamp.unitMeasure shouldBe "h"
 
         thirdTimestamp.timestamp shouldBe now + 4 * minutes +- timestampTolerance
         thirdTimestamp.operator shouldBe "+"
         thirdTimestamp.quantity shouldBe 4
-        thirdTimestamp.unitMeasure shouldBe "M"
+        thirdTimestamp.unitMeasure shouldBe "m"
       }
 
       "parse it successfully with a relative timestamp range condition" in {
@@ -192,11 +192,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         firstTimestamp.timestamp shouldBe now - 2 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 2
-        firstTimestamp.unitMeasure shouldBe "S"
+        firstTimestamp.unitMeasure shouldBe "s"
         secondTimestamp.timestamp shouldBe now + 4 * seconds +- timestampTolerance
         secondTimestamp.operator shouldBe "+"
         secondTimestamp.quantity shouldBe 4
-        secondTimestamp.unitMeasure shouldBe "S"
+        secondTimestamp.unitMeasure shouldBe "s"
       }
 
       "parse it successfully with a relative timestamp range condition with unnecessary brackets" in {
@@ -218,11 +218,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         firstTimestamp.timestamp shouldBe now - 2 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 2
-        firstTimestamp.unitMeasure shouldBe "S"
+        firstTimestamp.unitMeasure shouldBe "s"
         secondTimestamp.timestamp shouldBe now + 4 * seconds +- timestampTolerance
         secondTimestamp.operator shouldBe "+"
         secondTimestamp.quantity shouldBe 4
-        secondTimestamp.unitMeasure shouldBe "S"
+        secondTimestamp.unitMeasure shouldBe "s"
       }
 
       "parse it successfully with a mixed relative/absolute timestamp range condition" in {
@@ -242,7 +242,7 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         firstTimestamp.timestamp shouldBe now - 2 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 2
-        firstTimestamp.unitMeasure shouldBe "S"
+        firstTimestamp.unitMeasure shouldBe "s"
         expression.value2 shouldBe 5
       }
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
@@ -36,7 +36,9 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 4L)))
+            condition = Some(Condition(RangeExpression(dimension = "timestamp",
+                                                       value1 = AbsoluteComparisonValue(2L),
+                                                       value2 = AbsoluteComparisonValue(4L))))
           )))
       }
 
@@ -48,7 +50,9 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 3.5)))
+            condition = Some(Condition(RangeExpression(dimension = "timestamp",
+                                                       value1 = AbsoluteComparisonValue(2L),
+                                                       value2 = AbsoluteComparisonValue(3.5))))
           )))
       }
 
@@ -69,7 +73,8 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(EqualityExpression(dimension = "timestamp", value = "word_word")))
+            condition =
+              Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue("word_word"))))
           )))
       }
 
@@ -105,8 +110,9 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(
-              ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 10L)))
+            condition = Some(Condition(ComparisonExpression(dimension = "timestamp",
+                                                            comparison = GreaterOrEqualToOperator,
+                                                            value = AbsoluteComparisonValue(10L))))
           )))
       }
 
@@ -131,9 +137,11 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp", comparison = GreaterThanOperator, value = 2L),
+              expression1 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterThanOperator,
+                                                 value = AbsoluteComparisonValue(2L)),
               operator = AndOperator,
-              expression2 = EqualityExpression(dimension = "timestamp", value = 4L)
+              expression2 = EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(4L))
             )))
           )))
       }
@@ -161,10 +169,13 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(UnaryLogicalExpression(
               expression = TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
                 operator = OrOperator,
-                expression2 = ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = 4L)
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessThanOperator,
+                                                   value = AbsoluteComparisonValue(4L))
               ),
               operator = NotOperator
             )))
@@ -181,11 +192,14 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(TupledLogicalExpression(
-              expression1 = UnaryLogicalExpression(
-                ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
-                operator = NotOperator),
+              expression1 = UnaryLogicalExpression(ComparisonExpression(dimension = "timestamp",
+                                                                        comparison = GreaterOrEqualToOperator,
+                                                                        value = AbsoluteComparisonValue(2L)),
+                                                   operator = NotOperator),
               operator = OrOperator,
-              expression2 = ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = 4L)
+              expression2 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = LessThanOperator,
+                                                 value = AbsoluteComparisonValue(4L))
             )))
           )))
       }
@@ -202,12 +216,14 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(UnaryLogicalExpression(
               expression = TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
                 operator = OrOperator,
-                expression2 = UnaryLogicalExpression(
-                  ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = 4L),
-                  operator = NotOperator)
+                expression2 = UnaryLogicalExpression(ComparisonExpression(dimension = "timestamp",
+                                                                          comparison = LessThanOperator,
+                                                                          value = AbsoluteComparisonValue(4L)),
+                                                     operator = NotOperator)
               ),
               operator = NotOperator
             )))
@@ -230,11 +246,15 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(TupledLogicalExpression(
-              expression1 = TupledLogicalExpression(expression1 = LikeExpression("name", "$an$"),
-                                                    operator = AndOperator,
-                                                    expression2 = EqualityExpression("surname", "pippo")),
+              expression1 = TupledLogicalExpression(
+                expression1 = LikeExpression("name", "$an$"),
+                operator = AndOperator,
+                expression2 = EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo"))
+              ),
               operator = AndOperator,
-              expression2 = RangeExpression("timestamp", 2, 4)
+              expression2 = RangeExpression(dimension = "timestamp",
+                                            value1 = AbsoluteComparisonValue(2),
+                                            value2 = AbsoluteComparisonValue(4))
             ))),
             order = Some(DescOrderOperator(dimension = "name")),
             limit = Some(LimitOperator(5))
@@ -254,12 +274,17 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(
-              Condition(TupledLogicalExpression(LikeExpression("name", "$an$"),
-                                                AndOperator,
-                                                TupledLogicalExpression(EqualityExpression("surname", "pippo"),
-                                                                        AndOperator,
-                                                                        RangeExpression("timestamp", 2, 4))))),
+            condition = Some(Condition(TupledLogicalExpression(
+              LikeExpression("name", "$an$"),
+              AndOperator,
+              TupledLogicalExpression(
+                EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo")),
+                AndOperator,
+                RangeExpression(dimension = "timestamp",
+                                value1 = AbsoluteComparisonValue(2),
+                                value2 = AbsoluteComparisonValue(4))
+              )
+            ))),
             order = Some(DescOrderOperator(dimension = "name")),
             limit = Some(LimitOperator(5))
           )))
@@ -278,10 +303,11 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
               metric = "AreaOccupancy",
               distinct = false,
               fields = AllFields,
-              condition = Some(
-                Condition(TupledLogicalExpression(EqualityExpression("name", "MeetingArea"),
-                                                  AndOperator,
-                                                  UnaryLogicalExpression(NullableExpression("name"), NotOperator)))),
+              condition = Some(Condition(TupledLogicalExpression(
+                EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("MeetingArea")),
+                AndOperator,
+                UnaryLogicalExpression(NullableExpression("name"), NotOperator)
+              ))),
               order = Some(DescOrderOperator(dimension = "timestamp")),
               limit = Some(LimitOperator(1))
             ))
@@ -304,11 +330,12 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
               condition = Some(
                 Condition(
                   TupledLogicalExpression(
-                    expression1 =
-                      TupledLogicalExpression(expression1 = EqualityExpression("name", "MeetingArea"),
-                                              operator = AndOperator,
-                                              expression2 =
-                                                UnaryLogicalExpression(NullableExpression("name"), NotOperator)),
+                    expression1 = TupledLogicalExpression(
+                      expression1 =
+                        EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("MeetingArea")),
+                      operator = AndOperator,
+                      expression2 = UnaryLogicalExpression(NullableExpression("name"), NotOperator)
+                    ),
                     operator = OrOperator,
                     expression2 = UnaryLogicalExpression(NullableExpression("floor"), NotOperator)
                   )
@@ -335,11 +362,15 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(TupledLogicalExpression(
               expression1 = TupledLogicalExpression(
-                expression1 = TupledLogicalExpression(expression1 = LikeExpression("name", "$an$"),
-                                                      operator = AndOperator,
-                                                      expression2 = EqualityExpression("surname", "pippo")),
+                expression1 = TupledLogicalExpression(
+                  expression1 = LikeExpression("name", "$an$"),
+                  operator = AndOperator,
+                  expression2 = EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo"))
+                ),
                 operator = AndOperator,
-                expression2 = RangeExpression("timestamp", 2, 4)
+                expression2 = RangeExpression(dimension = "timestamp",
+                                              value1 = AbsoluteComparisonValue(2),
+                                              value2 = AbsoluteComparisonValue(4))
               ),
               expression2 = UnaryLogicalExpression(NullableExpression("code"), NotOperator),
               operator = AndOperator

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
@@ -142,7 +142,9 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 4L)))
+            condition = Some(Condition(RangeExpression(dimension = "timestamp",
+                                                       value1 = AbsoluteComparisonValue(2L),
+                                                       value2 = AbsoluteComparisonValue(4L))))
           )))
       }
 
@@ -154,7 +156,9 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 3.5)))
+            condition = Some(Condition(RangeExpression(dimension = "timestamp",
+                                                       value1 = AbsoluteComparisonValue(2L),
+                                                       value2 = AbsoluteComparisonValue(3.5))))
           )))
       }
     }
@@ -168,7 +172,8 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(EqualityExpression(dimension = "timestamp", value = 10L)))
+            condition =
+              Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(10L))))
           )))
       }
 
@@ -180,7 +185,8 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(EqualityExpression(dimension = "timestamp", value = 10.5)))
+            condition =
+              Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(10.5))))
           )))
       }
 
@@ -192,7 +198,8 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(EqualityExpression(dimension = "timestamp", value = "word_word")))
+            condition =
+              Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue("word_word"))))
           )))
       }
     }
@@ -232,8 +239,9 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(
-              ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 10L)))
+            condition = Some(Condition(ComparisonExpression(dimension = "timestamp",
+                                                            comparison = GreaterOrEqualToOperator,
+                                                            value = AbsoluteComparisonValue(10L))))
           )))
       }
     }
@@ -250,9 +258,11 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp", comparison = GreaterThanOperator, value = 2L),
+              expression1 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterThanOperator,
+                                                 value = AbsoluteComparisonValue(2L)),
               operator = AndOperator,
-              expression2 = EqualityExpression(dimension = "timestamp", value = 4L)
+              expression2 = EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(4L))
             )))
           )))
       }
@@ -268,9 +278,11 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp", comparison = GreaterThanOperator, value = 2.4),
+              expression1 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterThanOperator,
+                                                 value = AbsoluteComparisonValue(2.4)),
               operator = AndOperator,
-              expression2 = EqualityExpression(dimension = "timestamp", value = 4L)
+              expression2 = EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(4L))
             )))
           )))
       }
@@ -289,10 +301,13 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp", comparison = GreaterThanOperator, value = 2L),
+              expression1 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterThanOperator,
+                                                 value = AbsoluteComparisonValue(2L)),
               operator = AndOperator,
-              expression2 =
-                ComparisonExpression(dimension = "timestamp", comparison = LessOrEqualToOperator, value = 4l)
+              expression2 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = LessOrEqualToOperator,
+                                                 value = AbsoluteComparisonValue(4L))
             )))
           )))
       }
@@ -308,10 +323,13 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp", comparison = GreaterThanOperator, value = 2.5),
+              expression1 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterThanOperator,
+                                                 value = AbsoluteComparisonValue(2.5)),
               operator = AndOperator,
-              expression2 =
-                ComparisonExpression(dimension = "timestamp", comparison = LessOrEqualToOperator, value = 4.01)
+              expression2 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = LessOrEqualToOperator,
+                                                 value = AbsoluteComparisonValue(4.01))
             )))
           )))
       }
@@ -330,10 +348,13 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(UnaryLogicalExpression(
               expression = TupledLogicalExpression(
-                expression1 =
-                  ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 2L),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
                 operator = OrOperator,
-                expression2 = ComparisonExpression(dimension = "timestamp", comparison = LessThanOperator, value = 4L)
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessThanOperator,
+                                                   value = AbsoluteComparisonValue(4L))
               ),
               operator = NotOperator
             )))
@@ -378,7 +399,9 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2, value2 = 4))),
+            condition = Some(Condition(RangeExpression(dimension = "timestamp",
+                                                       value1 = AbsoluteComparisonValue(2),
+                                                       value2 = AbsoluteComparisonValue(4)))),
             order = Some(DescOrderOperator(dimension = "name")),
             limit = Some(LimitOperator(5))
           )))
@@ -393,7 +416,9 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2, value2 = 4))),
+            condition = Some(Condition(RangeExpression(dimension = "timestamp",
+                                                       value1 = AbsoluteComparisonValue(2),
+                                                       value2 = AbsoluteComparisonValue(4)))),
             order = Some(DescOrderOperator(dimension = "name")),
             limit = Some(LimitOperator(5))
           )))
@@ -414,12 +439,17 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(
-              Condition(TupledLogicalExpression(LikeExpression("name", "$an$"),
-                                                AndOperator,
-                                                TupledLogicalExpression(EqualityExpression("surname", "pippo"),
-                                                                        AndOperator,
-                                                                        RangeExpression("timestamp", 2, 4))))),
+            condition = Some(Condition(TupledLogicalExpression(
+              LikeExpression("name", "$an$"),
+              AndOperator,
+              TupledLogicalExpression(
+                EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo")),
+                AndOperator,
+                RangeExpression(dimension = "timestamp",
+                                value1 = AbsoluteComparisonValue(2),
+                                AbsoluteComparisonValue(4))
+              )
+            ))),
             order = Some(DescOrderOperator(dimension = "name")),
             limit = Some(LimitOperator(5))
           )))
@@ -438,7 +468,7 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             metric = "AreaOccupancy",
             distinct = false,
             fields = AllFields,
-            condition = Some(Condition(EqualityExpression("name", "MeetingArea"))),
+            condition = Some(Condition(EqualityExpression(dimension = "name", AbsoluteComparisonValue("MeetingArea")))),
             order = Some(DescOrderOperator(dimension = "timestamp")),
             limit = Some(LimitOperator(1))
           ))
@@ -457,9 +487,10 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             distinct = false,
             fields = AllFields,
             condition = Some(
-              Condition(TupledLogicalExpression(EqualityExpression("name", "MeetingArea"),
-                                                AndOperator,
-                                                NullableExpression("name")))),
+              Condition(
+                TupledLogicalExpression(EqualityExpression(dimension = "name", AbsoluteComparisonValue("MeetingArea")),
+                                        AndOperator,
+                                        NullableExpression("name")))),
             order = Some(DescOrderOperator(dimension = "timestamp")),
             limit = Some(LimitOperator(1))
           ))
@@ -478,10 +509,11 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             metric = "AreaOccupancy",
             distinct = false,
             fields = AllFields,
-            condition = Some(
-              Condition(TupledLogicalExpression(EqualityExpression("name", "MeetingArea"),
-                                                AndOperator,
-                                                UnaryLogicalExpression(NullableExpression("name"), NotOperator)))),
+            condition = Some(Condition(TupledLogicalExpression(
+              EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("MeetingArea")),
+              AndOperator,
+              UnaryLogicalExpression(NullableExpression("name"), NotOperator)
+            ))),
             order = Some(DescOrderOperator(dimension = "timestamp")),
             limit = Some(LimitOperator(1))
           ))
@@ -502,7 +534,7 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             distinct = false,
             fields = AllFields,
             condition = Some(Condition(TupledLogicalExpression(
-              EqualityExpression("name", "MeetingArea"),
+              EqualityExpression(dimension = "name", AbsoluteComparisonValue("MeetingArea")),
               AndOperator,
               TupledLogicalExpression(
                 UnaryLogicalExpression(NullableExpression("name"), NotOperator),
@@ -525,7 +557,8 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
           metric = "people",
           distinct = false,
           fields = ListFields(List(Field("name", None))),
-          condition = Some(Condition(EqualityExpression(dimension = "name", value = "string spaced"))),
+          condition =
+            Some(Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("string spaced")))),
           limit = Some(LimitOperator(5))
         )))
     }
@@ -538,7 +571,7 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
           metric = "people",
           distinct = false,
           fields = ListFields(List(Field("name", None))),
-          condition = Some(Condition(EqualityExpression(dimension = "name", value = "a"))),
+          condition = Some(Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("a")))),
           limit = Some(LimitOperator(5))
         )))
     }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
@@ -18,6 +18,8 @@ package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
 import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.TryValues._
+import org.scalatest.OptionValues._
 
 import scala.util.Success
 
@@ -155,13 +157,6 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             condition = Some(Condition(RangeExpression(dimension = "timestamp", value1 = 2L, value2 = 3.5)))
           )))
       }
-
-      "parse it successfully using relative time" in {
-        val statement = parser.parse(db = "db",
-                                     namespace = "registry",
-                                     input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, now + 4 s)")
-        statement.isSuccess shouldBe true
-      }
     }
 
     "receive a select containing a = selection" should {
@@ -199,12 +194,6 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(EqualityExpression(dimension = "timestamp", value = "word_word")))
           )))
-      }
-
-      "parse it successfully using relative time" in {
-        val statement =
-          parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp = now - 10s")
-        statement.isSuccess shouldBe true
       }
     }
 
@@ -247,14 +236,6 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
               ComparisonExpression(dimension = "timestamp", comparison = GreaterOrEqualToOperator, value = 10L)))
           )))
       }
-
-      "parse it successfully using relative time" in {
-        val statement =
-          parser.parse(db = "db",
-                       namespace = "registry",
-                       input = "SELECT name FROM people WHERE timestamp >= now - 10s")
-        statement.isSuccess shouldBe true
-      }
     }
 
     "receive a select containing a GT AND a = selection" should {
@@ -294,14 +275,6 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
           )))
       }
 
-      "parse it successfully using relative time" in {
-        val statement = parser.parse(
-          db = "db",
-          namespace = "registry",
-          input =
-            "SELECT name FROM people WHERE timestamp < now + 30d and timestamp > now - 2h AND timestamp = now + 4m")
-        statement.isSuccess shouldBe true
-      }
     }
 
     "receive a select containing a GT AND a LTE selection" should {
@@ -342,14 +315,6 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             )))
           )))
       }
-
-      "parse it successfully using relative time" in {
-        val statement = parser.parse(db = "db",
-                                     namespace = "registry",
-                                     input =
-                                       "SELECT name FROM people WHERE timestamp > now - 2h AND timestamp <= now + 4m")
-        statement.isSuccess shouldBe true
-      }
     }
 
     "receive a select containing a GTE OR a LT selection" should {
@@ -373,14 +338,6 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
               operator = NotOperator
             )))
           )))
-      }
-
-      "parse it successfully using relative time" in {
-        val statement =
-          parser.parse(db = "db",
-                       namespace = "registry",
-                       input = "SELECT name FROM people WHERE NOT timestamp >= now + 2m OR timestamp < now - 4h")
-        statement.isSuccess shouldBe true
       }
     }
 


### PR DESCRIPTION
This pr is in preparation for the modification of the /query api that with one optional parameter can return the query structure in addition to the result of the query

- parsing "now +- {quantity}{unitMeasure}" in queries take track of the relative timestamp, with an object that has: absolute timestamp value, plus or minus sign, quantity (1, 2, 3, ...) and unit measure (s, m, h or d)
- parsing of group by with time interval take track of the quantity and unit measure (same as above without the sign because there isn't the sign in interval)
- add some tests for relative timestamp queries and fixed queries with group by time interval tests