### PR TITLE
Evict locations for a Node

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
@@ -87,7 +87,9 @@ class ClusterListener(nodeActorsGuardianProps: Props) extends Actor with ActorLo
               .sequence {
                 locationsGroupedBy.map {
                   case ((db, namespace), locations) =>
-                    metadataCoordinator ? AddLocations(db, namespace, locations.map(_._3))
+                    metadataCoordinator ? AddLocations(db, namespace, locations.map {
+                      case (_, _, location) => location
+                    })
                 }
               }
               .map(ErrorManagementUtils.partitionResponses[LocationsAdded, AddLocationsFailed])
@@ -108,13 +110,14 @@ class ClusterListener(nodeActorsGuardianProps: Props) extends Actor with ActorLo
     case UnreachableMember(member) =>
       log.debug("Member detected as unreachable: {}", member)
     case MemberRemoved(member, previousStatus) =>
-      log.debug("Member is Removed: {} after {}", member.address, previousStatus)
+      log.info("Member is Removed: {} after {}", member.address, previousStatus)
+
     case _: MemberEvent => // ignore
   }
 }
 
 object ClusterListener {
 
-  def props(nodeActorsGuardianProps: Props) =
+  def props(nodeActorsGuardianProps: Props): Props =
     Props(new ClusterListener(nodeActorsGuardianProps))
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -87,7 +87,7 @@ class MetadataCoordinator(cache: ActorRef, schemaCoordinator: ActorRef, mediator
     Future
       .sequence(
         locations.map(location =>
-          (cache ? PutLocationInCache(db, namespace, location.metric, location.from, location.to, location))
+          (cache ? PutLocationInCache(db, namespace, location.metric, location))
             .mapTo[AddLocationResponse]))
       .flatMap { responses =>
         val (successResponses: List[LocationCached], errorResponses: List[PutLocationInCacheFailed]) =

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -98,8 +98,8 @@ class ReplicatedMetadataCacheSpec
 
       runOn(node1) {
         awaitAssert {
-          replicatedCache ! PutLocationInCache("db", "namespace", metric, 0, 1, location1)
-          expectMsg(LocationCached("db", "namespace", metric, 0, 1, location1))
+          replicatedCache ! PutLocationInCache("db", "namespace", metric,  location1)
+          expectMsg(LocationCached("db", "namespace", metric, location1))
         }
       }
 
@@ -114,8 +114,8 @@ class ReplicatedMetadataCacheSpec
 
       runOn(node1) {
         awaitAssert {
-          replicatedCache ! PutLocationInCache("db", "namespace", metric, 0, 1, location2)
-          expectMsg(LocationCached("db", "namespace", metric, 0, 1, location2))
+          replicatedCache ! PutLocationInCache("db", "namespace", metric,  location2)
+          expectMsg(LocationCached("db", "namespace", metric,  location2))
         }
       }
 
@@ -156,8 +156,8 @@ class ReplicatedMetadataCacheSpec
 
       runOn(node2) {
         awaitAssert {
-          replicatedCache ! PutLocationInCache("db1", "namespace1", "metric2", 0,1,location22)
-          expectMsg(LocationCached("db1", "namespace1", "metric2", 0,1, location22))
+          replicatedCache ! PutLocationInCache("db1", "namespace1", "metric2", location22)
+          expectMsg(LocationCached("db1", "namespace1", "metric2", location22))
         }
       }
 
@@ -224,8 +224,8 @@ class ReplicatedMetadataCacheSpec
 
       runOn(node1) {
         awaitAssert {
-          replicatedCache ! PutLocationInCache("db1", "namespace1", "metric2", 0, 1, newLocation)
-          expectMsg(LocationCached("db1", "namespace1", "metric2", 0, 1, newLocation))
+          replicatedCache ! PutLocationInCache("db1", "namespace1", "metric2",  newLocation)
+          expectMsg(LocationCached("db1", "namespace1", "metric2",  newLocation))
         }
       }
 
@@ -245,16 +245,16 @@ class ReplicatedMetadataCacheSpec
       val metric2InfoValue = MetricInfo("db1", "namespace1", "metric2", 1, 0)
 
       runOn(node1) {
-        replicatedCache ! PutLocationInCache("db1", "namespace1", "metric1", 0, 1, l1)
-        expectMsg(LocationCached("db1", "namespace1", "metric1", 0, 1, l1))
+        replicatedCache ! PutLocationInCache("db1", "namespace1", "metric1",  l1)
+        expectMsg(LocationCached("db1", "namespace1", "metric1",  l1))
 
         replicatedCache ! PutMetricInfoInCache(metric1InfoValue)
         expectMsg(MetricInfoCached("db1", "namespace1", "metric1", Some(metric1InfoValue)))
       }
 
       runOn(node1) {
-        replicatedCache ! PutLocationInCache("db1", "namespace1", "metric2", 0, 1, l2)
-        expectMsg(LocationCached("db1", "namespace1", "metric2", 0, 1, l2))
+        replicatedCache ! PutLocationInCache("db1", "namespace1", "metric2",  l2)
+        expectMsg(LocationCached("db1", "namespace1", "metric2",  l2))
 
         replicatedCache ! PutMetricInfoInCache(metric2InfoValue)
         expectMsg(MetricInfoCached("db1", "namespace1", "metric2", Some(metric2InfoValue)))
@@ -311,13 +311,13 @@ class ReplicatedMetadataCacheSpec
       enterBarrier("after-drop-namespace")
 
       runOn(node1) {
-        replicatedCache ! PutLocationInCache("db1", "namespace1", "metric1", 0, 1, l1)
-        expectMsg(LocationCached("db1", "namespace1", "metric1", 0, 1, l1))
+        replicatedCache ! PutLocationInCache("db1", "namespace1", "metric1",  l1)
+        expectMsg(LocationCached("db1", "namespace1", "metric1",  l1))
       }
 
       runOn(node1) {
-        replicatedCache ! PutLocationInCache("db1", "namespace1", "metric2", 0, 1, l2)
-        expectMsg(LocationCached("db1", "namespace1", "metric2", 0, 1, l2))
+        replicatedCache ! PutLocationInCache("db1", "namespace1", "metric2",  l2)
+        expectMsg(LocationCached("db1", "namespace1", "metric2",  l2))
       }
 
       awaitAssert {
@@ -336,8 +336,8 @@ class ReplicatedMetadataCacheSpec
 
       runOn(node1) {
         for (i ← 10 to 20) {
-          replicatedCache ! PutLocationInCache("db", "namespace", metric, i - 1, i, location(i - 1, i))
-          expectMsg(LocationCached("db", "namespace", metric, i - 1, i, location(i - 1, i)))
+          replicatedCache ! PutLocationInCache("db", "namespace", metric, location(i - 1, i))
+          expectMsg(LocationCached("db", "namespace", metric, location(i - 1, i)))
 
           replicatedCache ! PutMetricInfoInCache(metricInfoValue(s"metric_$i"))
           expectMsg(MetricInfoCached("db", "namespace", s"metric_$i", Some(metricInfoValue(s"metric_$i"))))
@@ -392,8 +392,8 @@ class ReplicatedMetadataCacheSpec
       val location  = Location(metric, "node1", 0, 1)
 
       runOn(node1) {
-        replicatedCache ! PutLocationInCache("db", "namespace", metric, 0, 1, location)
-        expectMsg(LocationCached("db", "namespace", metric, 0, 1, location))
+        replicatedCache ! PutLocationInCache("db", "namespace", metric,  location)
+        expectMsg(LocationCached("db", "namespace", metric,  location))
       }
 
       runOn(node2) {
@@ -422,13 +422,13 @@ class ReplicatedMetadataCacheSpec
       val updatedLocation = Location(metric, "node1", 0, 1)
 
       runOn(node1) {
-        replicatedCache ! PutLocationInCache("db", "namespace", metric, 0, 1, location)
-        expectMsg(LocationCached("db", "namespace", metric, 0, 1, location))
+        replicatedCache ! PutLocationInCache("db", "namespace", metric,  location)
+        expectMsg(LocationCached("db", "namespace", metric,  location))
       }
 
       runOn(node2) {
-        replicatedCache ! PutLocationInCache("db", "namespace", metric, 0, 1, updatedLocation)
-        expectMsg(LocationCached("db", "namespace", metric, 0, 1, updatedLocation))
+        replicatedCache ! PutLocationInCache("db", "namespace", metric,  updatedLocation)
+        expectMsg(LocationCached("db", "namespace", metric,  updatedLocation))
       }
 
       runOn(node1) {

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -105,10 +105,6 @@ class ReplicatedMetadataCacheSpec
 
       runOn(node2) {
         awaitAssert {
-          replicatedCache ! GetLocationFromCache("db", "namespace", metric, 0, 1)
-          expectMsg(LocationsCached("db", "namespace", metric, Seq(location1)))
-        }
-        awaitAssert {
           replicatedCache ! GetLocationsFromCache("db", "namespace", metric)
           expectMsg(LocationsCached("db", "namespace", metric, Seq(location1)))
         }
@@ -124,10 +120,6 @@ class ReplicatedMetadataCacheSpec
       }
 
       runOn(node2) {
-        awaitAssert {
-          replicatedCache ! GetLocationFromCache("db", "namespace", metric, 0, 1)
-          expectMsg(LocationsCached("db", "namespace", metric, Seq(location1, location2)))
-        }
         awaitAssert {
           replicatedCache ! GetLocationsFromCache("db", "namespace", metric)
           expectMsg(LocationsCached("db", "namespace", metric, Seq(location1, location2)))
@@ -169,10 +161,6 @@ class ReplicatedMetadataCacheSpec
         }
       }
 
-        awaitAssert {
-          replicatedCache ! GetLocationFromCache("db", "namespace", metric, 0, 1)
-          expectMsg(LocationsCached("db", "namespace", metric, Seq(location1, location2)))
-        }
         awaitAssert {
           replicatedCache ! GetLocationsFromCache("db1", "namespace1", metric1)
           expectMsg(LocationsCached("db1", "namespace1", "metric1", Seq()))
@@ -241,10 +229,6 @@ class ReplicatedMetadataCacheSpec
         }
       }
 
-      awaitAssert {
-        replicatedCache ! GetLocationFromCache("db1", "namespace1", "metric2", 0, 1)
-        expectMsg(LocationsCached("db1", "namespace1", "metric2", Seq(newLocation)))
-      }
       awaitAssert {
         replicatedCache ! GetLocationsFromCache("db1", "namespace1", "metric2")
         expectMsg(LocationsCached("db1", "namespace1", "metric2", Seq(newLocation)))
@@ -363,9 +347,6 @@ class ReplicatedMetadataCacheSpec
       runOn(node2) {
         awaitAssert {
           for (i ← 10 to 20) {
-            replicatedCache ! GetLocationFromCache("db", "namespace", metric, i - 1, i)
-            expectMsg(LocationsCached("db", "namespace", metric, Seq(location(i - 1, i))))
-
             replicatedCache ! GetMetricInfoFromCache("db", "namespace", s"metric_$i")
             expectMsg(MetricInfoCached("db", "namespace", s"metric_$i", Some(metricInfoValue(s"metric_$i"))))
           }
@@ -417,7 +398,7 @@ class ReplicatedMetadataCacheSpec
 
       runOn(node2) {
         awaitAssert {
-          replicatedCache ! GetLocationFromCache("db", "namespace", metric, 0, 1)
+          replicatedCache ! GetLocationsFromCache("db", "namespace", metric)
           expectMsg(LocationsCached("db", "namespace", metric, Seq(location)))
         }
 
@@ -427,13 +408,8 @@ class ReplicatedMetadataCacheSpec
 
       runOn(node1) {
         awaitAssert {
-          replicatedCache ! GetLocationFromCache("db", "namespace", metric, 0, 1)
-          expectMsg(LocationsCached("db", "namespace", metric, Seq.empty))
-        }
-        awaitAssert {
           replicatedCache ! GetLocationsFromCache("db", "namespace", metric)
-          val cached = expectMsgType[LocationsCached]
-          cached.value.size shouldBe 0
+          expectMsg(LocationsCached("db", "namespace", metric, Seq.empty))
         }
 
       }
@@ -457,13 +433,8 @@ class ReplicatedMetadataCacheSpec
 
       runOn(node1) {
         awaitAssert {
-          replicatedCache ! GetLocationFromCache("db", "namespace", metric, 0, 1)
-          expectMsg(LocationsCached("db", "namespace", metric, Seq(updatedLocation)))
-        }
-        awaitAssert {
           replicatedCache ! GetLocationsFromCache("db", "namespace", metric)
-          val cached = expectMsgType[LocationsCached]
-          cached.value.size shouldBe 1
+          expectMsg(LocationsCached("db", "namespace", metric, Seq(updatedLocation)))
         }
 
       }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
@@ -31,7 +31,7 @@ class LocalMetadataCache extends Actor {
 
   import LocalMetadataCache.{DeleteAll, DeleteDone}
 
-  val locations: mutable.Map[LocationWithNodeKey, Location] = mutable.Map.empty
+  val locations: mutable.Map[LocationKey, Location] = mutable.Map.empty
 
   val metricInfo: ConcurrentHashMap[MetricInfoCacheKey, MetricInfo] = new ConcurrentHashMap
 
@@ -56,7 +56,7 @@ class LocalMetadataCache extends Actor {
       coordinates --= coordinates.filter(c => c.db == db && c.namespace == namespace)
       sender() ! NamespaceFromCacheDropped(db, namespace)
     case PutLocationInCache(db, namespace, metric, from, to, value) =>
-      val key = LocationWithNodeKey(db, namespace, metric, value.node, from: Long, to: Long)
+      val key = LocationKey(db, namespace, metric, value.node, from: Long, to: Long)
       locations.put(key, value)
       coordinates += Coordinates(db, namespace, metric)
       sender ! LocationCached(db, namespace, metric, from, to, value)
@@ -80,7 +80,7 @@ class LocalMetadataCache extends Actor {
           sender ! MetricInfoCached(db, namespace, metric, Some(info))
       }
     case EvictLocation(db, namespace, location) =>
-      locations -= LocationWithNodeKey(db, namespace, location.metric, location.node, location.from, location.to)
+      locations -= LocationKey(db, namespace, location.metric, location.node, location.from, location.to)
       sender ! Right(LocationEvicted(db, namespace, location))
     case GetMetricInfoFromCache(db, namespace, metric) =>
       val key = MetricInfoCacheKey(db, namespace, metric)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
@@ -79,17 +79,17 @@ class LocalMetadataCoordinator(cache: ActorRef) extends Actor {
 
       val location = Location(metric, "localhost", start, end)
 
-      (cache ? PutLocationInCache(db, namespace, location.metric, location.from, location.to, location))
+      (cache ? PutLocationInCache(db, namespace, location.metric, location))
         .map {
-          case LocationCached(_, _, _, _, _, loc) => LocationsGot(db, namespace, metric, Seq(loc))
-          case _                                  => GetWriteLocationsFailed(db, namespace, metric, timestamp)
+          case LocationCached(_, _, _, loc) => LocationsGot(db, namespace, metric, Seq(loc))
+          case _                            => GetWriteLocationsFailed(db, namespace, metric, timestamp)
         }
         .pipeTo(sender())
     case AddLocation(db, namespace, location) =>
-      (cache ? PutLocationInCache(db, namespace, location.metric, location.from, location.to, location))
+      (cache ? PutLocationInCache(db, namespace, location.metric, location))
         .map {
-          case LocationCached(_, _, _, _, _, loc) => LocationsGot(db, namespace, location.metric, Seq(loc))
-          case _                                  => GetWriteLocationsFailed(db, namespace, location.metric, location.from)
+          case LocationCached(_, _, _, loc) => LocationsGot(db, namespace, location.metric, Seq(loc))
+          case _                            => GetWriteLocationsFailed(db, namespace, location.metric, location.from)
         }
         .pipeTo(sender())
     case GetMetricInfo(db, namespace, metric) =>


### PR DESCRIPTION
This PRs, besides applying some optimization in the distributed cache and removing a useless key previously managed, adds the `delete locations by node` that will be bound to the cluster events in a following PR 