### PR TITLE
K8s deployments support

### DIFF
--- a/k8s/nsdb-cluster.yml
+++ b/k8s/nsdb-cluster.yml
@@ -1,0 +1,97 @@
+#deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nsdb
+  name: nsdb
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+     app: nsdb
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+
+  template:
+    metadata:
+      labels:
+        app: nsdb
+        actorSystemName: nsdb
+    spec:
+      containers:
+      - name: nsdb
+        image: tools.radicalbit.io/nsdb:1.0.0-SNAPSHOT
+        # Remove for a real project, the image is picked up locally for the integratio test
+        imagePullPolicy: Never
+        #health
+        livenessProbe:
+          httpGet:
+            path: /alive
+            port: management
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: management
+        #health
+        ports:
+        - name: remoting
+          containerPort: 2552
+          protocol: TCP
+        - name: management
+          containerPort: 8558
+          protocol: TCP
+        - name: http
+          containerPort: 9000
+          protocol: TCP
+        - name: grpc
+          containerPort: 7817
+          protocol: TCP
+          # when contact-point-discovery.port-name is set for cluster bootstrap,
+          # the management port must be named accordingly:
+          # name: management
+        env:
+        # The Kubernetes API discovery will use this service name to look for
+        # nodes with this value in the 'app' label.
+        # This can be customized with the 'pod-label-selector' setting.
+        - name: AKKA_CLUSTER_BOOTSTRAP_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: "metadata.labels['app']"
+#deployment
+---
+#rbac
+#
+# Create a role, `pod-reader`, that can list pods and
+# bind the default service account in the namespace
+# that the binding is deployed to to that role.
+#
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-reader
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: read-pods
+subjects:
+  # Uses the default service account.
+  # Consider creating a dedicated service account to run your
+  # Akka Cluster services and binding the role to that one.
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io
+#rbac

--- a/k8s/nsdb-cluster.yml
+++ b/k8s/nsdb-cluster.yml
@@ -25,8 +25,6 @@ spec:
       containers:
       - name: nsdb
         image: tools.radicalbit.io/nsdb:1.0.0-SNAPSHOT
-        # Remove for a real project, the image is picked up locally for the integratio test
-        imagePullPolicy: Never
         #health
         livenessProbe:
           httpGet:
@@ -62,6 +60,10 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: "metadata.labels['app']"
+        - name: CLUSTER_MODE
+          value: "k8s"
+        - name: SHARD_INTERVAL
+            value: "10d"
 #deployment
 ---
 #rbac

--- a/k8s/nsdb-service.yml
+++ b/k8s/nsdb-service.yml
@@ -1,0 +1,21 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: nsdb
+spec:
+  type: NodePort
+  selector:
+    app: nsdb
+  ports:
+  - protocol: TCP
+    name: management
+    port: 8558
+    targetPort: management
+  - protocol: TCP
+    name: http
+    port: 9000
+    targetPort: http
+  - protocol: TCP
+    name: grpc
+    port: 7817
+    targetPort: grpc

--- a/nsdb-cluster/src/main/resources/application-k8s.conf
+++ b/nsdb-cluster/src/main/resources/application-k8s.conf
@@ -1,3 +1,17 @@
+# Copyright 2018 Radicalbit S.r.l.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 akka {
   discovery {
     kubernetes-api {

--- a/nsdb-cluster/src/main/resources/nsdb.conf
+++ b/nsdb-cluster/src/main/resources/nsdb.conf
@@ -35,7 +35,6 @@ nsdb {
     port = ${?HTTP_PORT}
     https-port = 9443
     https-port = ${?HTTPS_PORT}
-
   }
 
   storage {
@@ -69,6 +68,7 @@ nsdb {
 
   sharding {
     interval = 1d
+    interval = ${?SHARD_INTERVAL}
     passivate-after = 1h
   }
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDBAkkaCluster.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDBAkkaCluster.scala
@@ -26,7 +26,6 @@ import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.actor._
-import io.radicalbit.nsdb.common.configuration.NsdbConfigProvider
 
 import scala.concurrent.ExecutionContextExecutor
 
@@ -43,15 +42,15 @@ trait NSDBActors {
   implicit lazy val executionContext: ExecutionContextExecutor = system.dispatcher
 
   def initTopLevelActors(): Unit = {
+    AkkaManagement(system).start()
+    ClusterBootstrap(system).start()
+
     system.actorOf(
       ClusterSingletonManager.props(singletonProps = Props(classOf[DatabaseActorsGuardian]),
                                     terminationMessage = PoisonPill,
                                     settings = ClusterSingletonManagerSettings(system)),
       name = "databaseActorGuardian"
     )
-
-    AkkaManagement(system).start()
-    ClusterBootstrap(system).start()
 
     DistributedData(system).replicator
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbClusterConfigProvider.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbClusterConfigProvider.scala
@@ -20,6 +20,7 @@ import java.nio.file.Paths
 
 import com.typesafe.config.{Config, ConfigFactory}
 import io.radicalbit.nsdb.common.configuration.NsdbConfigProvider
+import io.radicalbit.nsdb.util.ConfigKeys
 
 /**
   * Creates NSDb user defined configuration looking up the `ConfDir` folder or into the classpath.
@@ -32,8 +33,10 @@ trait NsdbClusterConfigProvider extends NsdbConfigProvider {
     .resolve()
 
   override lazy val lowLevelTemplateConfig: Config =
-    mergeConf(userDefinedConfig,
-              ConfigFactory.parseResources("application-native.conf"),
-              ConfigFactory.parseResources("application-common.conf"))
+    mergeConf(
+      userDefinedConfig,
+      ConfigFactory.parseResources(s"application-${userDefinedConfig.getString(ConfigKeys.ClusterMode)}.conf"),
+      ConfigFactory.parseResources("application-common.conf")
+    )
 
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/util/ErrorManagementUtils.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/util/ErrorManagementUtils.scala
@@ -16,8 +16,6 @@
 
 package io.radicalbit.nsdb.cluster.util
 
-import scala.reflect.ClassTag
-
 object ErrorManagementUtils {
 
   /**

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
@@ -23,7 +23,6 @@ import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache._
 import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.Coordinates
 import io.radicalbit.nsdb.model.Location
-import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
@@ -176,14 +176,12 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
     * Retrieves and order results from different shards in case the statement does not contains aggregations
     * and a where condition involving timestamp has been provided.
     *
-    * @param statement select sql statement.
     * @param actors shard actors to retrieve data from.
     * @param parsedStatement parsed statement.
     * @param msg the original [[ExecuteSelectStatement]] command
     * @return a single sequence of results obtained from different shards.
     */
   private def retrieveAndOrderPlainResults(
-      statement: SelectSQLStatement,
       actors: Seq[(Location, ActorRef)],
       parsedStatement: ParsedSimpleQuery,
       msg: ExecuteSelectStatement): Future[Either[SelectStatementFailed, Seq[Bit]]] = {
@@ -253,7 +251,7 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
           val actors =
             actorsForLocations(locations)
 
-          val orderedResults = retrieveAndOrderPlainResults(statement, actors, parsedStatement, msg)
+          val orderedResults = retrieveAndOrderPlainResults(actors, parsedStatement, msg)
 
           orderedResults
             .map {

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/RollingCommitLogFileChecker.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/RollingCommitLogFileChecker.scala
@@ -88,7 +88,7 @@ class RollingCommitLogFileChecker(db: String, namespace: String, metric: String)
         closedEntries.foreach {
           closedEntry =>
             pendingOutdatedEntries.foreach {
-              case (file, (pending, _)) =>
+              case (_, (pending, _)) =>
                 if (pending.toList.contains(closedEntry)) {
                   log.debug(s"removing entry: $closedEntry in file $fileName processing file: $fileName")
                   pendingOutdatedEntries(fileName)._1 -= closedEntry

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/FacetIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/FacetIndex.scala
@@ -18,7 +18,6 @@ package io.radicalbit.nsdb.index
 
 import io.radicalbit.nsdb.common.JSerializable
 import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType}
-import io.radicalbit.nsdb.model.TypedField
 import org.apache.lucene.document._
 import org.apache.lucene.facet._
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/ConfigKeys.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/ConfigKeys.scala
@@ -33,4 +33,5 @@ object ConfigKeys {
   val HttpPort      = "nsdb.http.port"
   val HttpsPort     = "nsdb.http.https-port"
 
+  val ClusterMode = "nsdb.cluster.mode"
 }

--- a/nsdb-it/src/test/resources/application-k8s.conf
+++ b/nsdb-it/src/test/resources/application-k8s.conf
@@ -1,0 +1,37 @@
+akka {
+  discovery {
+    kubernetes-api {
+      class = akka.discovery.kubernetes.KubernetesApiServiceDiscovery
+
+      # API server, cert and token information. Currently these are present on K8s versions: 1.6, 1.7, 1.8, and perhaps more
+      api-ca-path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      api-token-path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      api-service-host-env-name = "KUBERNETES_SERVICE_HOST"
+      api-service-port-env-name = "KUBERNETES_SERVICE_PORT"
+
+      # Namespace discovery path
+      #
+      # If this path doesn't exist, the namespace will default to "default".
+      pod-namespace-path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+      # Namespace to query for pods.
+      #
+      # Set this value to a specific string to override discovering the namespace using pod-namespace-path.
+      pod-namespace = "<pod-namespace>"
+
+      # Domain of the k8s cluster
+      pod-domain = "cluster.local"
+
+      # in fact, this is already the default:
+      pod-label-selector = "app=%s"
+    }
+  }
+
+  management {
+    cluster.bootstrap {
+      contact-point-discovery {
+        discovery-method = kubernetes-api
+      }
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,6 +72,13 @@ object Dependencies {
     lazy val version   = "1.0.3"
     lazy val namespace = "com.lightbend.akka.management"
     lazy val cluster_bootstrap = namespace %% "akka-management-cluster-bootstrap" % version
+    lazy val cluster_http = namespace %% "akka-management-cluster-http" % version
+  }
+
+  object akka_discovery {
+    lazy val version   = akka_management.version
+    lazy val namespace = "com.lightbend.akka.discovery"
+    lazy val kubernetes_api =  namespace %% "akka-discovery-kubernetes-api" % version
   }
 
   object scala_logging {
@@ -240,6 +247,8 @@ object Dependencies {
       akka.clusterTools,
       akka.discovery,
       akka_management.cluster_bootstrap,
+      akka_management.cluster_http,
+      akka_discovery.kubernetes_api,
       akka.distributedData,
       scala_logging.scala_logging,
       akka.slf4j,


### PR DESCRIPTION
This PR allows a cluster formation inside a k8s deployment (statefulset is not supported at the moment)

The implementation strongly leverages akka management library that can be found here:
https://doc.akka.io/docs/akka-management/current/bootstrap/kubernetes.html

inside the k8s folder, we can find a deployment and service example