### PR TITLE
Improve http api to return json of parsed query

### DIFF
--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
@@ -104,8 +104,6 @@ class ApiResources(val publisherActor: ActorRef,
     with QueryValidationApi
     with DataApi {
 
-  override implicit val formats: DefaultFormats = DefaultFormats
-
   def healthCheckApi: Route = {
     pathPrefix("status") {
       (pathEnd & get) {

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
@@ -104,7 +104,7 @@ class ApiResources(val publisherActor: ActorRef,
     with QueryValidationApi
     with DataApi {
 
-  implicit val formats: DefaultFormats = DefaultFormats
+  override implicit val formats: DefaultFormats = DefaultFormats
 
   def healthCheckApi: Route = {
     pathPrefix("status") {

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
@@ -80,7 +80,7 @@ object Formats extends DefaultJsonProtocol with SprayJsonSupport {
       }
   }
 
-  implicit val QbFormat = jsonFormat7(QueryBody.apply)
+  implicit val QbFormat = jsonFormat8(QueryBody.apply)
 
   implicit val QvbFormat = jsonFormat4(QueryValidationBody.apply)
 

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
@@ -17,8 +17,7 @@
 package io.radicalbit.nsdb.web
 
 import io.radicalbit.nsdb.common.statement._
-import org.json4s
-import org.json4s.JsonAST.{JArray, JDouble, JField, JInt, JLong, JValue}
+import org.json4s.JsonAST.{JDouble, JField, JInt, JLong}
 import org.json4s.{CustomSerializer, JNull, JObject, JString}
 
 object CustomSerializers {
@@ -32,7 +31,7 @@ object CustomSerializers {
     EqualityExpressionSerializer
   )
 
-  val customTestingSerializers = customSerializers ++ List(RelativeComparisonTestingSerializer)
+  val customSerializersForTesting = customSerializers ++ List(RelativeComparisonSerializerForTesting)
 
   case object AggregationSerializer
       extends CustomSerializer[Aggregation](_ =>
@@ -130,37 +129,7 @@ object CustomSerializers {
   case object EqualityExpressionSerializer
       extends CustomSerializer[EqualityExpression[_]](_ =>
         ({
-          case JObject(
-              List(JField("dimension", JString(dimension)),
-                   JField("comparison", JString("=")),
-                   JField("value", JLong(value)))) =>
-            EqualityExpression(dimension, AbsoluteComparisonValue(value: Long))
-          case JObject(
-              List(JField("dimension", JString(dimension)),
-                   JField("comparison", JString("=")),
-                   JField("value", JInt(value)))) =>
-            EqualityExpression(dimension, AbsoluteComparisonValue(value.intValue(): Int))
-          case JObject(
-              List(JField("dimension", JString(dimension)),
-                   JField("comparison", JString("=")),
-                   JField("value", JString(value)))) =>
-            EqualityExpression(dimension, AbsoluteComparisonValue(value: String))
-          case JObject(
-              List(JField("dimension", JString(dimension)),
-                   JField("comparison", JString("=")),
-                   JField("value", JDouble(value)))) =>
-            EqualityExpression(dimension, AbsoluteComparisonValue(value: Double))
-          case JObject(
-              List(JField("dimension", JString(dimension)),
-                   JField("comparison", JString("=")),
-                   JField("value",
-                          JObject(
-                            List(JField("value", JLong(value)),
-                                 JField("operator", JString(operator)),
-                                 JField("quantity", JLong(quantity)),
-                                 JField("unitMeasure", JString(unitMeasure)))
-                          )))) =>
-            EqualityExpression(dimension, RelativeComparisonValue(value: Long, operator, quantity: Long, unitMeasure))
+          case _ => throw new UnsupportedOperationException("Deserializing an EqualityExpression is not yet supported")
         }, {
           case EqualityExpression(dimension, AbsoluteComparisonValue(value: Long)) =>
             JObject(
@@ -200,7 +169,7 @@ object CustomSerializers {
               ))
         }))
 
-  case object RelativeComparisonTestingSerializer
+  case object RelativeComparisonSerializerForTesting
       extends CustomSerializer[RelativeComparisonValue[_]](_ =>
         ({
           case JObject(

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
@@ -95,10 +95,10 @@ object CustomSerializers {
             }
           case JNull => null
         }, {
-          case AscOrderOperator(order_by) =>
-            JObject(List(JField("order_by", JString(order_by)), JField("direction", JString("asc"))))
-          case DescOrderOperator(order_by) =>
-            JObject(List(JField("order_by", JString(order_by)), JField("direction", JString("desc"))))
+          case AscOrderOperator(orderBy) =>
+            JObject(List(JField("order_by", JString(orderBy)), JField("direction", JString("asc"))))
+          case DescOrderOperator(orderBy) =>
+            JObject(List(JField("order_by", JString(orderBy)), JField("direction", JString("desc"))))
         }))
 
   case object NullableExpressionSerializer

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
@@ -1,11 +1,13 @@
 package io.radicalbit.nsdb.web
 
-import io.radicalbit.nsdb.common.statement.{Aggregation, CountAggregation, MaxAggregation, MinAggregation, SumAggregation}
-import org.json4s
-import org.json4s.{CustomSerializer, JNull, JString}
+import io.radicalbit.nsdb.common.statement.{Aggregation, AndOperator, AscOrderOperator, ComparisonOperator, CountAggregation, DescOrderOperator, GreaterOrEqualToOperator, GreaterThanOperator, LessOrEqualToOperator, LessThanOperator, LogicalOperator, MaxAggregation, MinAggregation, NotOperator, OrOperator, OrderOperator, SumAggregation}
+import org.json4s.JsonAST.JField
+import org.json4s.{CustomSerializer, JNull, JObject, JString}
 
 object CustomSerializers {
 
+  val customSerializers = List(AggregationSerializer, ComparisonOperatorSerializer, LogicalOperatorSerializer, OrderOperatorSerializer)
+  
   case object AggregationSerializer extends CustomSerializer[Aggregation](_ => ({
         case JString(aggregation) =>
           aggregation match {
@@ -22,7 +24,46 @@ object CustomSerializers {
         case SumAggregation => JString("sum")
       }))
 
+  case object ComparisonOperatorSerializer extends CustomSerializer[ComparisonOperator](_ => ({
+    case JString(comparison) =>
+      comparison match {
+        case ">" => GreaterThanOperator
+        case ">=" => GreaterOrEqualToOperator
+        case "<" => LessThanOperator
+        case "<=" => LessOrEqualToOperator
+      }
+    case JNull => null
+  }, {
+    case GreaterThanOperator => JString(">")
+    case GreaterOrEqualToOperator => JString(">=")
+    case LessThanOperator => JString("<")
+    case LessOrEqualToOperator => JString("<=")
+  }))
 
-  val customSerializers = List(AggregationSerializer)
+  case object LogicalOperatorSerializer extends CustomSerializer[LogicalOperator](_ => ({
+    case JString(logical) =>
+      logical match {
+        case "not" => NotOperator
+        case "and" => AndOperator
+        case "or" => OrOperator
+      }
+    case JNull => null
+  }, {
+    case NotOperator => JString("not")
+    case AndOperator => JString("and")
+    case OrOperator => JString("or")
+  }))
+
+  case object OrderOperatorSerializer extends CustomSerializer[OrderOperator](ser = _ => ( {
+    case JString(order) =>
+      order match {
+        case "asc" => AscOrderOperator("test")
+        case "desc" => DescOrderOperator("test")
+      }
+    case JNull => null
+  }, {
+    case AscOrderOperator(order_by) => JObject(List(JField("order_by", JString(order_by)), JField("direction", JString("asc"))))
+    case DescOrderOperator(order_by) => JObject(List(JField("order_by", JString(order_by)), JField("direction", JString("desc"))))
+  }))
 
 }

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
@@ -1,0 +1,28 @@
+package io.radicalbit.nsdb.web
+
+import io.radicalbit.nsdb.common.statement.{Aggregation, CountAggregation, MaxAggregation, MinAggregation, SumAggregation}
+import org.json4s
+import org.json4s.{CustomSerializer, JNull, JString}
+
+object CustomSerializers {
+
+  case object AggregationSerializer extends CustomSerializer[Aggregation](_ => ({
+        case JString(aggregation) =>
+          aggregation match {
+            case "count" => CountAggregation
+            case "max" => MaxAggregation
+            case "min" => MinAggregation
+            case "sum" => SumAggregation
+          }
+        case JNull => null
+      }, {
+        case CountAggregation => JString("count")
+        case MaxAggregation => JString("max")
+        case MinAggregation => JString("min")
+        case SumAggregation => JString("sum")
+      }))
+
+
+  val customSerializers = List(AggregationSerializer)
+
+}

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
@@ -37,7 +37,7 @@ object CustomSerializers {
       extends CustomSerializer[Aggregation](_ =>
         ({
           case JString(aggregation) =>
-            aggregation match {
+            aggregation.toLowerCase match {
               case "count" => CountAggregation
               case "max"   => MaxAggregation
               case "min"   => MinAggregation
@@ -73,7 +73,7 @@ object CustomSerializers {
       extends CustomSerializer[LogicalOperator](_ =>
         ({
           case JString(logical) =>
-            logical match {
+            logical.toLowerCase match {
               case "not" => NotOperator
               case "and" => AndOperator
               case "or"  => OrOperator
@@ -89,7 +89,7 @@ object CustomSerializers {
       extends CustomSerializer[OrderOperator](_ =>
         ({
           case JObject(List(JField("order_by", JString(order)), JField("direction", JString(direction)))) =>
-            direction match {
+            direction.toLowerCase match {
               case "asc"  => AscOrderOperator(order)
               case "desc" => DescOrderOperator(order)
             }

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.radicalbit.nsdb.web
 
 import io.radicalbit.nsdb.common.statement._
@@ -5,100 +21,202 @@ import org.json4s
 import org.json4s.JsonAST.{JArray, JDouble, JField, JInt, JLong, JValue}
 import org.json4s.{CustomSerializer, JNull, JObject, JString}
 
-
 object CustomSerializers {
 
-  val customSerializers = List(AggregationSerializer, ComparisonOperatorSerializer, LogicalOperatorSerializer, OrderOperatorSerializer, LikeExpressionSerializer, EqualityExpressionSerializer)
+  val customSerializers = List(
+    AggregationSerializer,
+    ComparisonOperatorSerializer,
+    LogicalOperatorSerializer,
+    OrderOperatorSerializer,
+    LikeExpressionSerializer,
+    EqualityExpressionSerializer
+  )
 
-  case object AggregationSerializer extends CustomSerializer[Aggregation](_ => ({
-        case JString(aggregation) =>
-          aggregation match {
-            case "count" => CountAggregation
-            case "max" => MaxAggregation
-            case "min" => MinAggregation
-            case "sum" => SumAggregation
-          }
-        case JNull => null
-      }, {
-        case CountAggregation => JString("count")
-        case MaxAggregation => JString("max")
-        case MinAggregation => JString("min")
-        case SumAggregation => JString("sum")
-      }))
+  val customTestingSerializers = customSerializers ++ List(RelativeComparisonTestingSerializer)
 
-  case object ComparisonOperatorSerializer extends CustomSerializer[ComparisonOperator](_ => ({
-    case JString(comparison) =>
-      comparison match {
-        case ">" => GreaterThanOperator
-        case ">=" => GreaterOrEqualToOperator
-        case "<" => LessThanOperator
-        case "<=" => LessOrEqualToOperator
-      }
-    case JNull => null
-  }, {
-    case GreaterThanOperator => JString(">")
-    case GreaterOrEqualToOperator => JString(">=")
-    case LessThanOperator => JString("<")
-    case LessOrEqualToOperator => JString("<=")
-  }))
+  case object AggregationSerializer
+      extends CustomSerializer[Aggregation](_ =>
+        ({
+          case JString(aggregation) =>
+            aggregation match {
+              case "count" => CountAggregation
+              case "max"   => MaxAggregation
+              case "min"   => MinAggregation
+              case "sum"   => SumAggregation
+            }
+          case JNull => null
+        }, {
+          case CountAggregation => JString("count")
+          case MaxAggregation   => JString("max")
+          case MinAggregation   => JString("min")
+          case SumAggregation   => JString("sum")
+        }))
 
-  case object LogicalOperatorSerializer extends CustomSerializer[LogicalOperator](_ => ({
-    case JString(logical) =>
-      logical match {
-        case "not" => NotOperator
-        case "and" => AndOperator
-        case "or" => OrOperator
-      }
-    case JNull => null
-  }, {
-    case NotOperator => JString("not")
-    case AndOperator => JString("and")
-    case OrOperator => JString("or")
-  }))
+  case object ComparisonOperatorSerializer
+      extends CustomSerializer[ComparisonOperator](_ =>
+        ({
+          case JString(comparison) =>
+            comparison match {
+              case ">"  => GreaterThanOperator
+              case ">=" => GreaterOrEqualToOperator
+              case "<"  => LessThanOperator
+              case "<=" => LessOrEqualToOperator
+            }
+          case JNull => null
+        }, {
+          case GreaterThanOperator      => JString(">")
+          case GreaterOrEqualToOperator => JString(">=")
+          case LessThanOperator         => JString("<")
+          case LessOrEqualToOperator    => JString("<=")
+        }))
 
-  case object OrderOperatorSerializer extends CustomSerializer[OrderOperator](_ => ( {
-    case JObject(List(JField("order_by", JString(order)), JField("direction", JString(direction)))) =>
-      direction match {
-        case "asc" => AscOrderOperator(order)
-        case "desc" => DescOrderOperator(order)
-      }
-    case JNull => null
-  }, {
-    case AscOrderOperator(order_by) => JObject(List(JField("order_by", JString(order_by)), JField("direction", JString("asc"))))
-    case DescOrderOperator(order_by) => JObject(List(JField("order_by", JString(order_by)), JField("direction", JString("desc"))))
-  }))
+  case object LogicalOperatorSerializer
+      extends CustomSerializer[LogicalOperator](_ =>
+        ({
+          case JString(logical) =>
+            logical match {
+              case "not" => NotOperator
+              case "and" => AndOperator
+              case "or"  => OrOperator
+            }
+          case JNull => null
+        }, {
+          case NotOperator => JString("not")
+          case AndOperator => JString("and")
+          case OrOperator  => JString("or")
+        }))
 
-  case object NullableExpressionSerializer extends CustomSerializer[NullableExpression](_ => ( {
-    case JObject(List(JField(_, JString(dimension)), JField(_, JString("like") ))) => NullableExpression(dimension)
-  }, {
-    case NullableExpression(dimension) => JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("null"))))
-  }
-    ))
+  case object OrderOperatorSerializer
+      extends CustomSerializer[OrderOperator](_ =>
+        ({
+          case JObject(List(JField("order_by", JString(order)), JField("direction", JString(direction)))) =>
+            direction match {
+              case "asc"  => AscOrderOperator(order)
+              case "desc" => DescOrderOperator(order)
+            }
+          case JNull => null
+        }, {
+          case AscOrderOperator(order_by) =>
+            JObject(List(JField("order_by", JString(order_by)), JField("direction", JString("asc"))))
+          case DescOrderOperator(order_by) =>
+            JObject(List(JField("order_by", JString(order_by)), JField("direction", JString("desc"))))
+        }))
 
-  case object LikeExpressionSerializer extends CustomSerializer[LikeExpression](_ => ( {
-    case JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("null")), JField("value", JString(value)))) => LikeExpression(dimension, value)
-  }, {
-    case LikeExpression(dimension, value) => JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("like")), JField("value", JString(value))))
-  }
-  ))
+  case object NullableExpressionSerializer
+      extends CustomSerializer[NullableExpression](_ =>
+        ({
+          case JObject(List(JField(_, JString(dimension)), JField(_, JString("like")))) => NullableExpression(dimension)
+        }, {
+          case NullableExpression(dimension) =>
+            JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("null"))))
+        }))
 
-  case object EqualityExpressionSerializer extends CustomSerializer[EqualityExpression[_]](_ => ( {
-    case JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("=")), JField("value", JLong(value)))) => EqualityExpression(dimension, AbsoluteComparisonValue(value: Long))
-    case JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("=")), JField("value", JInt(value)))) =>EqualityExpression(dimension, AbsoluteComparisonValue(value.intValue(): Int))
-    case JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("=")), JField("value", JString(value)))) =>EqualityExpression(dimension, AbsoluteComparisonValue(value: String))
-    case JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("=")), JField("value", JDouble(value)))) =>EqualityExpression(dimension, AbsoluteComparisonValue(value: Double))
-    case JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("=")), JField("value", JObject(
-    List(JField("value", JLong(value)), JField("operator", JString(operator)), JField("quantity", JLong(quantity)), JField("unitMeasure", JString(unitMeasure)))
-    )))) => EqualityExpression(dimension, RelativeComparisonValue(value: Long, operator, quantity: Long, unitMeasure))
-  }, {
-    case EqualityExpression(dimension, AbsoluteComparisonValue(value: Long)) => JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("=")), JField("value", JLong(value))))
-    case EqualityExpression(dimension, AbsoluteComparisonValue(value: Int)) => JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("=")), JField("value", JInt(value))))
-    case EqualityExpression(dimension, AbsoluteComparisonValue(value: String)) => JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("=")), JField("value", JString(value))))
-    case EqualityExpression(dimension, AbsoluteComparisonValue(value: Double)) => JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("=")), JField("value", JDouble(value))))
-    case EqualityExpression(dimension, RelativeComparisonValue(value: Long, operator, quantity: Long, unitMeasure)) =>
-      JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("=")), JField("value", JObject(
-        List(JField("value", JLong(value)), JField("operator", JString(operator)), JField("quantity", JLong(quantity)), JField("unitMeasure", JString(unitMeasure)))
-      ))))
-  }))
+  case object LikeExpressionSerializer
+      extends CustomSerializer[LikeExpression](_ =>
+        ({
+          case JObject(
+              List(JField("dimension", JString(dimension)),
+                   JField("comparison", JString("null")),
+                   JField("value", JString(value)))) =>
+            LikeExpression(dimension, value)
+        }, {
+          case LikeExpression(dimension, value) =>
+            JObject(
+              List(JField("dimension", JString(dimension)),
+                   JField("comparison", JString("like")),
+                   JField("value", JString(value))))
+        }))
+
+  case object EqualityExpressionSerializer
+      extends CustomSerializer[EqualityExpression[_]](_ =>
+        ({
+          case JObject(
+              List(JField("dimension", JString(dimension)),
+                   JField("comparison", JString("=")),
+                   JField("value", JLong(value)))) =>
+            EqualityExpression(dimension, AbsoluteComparisonValue(value: Long))
+          case JObject(
+              List(JField("dimension", JString(dimension)),
+                   JField("comparison", JString("=")),
+                   JField("value", JInt(value)))) =>
+            EqualityExpression(dimension, AbsoluteComparisonValue(value.intValue(): Int))
+          case JObject(
+              List(JField("dimension", JString(dimension)),
+                   JField("comparison", JString("=")),
+                   JField("value", JString(value)))) =>
+            EqualityExpression(dimension, AbsoluteComparisonValue(value: String))
+          case JObject(
+              List(JField("dimension", JString(dimension)),
+                   JField("comparison", JString("=")),
+                   JField("value", JDouble(value)))) =>
+            EqualityExpression(dimension, AbsoluteComparisonValue(value: Double))
+          case JObject(
+              List(JField("dimension", JString(dimension)),
+                   JField("comparison", JString("=")),
+                   JField("value",
+                          JObject(
+                            List(JField("value", JLong(value)),
+                                 JField("operator", JString(operator)),
+                                 JField("quantity", JLong(quantity)),
+                                 JField("unitMeasure", JString(unitMeasure)))
+                          )))) =>
+            EqualityExpression(dimension, RelativeComparisonValue(value: Long, operator, quantity: Long, unitMeasure))
+        }, {
+          case EqualityExpression(dimension, AbsoluteComparisonValue(value: Long)) =>
+            JObject(
+              List(JField("dimension", JString(dimension)),
+                   JField("comparison", JString("=")),
+                   JField("value", JLong(value))))
+          case EqualityExpression(dimension, AbsoluteComparisonValue(value: Int)) =>
+            JObject(
+              List(JField("dimension", JString(dimension)),
+                   JField("comparison", JString("=")),
+                   JField("value", JInt(value))))
+          case EqualityExpression(dimension, AbsoluteComparisonValue(value: String)) =>
+            JObject(
+              List(JField("dimension", JString(dimension)),
+                   JField("comparison", JString("=")),
+                   JField("value", JString(value))))
+          case EqualityExpression(dimension, AbsoluteComparisonValue(value: Double)) =>
+            JObject(
+              List(JField("dimension", JString(dimension)),
+                   JField("comparison", JString("=")),
+                   JField("value", JDouble(value))))
+          case EqualityExpression(dimension,
+                                  RelativeComparisonValue(value: Long, operator, quantity: Long, unitMeasure)) =>
+            JObject(
+              List(
+                JField("dimension", JString(dimension)),
+                JField("comparison", JString("=")),
+                JField(
+                  "value",
+                  JObject(
+                    List(JField("value", JLong(value)),
+                         JField("operator", JString(operator)),
+                         JField("quantity", JLong(quantity)),
+                         JField("unitMeasure", JString(unitMeasure)))
+                  )
+                )
+              ))
+        }))
+
+  case object RelativeComparisonTestingSerializer
+      extends CustomSerializer[RelativeComparisonValue[_]](_ =>
+        ({
+          case JObject(
+              List(JField("value", JLong(0L)),
+                   JField("operator", JString(operator)),
+                   JField("quantity", JLong(quantity)),
+                   JField("unitMeasure", JString(unitMeasure)))) =>
+            RelativeComparisonValue(0L, operator, quantity, unitMeasure)
+        }, {
+          case RelativeComparisonValue(_, operator, quantity: Long, unitMeasure) =>
+            JObject(
+              List(JField("value", JLong(0L)),
+                   JField("operator", JString(operator)),
+                   JField("quantity", JLong(quantity)),
+                   JField("unitMeasure", JString(unitMeasure))))
+
+        }))
 
 }

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
@@ -30,7 +30,7 @@ import io.radicalbit.nsdb.security.http.NSDBAuthProvider
 import io.radicalbit.nsdb.security.model.{Db, Metric, Namespace}
 import io.swagger.annotations._
 import javax.ws.rs.Path
-import org.json4s.DefaultFormats
+import org.json4s.{DefaultFormats, Formats}
 import org.json4s.jackson.Serialization.write
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -46,7 +46,7 @@ trait CommandApi {
   def authenticationProvider: NSDBAuthProvider
 
   implicit val timeout: Timeout
-  implicit val formats: DefaultFormats
+  implicit val formats: Formats
   implicit val ec: ExecutionContext
 
   case class CommandRequestDatabase(db: String)                                  extends Db

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/DataApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/DataApi.scala
@@ -17,7 +17,6 @@
 package io.radicalbit.nsdb.web.routes
 
 import javax.ws.rs.Path
-
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.http.scaladsl.model.HttpResponse
@@ -31,7 +30,7 @@ import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{InputMapped, RecordRe
 import io.radicalbit.nsdb.security.http.NSDBAuthProvider
 import io.radicalbit.nsdb.security.model.Metric
 import io.swagger.annotations._
-import org.json4s.DefaultFormats
+import org.json4s.{DefaultFormats, Formats}
 
 import scala.annotation.meta.field
 import scala.util.{Failure, Success}
@@ -57,7 +56,7 @@ trait DataApi {
   def authenticationProvider: NSDBAuthProvider
 
   implicit val timeout: Timeout
-  implicit val formats: DefaultFormats
+  implicit val formats: Formats
 
   @ApiOperation(value = "Insert Bit", nickname = "insert", httpMethod = "POST", response = classOf[String])
   @ApiImplicitParams(

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
@@ -16,26 +16,17 @@
 
 package io.radicalbit.nsdb.web.routes
 
-import javax.ws.rs.Path
 import akka.actor.ActorRef
 import akka.event.LoggingAdapter
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
 import akka.http.scaladsl.model.StatusCodes.{BadRequest, InternalServerError, NotFound}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import akka.util.Timeout
 import akka.pattern.ask
+import akka.util.Timeout
 import io.radicalbit.nsdb.common.JSerializable
 import io.radicalbit.nsdb.common.protocol.Bit
-import io.radicalbit.nsdb.common.statement.{
-  Aggregation,
-  CountAggregation,
-  MaxAggregation,
-  MinAggregation,
-  SQLStatement,
-  SelectSQLStatement,
-  SumAggregation
-}
+import io.radicalbit.nsdb.common.statement.{SQLStatement, SelectSQLStatement}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.ExecuteStatement
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.security.http.NSDBAuthProvider
@@ -43,9 +34,9 @@ import io.radicalbit.nsdb.security.model.Metric
 import io.radicalbit.nsdb.sql.parser.SQLStatementParser
 import io.radicalbit.nsdb.web.CustomSerializers
 import io.swagger.annotations._
-import org.json4s
-import org.json4s.{CustomSerializer, DefaultFormats, Formats, JNull, JString}
+import javax.ws.rs.Path
 import org.json4s.jackson.Serialization.write
+import org.json4s.{DefaultFormats, Formats}
 
 import scala.annotation.meta.field
 import scala.util.{Failure, Success}
@@ -129,7 +120,7 @@ trait QueryApi {
   case class QueryResponse(
       @(ApiModelProperty @field)(value = "query result as a Seq of Bits ") records: Seq[Bit],
       @(ApiModelProperty @field)(value = "json representation of query ", required = false, dataType = "SQLStatement") parsed: Option[
-        SQLStatement],
+        SQLStatement]
   )
 
   @ApiOperation(value = "Perform query", nickname = "query", httpMethod = "POST", response = classOf[QueryResponse])

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
@@ -57,7 +57,7 @@ object NullableOperators extends Enumeration {
   val IsNotNull = Value("ISNOTNULL")
 }
 
-@ApiModel(description = "Filter sealed trait ", subTypes = Array(classOf[FilterNullableValue], classOf[FilterByValue]))
+@ApiModel(description = "Filter sealed trait", subTypes = Array(classOf[FilterNullableValue], classOf[FilterByValue]))
 sealed trait Filter
 
 case object Filter {
@@ -70,27 +70,27 @@ case object Filter {
 
 @ApiModel(description = "Filter using operator", parent = classOf[Filter])
 case class FilterByValue(
-    @(ApiModelProperty @field)(value = "dimension on which apply condition ") dimension: String,
+    @(ApiModelProperty @field)(value = "dimension on which apply condition") dimension: String,
     @(ApiModelProperty @field)(value = "value of comparation") value: JSerializable,
     @(ApiModelProperty @field)(
       value = "filter comparison operator",
       dataType = "io.radicalbit.nsdb.web.routes.FilterOperators") operator: FilterOperators.Value
 ) extends Filter
 
-@ApiModel(description = "Filter for nullable ", parent = classOf[Filter])
+@ApiModel(description = "Filter for nullable", parent = classOf[Filter])
 case class FilterNullableValue(
-    @(ApiModelProperty @field)(value = "dimension on which apply condition ") dimension: String,
+    @(ApiModelProperty @field)(value = "dimension on which apply condition") dimension: String,
     @(ApiModelProperty @field)(
       value = "filter nullability operator",
       dataType = "io.radicalbit.nsdb.web.routes.NullableOperators") operator: NullableOperators.Value
 ) extends Filter
 
 @ApiModel(description = "Query body")
-case class QueryBody(@(ApiModelProperty @field)(value = "database name ") db: String,
-                     @(ApiModelProperty @field)(value = "namespace name ") namespace: String,
-                     @(ApiModelProperty @field)(value = "metric name ") metric: String,
+case class QueryBody(@(ApiModelProperty @field)(value = "database name") db: String,
+                     @(ApiModelProperty @field)(value = "namespace name") namespace: String,
+                     @(ApiModelProperty @field)(value = "metric name") metric: String,
                      @(ApiModelProperty @field)(value = "sql query string") queryString: String,
-                     @(ApiModelProperty @field)(value = "timestamp lower bound condition ",
+                     @(ApiModelProperty @field)(value = "timestamp lower bound condition",
                                                 required = false,
                                                 dataType = "long") from: Option[Long],
                      @(ApiModelProperty @field)(value = "timestamp upper bound condition",
@@ -118,8 +118,8 @@ trait QueryApi {
 
   @ApiModel(description = "Query Response")
   case class QueryResponse(
-      @(ApiModelProperty @field)(value = "query result as a Seq of Bits ") records: Seq[Bit],
-      @(ApiModelProperty @field)(value = "json representation of query ", required = false, dataType = "SQLStatement") parsed: Option[
+      @(ApiModelProperty @field)(value = "query result as a Seq of Bits") records: Seq[Bit],
+      @(ApiModelProperty @field)(value = "json representation of query", required = false, dataType = "SQLStatement") parsed: Option[
         SQLStatement]
   )
 
@@ -169,13 +169,8 @@ trait QueryApi {
                 case Some(statement) =>
                   onComplete(readCoordinator ? ExecuteStatement(statement)) {
                     case Success(SelectStatementExecuted(_, values)) =>
-                      qb.parsed match {
-                        case Some(true) =>
-                          complete(
-                            HttpEntity(ContentTypes.`application/json`, write(QueryResponse(values, Some(statement)))))
-                        case None =>
-                          complete(HttpEntity(ContentTypes.`application/json`, write(QueryResponse(values, None))))
-                      }
+                      complete(HttpEntity(ContentTypes.`application/json`,
+                                          write(QueryResponse(values, qb.parsed.map(_ => statement)))))
                     case Success(SelectStatementFailed(_, reason, MetricNotFound(metric))) =>
                       complete(HttpResponse(NotFound, entity = reason))
                     case Success(SelectStatementFailed(_, reason, _)) =>

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
@@ -27,14 +27,16 @@ import akka.util.Timeout
 import akka.pattern.ask
 import io.radicalbit.nsdb.common.JSerializable
 import io.radicalbit.nsdb.common.protocol.Bit
-import io.radicalbit.nsdb.common.statement.{SQLStatement, SelectSQLStatement}
+import io.radicalbit.nsdb.common.statement.{Aggregation, CountAggregation, MaxAggregation, MinAggregation, SQLStatement, SelectSQLStatement, SumAggregation}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.ExecuteStatement
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.security.http.NSDBAuthProvider
 import io.radicalbit.nsdb.security.model.Metric
 import io.radicalbit.nsdb.sql.parser.SQLStatementParser
+import io.radicalbit.nsdb.web.CustomSerializers
 import io.swagger.annotations._
-import org.json4s.DefaultFormats
+import org.json4s
+import org.json4s.{CustomSerializer, DefaultFormats, Formats, JNull, JString}
 import org.json4s.jackson.Serialization.write
 
 import scala.annotation.meta.field
@@ -113,7 +115,9 @@ trait QueryApi {
   def authenticationProvider: NSDBAuthProvider
 
   implicit val timeout: Timeout
-  implicit val formats: DefaultFormats
+  implicit val newFormats: Formats = DefaultFormats ++ CustomSerializers.customSerializers
+
+  // implicit val formats: DefaultFormats = DefaultFormats
 
   @ApiModel(description = "Query Response")
   case class QueryResponse(

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
@@ -27,7 +27,15 @@ import akka.util.Timeout
 import akka.pattern.ask
 import io.radicalbit.nsdb.common.JSerializable
 import io.radicalbit.nsdb.common.protocol.Bit
-import io.radicalbit.nsdb.common.statement.{Aggregation, CountAggregation, MaxAggregation, MinAggregation, SQLStatement, SelectSQLStatement, SumAggregation}
+import io.radicalbit.nsdb.common.statement.{
+  Aggregation,
+  CountAggregation,
+  MaxAggregation,
+  MinAggregation,
+  SQLStatement,
+  SelectSQLStatement,
+  SumAggregation
+}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.ExecuteStatement
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.security.http.NSDBAuthProvider
@@ -115,9 +123,7 @@ trait QueryApi {
   def authenticationProvider: NSDBAuthProvider
 
   implicit val timeout: Timeout
-  implicit val newFormats: Formats = DefaultFormats ++ CustomSerializers.customSerializers
-
-  // implicit val formats: DefaultFormats = DefaultFormats
+  implicit val formats: Formats = DefaultFormats ++ CustomSerializers.customSerializers
 
   @ApiModel(description = "Query Response")
   case class QueryResponse(

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryValidationApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryValidationApi.scala
@@ -32,7 +32,7 @@ import io.radicalbit.nsdb.security.model.Metric
 import io.radicalbit.nsdb.sql.parser.SQLStatementParser
 import io.swagger.annotations._
 import javax.ws.rs.Path
-import org.json4s.DefaultFormats
+import org.json4s.{DefaultFormats, Formats}
 
 import scala.annotation.meta.field
 import scala.util.{Failure, Success}
@@ -54,7 +54,7 @@ trait QueryValidationApi {
   def authenticationProvider: NSDBAuthProvider
 
   implicit val timeout: Timeout
-  implicit val formats: DefaultFormats
+  implicit val formats: Formats
 
   @ApiOperation(value = "Perform query", nickname = "query", httpMethod = "POST", response = classOf[String])
   @ApiImplicitParams(

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
@@ -56,7 +56,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
     override def authenticationProvider: NSDBAuthProvider = secureAuthenticationProvider
 
     override def readCoordinator: ActorRef        = readCoordinatorActor
-    override implicit val formats: DefaultFormats = DefaultFormats
+    implicit val formats: DefaultFormats = DefaultFormats
     override implicit val timeout: Timeout        = 5 seconds
 
   }
@@ -66,7 +66,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
 
     override def readCoordinator: ActorRef = readCoordinatorActor
 
-    override implicit val formats: DefaultFormats = DefaultFormats
+    implicit val formats: DefaultFormats = DefaultFormats
     override implicit val timeout: Timeout        = 5 seconds
   }
 
@@ -281,15 +281,15 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
   }
 
   "QueryApi called with optional parameter parsed = true" should
-    "correctly query the db with a single filter over Long and return the parsed query" in {
+    "correctly query the db with a simple count aggregation query and return the parsed query" in {
     val q =
       QueryBody("db",
                 "namespace",
                 "metric",
-                "select * from metric limit 1",
+                "select count(*) from metric limit 1",
                 None,
                 None,
-                Some(Seq(FilterByValue("value", 1L, FilterOperators.Equality))),
+                None,
                 Some(true))
 
     Post("/query", q) ~> testRoutes ~> check {
@@ -325,12 +325,11 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
           |    "namespace" : "namespace",
           |    "metric" : "metric",
           |    "distinct" : false,
-          |    "fields" : { },
-          |    "condition" : {
-          |      "expression" : {
-          |        "dimension" : "value",
-          |        "value" : 1
-          |      }
+          |    "fields" : {
+          |      "fields" : [ {
+          |        "name" : "*",
+          |        "aggregation" : "count"
+          |      } ]
           |    },
           |    "limit" : {
           |      "value" : 1


### PR DESCRIPTION
This PR completes #89 adding the possibility to have the parsed query (in json) returned from the /query API using an optional parameter in the POST request

- with optional boolean parsed parameter in the request we can have the parsed query returned, omitting the parameter the api will only return the data retrieved
- added some tests to test the new functionality, in particular for relative values tests there is an additional custom serializer that is plugged in that cut off the now timestamp (replacing it with a 0) in order to make the test time independent.
- CustomSerializers.scala can be eventually used to plug-in other custom serializers

PS: please focus on implicit formats changes to see if they are correct