### PR TITLE
modify now clause allowing absolute comparison

### DIFF
--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -126,12 +126,12 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
 
   // def instead val because timestamp should be calculated everytime but there is a problem with
   // more than one "now - something" in the same query because "now" will be different for each condition
-  private def delta: PackratParser[ComparisonValue[Long]] = now ~> ("+" | "-").? ~ longValue.? ~ timeMeasure.? ^^ {
-    case Some("+") ~ Some(v) ~ Some((unitMeasure, timeInterval)) =>
+  private def delta: PackratParser[ComparisonValue[Long]] = now ~> (("+" | "-") ~ longValue ~ timeMeasure).? ^^ {
+    case Some("+" ~ v ~ ((unitMeasure, timeInterval))) =>
       RelativeComparisonValue(System.currentTimeMillis() + v * timeInterval, "+", v, unitMeasure)
-    case Some("-") ~ Some(v) ~ Some((unitMeasure, timeInterval)) =>
+    case Some("-" ~ v ~ ((unitMeasure, timeInterval))) =>
       RelativeComparisonValue(System.currentTimeMillis() - v * timeInterval, "-", v, unitMeasure)
-    case None ~ None ~ None =>
+    case None =>
       AbsoluteComparisonValue(System.currentTimeMillis())
   }
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
@@ -18,8 +18,6 @@ package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
 import org.scalatest.{Matchers, WordSpec}
-import org.scalatest.TryValues._
-import org.scalatest.OptionValues._
 
 import scala.util.Success
 


### PR DESCRIPTION
This PR solves the following problem:

- `... WHERE timestamp < now`

nsdb sql parser didn't allow this before the bugfix