### PR TITLE
Validate json object fields in data API

### DIFF
--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
@@ -28,6 +28,7 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.security.http.NSDBAuthProvider
 import io.radicalbit.nsdb.web.routes._
 import io.radicalbit.nsdb.web.swagger.SwaggerDocService
+import io.radicalbit.nsdb.web.validation.FieldErrorInfo
 import org.json4s.DefaultFormats
 import spray.json._
 
@@ -86,6 +87,8 @@ object Formats extends DefaultJsonProtocol with SprayJsonSupport {
   implicit val BitFormat = jsonFormat4(Bit.apply)
 
   implicit val InsertBodyFormat = jsonFormat4(InsertBody.apply)
+
+  implicit val validatedFieldFormat = jsonFormat2(FieldErrorInfo.apply)
 
 }
 

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
@@ -88,7 +88,7 @@ object Formats extends DefaultJsonProtocol with SprayJsonSupport {
 
   implicit val InsertBodyFormat = jsonFormat4(InsertBody.apply)
 
-  implicit val validatedFieldFormat = jsonFormat2(FieldErrorInfo.apply)
+  implicit val FieldErrorInfoFormat = jsonFormat2(FieldErrorInfo.apply)
 
 }
 

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
@@ -53,7 +53,7 @@ trait WsResources {
 
   /**
     * Akka stream Flow used to define the webSocket behaviour.
-    * @param clientAddress the client addess that opened the connection (for debugging and monitoring purposes).
+    * @param clientAddress the client address that opened the connection (for debugging and monitoring purposes).
     * @param publishInterval interval of data publishing operation.
     * @param retentionSize size of the buffer used to retain events in case of no subscribers.
     * @param publisherActor the global [[io.radicalbit.nsdb.actors.PublisherActor]].

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/DataApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/DataApi.scala
@@ -50,6 +50,8 @@ case class InsertBody(@(ApiModelProperty @field)(value = "database name") db: St
 trait DataApi {
 
   import io.radicalbit.nsdb.web.Formats._
+  import io.radicalbit.nsdb.web.validation.ValidationDirective._
+  import io.radicalbit.nsdb.web.validation.Validators._
 
   def writeCoordinator: ActorRef
   def authenticationProvider: NSDBAuthProvider
@@ -75,21 +77,23 @@ trait DataApi {
     pathPrefix("data") {
       post {
         entity(as[InsertBody]) { insertBody =>
-          optionalHeaderValueByName(authenticationProvider.headerName) { header =>
-            authenticationProvider.authorizeMetric(ent = insertBody, header = header, writePermission = true) {
-              onComplete(
-                writeCoordinator ? MapInput(insertBody.bit.timestamp,
-                                            insertBody.db,
-                                            insertBody.namespace,
-                                            insertBody.metric,
-                                            insertBody.bit)) {
-                case Success(_: InputMapped) =>
-                  complete("OK")
-                case Success(RecordRejected(_, _, _, _, _, reasons, _)) =>
-                  complete(HttpResponse(BadRequest, entity = reasons.mkString(",")))
-                case Success(_) =>
-                  complete(HttpResponse(InternalServerError, entity = "unknown response"))
-                case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
+          validateModel(insertBody).apply { validatedInsertBody =>
+            optionalHeaderValueByName(authenticationProvider.headerName) { header =>
+              authenticationProvider.authorizeMetric(ent = validatedInsertBody, header = header, writePermission = true) {
+                onComplete(
+                  writeCoordinator ? MapInput(validatedInsertBody.bit.timestamp,
+                                              validatedInsertBody.db,
+                                              validatedInsertBody.namespace,
+                                              validatedInsertBody.metric,
+                                              validatedInsertBody.bit)) {
+                  case Success(_: InputMapped) =>
+                    complete("OK")
+                  case Success(RecordRejected(_, _, _, _, _, reasons, _)) =>
+                    complete(HttpResponse(BadRequest, entity = reasons.mkString(",")))
+                  case Success(_) =>
+                    complete(HttpResponse(InternalServerError, entity = "unknown response"))
+                  case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
+                }
               }
             }
           }

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/DataApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/DataApi.scala
@@ -77,8 +77,8 @@ trait DataApi {
     pathPrefix("data") {
       post {
         entity(as[InsertBody]) { insertBody =>
-          validateModel(insertBody).apply { validatedInsertBody =>
-            optionalHeaderValueByName(authenticationProvider.headerName) { header =>
+          optionalHeaderValueByName(authenticationProvider.headerName) { header =>
+            validateModel(insertBody).apply { validatedInsertBody =>
               authenticationProvider.authorizeMetric(ent = validatedInsertBody, header = header, writePermission = true) {
                 onComplete(
                   writeCoordinator ? MapInput(validatedInsertBody.bit.timestamp,

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/FieldErrorInfo.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/FieldErrorInfo.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.web.validation
+
+final case class FieldErrorInfo(name: String, error: String)

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/FieldErrorInfo.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/FieldErrorInfo.scala
@@ -16,4 +16,9 @@
 
 package io.radicalbit.nsdb.web.validation
 
+/**
+  * Information about validation field error
+  * @param name the name of the field
+  * @param error message explaining the error
+  */
 final case class FieldErrorInfo(name: String, error: String)

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/ModelValidationRejection.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/ModelValidationRejection.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.web.validation
+
+import akka.http.scaladsl.server.Rejection
+
+final case class ModelValidationRejection(invalidFields: Seq[FieldErrorInfo]) extends Rejection

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/ValidationDirective.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/ValidationDirective.scala
@@ -19,6 +19,9 @@ package io.radicalbit.nsdb.web.validation
 import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives._
 
+/**
+  * Akka Http Directive for case class fields validation
+  */
 object ValidationDirective {
 
   def validateModel[T](model: T)(implicit validator: Validator[T]): Directive1[T] = {

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/ValidationDirective.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/ValidationDirective.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.web.validation
+
+import akka.http.scaladsl.server.Directive1
+import akka.http.scaladsl.server.Directives._
+
+object ValidationDirective {
+
+  def validateModel[T](model: T)(implicit validator: Validator[T]): Directive1[T] = {
+    validator(model) match {
+      case Nil                         => provide(model)
+      case errors: Seq[FieldErrorInfo] => reject(ModelValidationRejection(errors))
+    }
+  }
+}

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/Validator.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/Validator.scala
@@ -16,6 +16,10 @@
 
 package io.radicalbit.nsdb.web.validation
 
+/**
+  * The type class for field validation
+  * @tparam T
+  */
 trait Validator[T] extends (T => Seq[FieldErrorInfo]) {
 
   def validationStage(rule: Boolean, fieldName: String, errorText: String): Option[FieldErrorInfo] =

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/Validator.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/Validator.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.web.validation
+
+trait Validator[T] extends (T => Seq[FieldErrorInfo]) {
+
+  def validationStage(rule: Boolean, fieldName: String, errorText: String): Option[FieldErrorInfo] =
+    if (rule) Some(FieldErrorInfo(fieldName, errorText)) else None
+}

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/ValidatorRegexHelpers.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/ValidatorRegexHelpers.scala
@@ -16,10 +16,13 @@
 
 package io.radicalbit.nsdb.web.validation
 
-import akka.http.scaladsl.server.Rejection
+import scala.util.matching.Regex
 
 /**
-  * Custom Rejection for validation field error
-  * @param invalidFields list of [[FieldErrorInfo]] occurred during the validation
+  * Implicit class utilities for regular expression evaluation
   */
-final case class ModelValidationRejection(invalidFields: Seq[FieldErrorInfo]) extends Rejection
+object ValidatorRegexHelpers {
+  implicit class EvaluateStringAgainstRegex(s: String) {
+    def evaluateAgainstRegex(regex: Regex): Boolean = s.matches(regex.regex)
+  }
+}

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/Validators.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/Validators.scala
@@ -19,11 +19,15 @@ package io.radicalbit.nsdb.web.validation
 import io.radicalbit.nsdb.sql.parser.RegexNSDb
 import io.radicalbit.nsdb.web.routes.InsertBody
 
+/**
+  * Collection of type class instances of [[Validator]]
+  */
 object Validators extends RegexNSDb {
 
-  implicit val insertBodyValidator: Validator[InsertBody] = new Validator[InsertBody] {
+  import ValidatorRegexHelpers._
 
-    private def metricRule(metricName: String): Boolean = !metricName.matches(metric.regex)
+  implicit val insertBodyValidator: Validator[InsertBody] = new Validator[InsertBody] {
+    private def metricRule(metricName: String): Boolean = !metricName.evaluateAgainstRegex(metric)
 
     def apply(insertBody: InsertBody): Seq[FieldErrorInfo] = {
       val metricErrorOpt =

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/Validators.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/validation/Validators.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.web.validation
+
+import io.radicalbit.nsdb.sql.parser.RegexNSDb
+import io.radicalbit.nsdb.web.routes.InsertBody
+
+object Validators extends RegexNSDb {
+
+  implicit val insertBodyValidator: Validator[InsertBody] = new Validator[InsertBody] {
+
+    private def metricRule(metricName: String): Boolean = !metricName.matches(metric.regex)
+
+    def apply(insertBody: InsertBody): Seq[FieldErrorInfo] = {
+      val metricErrorOpt =
+        validationStage(metricRule(insertBody.metric), "metric", "Field metric must contain only alphanumeric chars")
+      (metricErrorOpt :: Nil).flatten
+    }
+  }
+}

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/validation/ValidatorsTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/validation/ValidatorsTest.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.web.validation
+
+import org.scalatest.{FlatSpec, Matchers}
+import Validators._
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.web.routes.InsertBody
+
+class ValidatorsTest extends FlatSpec with Matchers {
+  "Validators" should "validate InsertBody returning empty errors" in {
+    val metric = "metric"
+    val result = insertBodyValidator.apply(InsertBody("db", "namespace", metric, Bit.empty))
+    result shouldBe Seq.empty[FieldErrorInfo]
+  }
+
+  "Validators" should "validate InsertBody returning sequence of errors" in {
+    val metric = "ghost-metric"
+    val result = insertBodyValidator.apply(InsertBody("db", "namespace", metric, Bit.empty))
+    result shouldBe Seq(FieldErrorInfo("metric", "Field metric must contain only alphanumeric chars"))
+  }
+}

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/RegexNSDb.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/RegexNSDb.scala
@@ -1,0 +1,5 @@
+package io.radicalbit.nsdb.sql.parser
+
+trait RegexNSDb {
+  val metric    = """(^[a-zA-Z][a-zA-Z0-9_]*)""".r
+}

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/RegexNSDb.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/RegexNSDb.scala
@@ -16,6 +16,9 @@
 
 package io.radicalbit.nsdb.sql.parser
 
+/**
+  * Collection of regular expressions used in NSDb
+  */
 trait RegexNSDb {
   val metric = """(^[a-zA-Z][a-zA-Z0-9_]*)""".r
 }

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/RegexNSDb.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/RegexNSDb.scala
@@ -1,5 +1,21 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.radicalbit.nsdb.sql.parser
 
 trait RegexNSDb {
-  val metric    = """(^[a-zA-Z][a-zA-Z0-9_]*)""".r
+  val metric = """(^[a-zA-Z][a-zA-Z0-9_]*)""".r
 }

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -44,7 +44,7 @@ import scala.util.parsing.input.CharSequenceReader
   *   timeMeasure := "D" | "H" | "M" | "S"
   * }}}
   */
-final class SQLStatementParser extends RegexParsers with PackratParsers {
+final class SQLStatementParser extends RegexParsers with PackratParsers with RegexNSDb {
 
   implicit class InsensitiveString(str: String) {
     def ignoreCase: PackratParser[String] = ("""(?i)\Q""" + str + """\E""").r ^^ { _.toString.toUpperCase }
@@ -109,7 +109,6 @@ final class SQLStatementParser extends RegexParsers with PackratParsers {
   private val aggField = ((sum | min | max | count) <~ OpenRoundBracket) ~ (digits | All) <~ CloseRoundBracket ^^ { e =>
     Field(e._2, Some(e._1))
   }
-  private val metric    = """(^[a-zA-Z][a-zA-Z0-9_]*)""".r
   private val dimension = digits
   private val stringValue = (digitsWithDashes | (("'" ?) ~> (digitsWithDashes +) <~ ("'" ?))) ^^ {
     case string: String        => string


### PR DESCRIPTION
With this PR we deal with the problem of validating object fields received from data POST API.

This PR has been inspired from [here](http://fruzenshtein.com/akka-http-another-one-validation-directive/)

The main idea is to have a vaidation that could be as general as possible and do not make custom validation for each object.