### PR TITLE
Add Monitoring powered by Kamon

### DIFF
--- a/nsdb-cluster/src/main/resources/kamon.conf
+++ b/nsdb-cluster/src/main/resources/kamon.conf
@@ -1,0 +1,31 @@
+# Copyright 2018 Radicalbit S.r.l.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kamon {
+  prometheus {
+    embedded-server {
+      hostname = 0.0.0.0
+      port = 9095
+    }
+  }
+
+  metric {
+    tick-interval = 5 seconds
+    filters {
+      akka-actor {
+        includes = ["NSDb/**"]
+      }
+    }
+  }
+}

--- a/nsdb-cluster/src/main/resources/monitoring.conf
+++ b/nsdb-cluster/src/main/resources/monitoring.conf
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+nsdb.monitoring.enabled = false
+
 kamon {
   prometheus {
     embedded-server {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
@@ -32,7 +32,7 @@ import scala.concurrent.ExecutionContextExecutor
 /**
   * Creates the top level actor [[DatabaseActorsGuardian]] and grpc endpoint [[GrpcEndpoint]] based on coordinators
   */
-trait NSDBActors {
+trait NSDbActors {
 
   implicit def system: ActorSystem
 
@@ -72,8 +72,3 @@ trait NSDBActors {
     )
   }
 }
-
-/**
-  * Simply mix in [[NSDBActors]] with [[NsdbClusterConfigProvider]]
-  */
-trait ProductionCluster extends NSDBActors with NsdbClusterConfigProvider

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbCluster.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbCluster.scala
@@ -17,11 +17,14 @@
 package io.radicalbit.nsdb.cluster
 
 import akka.actor.ActorSystem
+import com.typesafe.config.ConfigFactory
+import kamon.Kamon
 
 /**
   * Run a concrete Nsdb cluster node according to the configuration provided in `confDir` folder or into the classpath
   */
 object NsdbCluster extends App with ProductionCluster {
-  override val system = ActorSystem("NSDb", config)
+  Kamon.init(ConfigFactory.load("kamon.conf"))
+  val system: ActorSystem = ActorSystem("NSDb", config)
   initTopLevelActors()
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbCluster.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbCluster.scala
@@ -17,14 +17,12 @@
 package io.radicalbit.nsdb.cluster
 
 import akka.actor.ActorSystem
-import com.typesafe.config.ConfigFactory
-import kamon.Kamon
 
 /**
   * Run a concrete Nsdb cluster node according to the configuration provided in `confDir` folder or into the classpath
   */
 object NsdbCluster extends App with ProductionCluster {
-  Kamon.init(ConfigFactory.load("kamon.conf"))
+  initMonitoring()
   val system: ActorSystem = ActorSystem("NSDb", config)
   initTopLevelActors()
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/ProductionCluster.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/ProductionCluster.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster
+
+import java.nio.file.Paths
+
+import com.typesafe.config.ConfigFactory
+import io.radicalbit.nsdb.util.ConfigKeys
+import kamon.Kamon
+
+/**
+  * Defines NSDb monitoring system.
+  */
+trait NSDbMonitoring {
+
+  private def monitoringConfiguration =
+    ConfigFactory
+      .parseFile(Paths.get(System.getProperty("confDir"), "monitoring.conf").toFile)
+      .withFallback(ConfigFactory.parseResources("monitoring.conf"))
+      .resolve()
+
+  /**
+    * Initializes monitoring system if it is enabled.
+    */
+  protected def initMonitoring(): Unit =
+    if (monitoringConfiguration.getBoolean(ConfigKeys.MonitoringEnabled))
+      Kamon.init(ConfigFactory.load("monitoring.conf"))
+}
+
+/**
+  * Simply mix in [[NSDbActors]] with [[NSDbMonitoring]] and [[NsdbClusterConfigProvider]]
+  */
+trait ProductionCluster extends NSDbActors with NSDbMonitoring with NsdbClusterConfigProvider

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/ConfigKeys.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/ConfigKeys.scala
@@ -34,4 +34,6 @@ object ConfigKeys {
   val HttpsPort     = "nsdb.http.https-port"
 
   val ClusterMode = "nsdb.cluster.mode"
+
+  val MonitoringEnabled = "nsdb.monitoring.enabled"
 }

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NSDBAkkaMiniCluster.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NSDBAkkaMiniCluster.scala
@@ -1,13 +1,13 @@
 package io.radicalbit.nsdb.minicluster
 
 import akka.actor.ActorSystem
-import io.radicalbit.nsdb.cluster.NSDBActors
+import io.radicalbit.nsdb.cluster.NSDbActors
 import io.radicalbit.nsdb.common.configuration.NsdbConfigProvider
 
 import scala.concurrent.duration._
 import scala.concurrent.Await
 
-trait NSDBAkkaMiniCluster { this: NsdbConfigProvider with NSDBActors =>
+trait NSDBAkkaMiniCluster { this: NsdbConfigProvider with NSDbActors =>
 
   implicit var system: ActorSystem = _
 

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NSDbMiniClusterNode.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NSDbMiniClusterNode.scala
@@ -18,11 +18,11 @@ package io.radicalbit.nsdb.minicluster
 
 import java.time.Duration
 
-import io.radicalbit.nsdb.cluster.NSDBActors
+import io.radicalbit.nsdb.cluster.NSDbActors
 
 class NSDbMiniClusterNode(val hostname: String,
                           val storageDir: String,
                           val passivateAfter: Duration = Duration.ofHours(1))
     extends NSDBAkkaMiniCluster
-    with NSDBActors
+    with NSDbActors
     with NsdbMiniClusterConfigProvider

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -110,6 +110,13 @@ object Dependencies {
     lazy val contrib   = namespace %% "akka-stream-contrib" % version
   }
 
+  object kamon {
+    lazy val kamonVersion = "2.0.3"
+    lazy val kamonPrometheusVersion = "2.0.0"
+    lazy val bundle = "io.kamon" %% "kamon-bundle" % kamonVersion
+    lazy val prometheus = "io.kamon" %% "kamon-prometheus" %  kamonPrometheusVersion
+  }
+
   object swagger {
     lazy val version     = "1.5.19"
     lazy val namespace   = "io.swagger"
@@ -252,6 +259,8 @@ object Dependencies {
       akka.distributedData,
       scala_logging.scala_logging,
       akka.slf4j,
+      kamon.bundle,
+      kamon.prometheus,
       logback.logback,
       scalatest.core % Test,
       akka.testkit   % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,7 +69,7 @@ object Dependencies {
   }
 
   object akka_management {
-    lazy val version   = "1.0.3"
+    lazy val version   = "1.0.5"
     lazy val namespace = "com.lightbend.akka.management"
     lazy val cluster_bootstrap = namespace %% "akka-management-cluster-bootstrap" % version
     lazy val cluster_http = namespace %% "akka-management-cluster-http" % version
@@ -104,12 +104,6 @@ object Dependencies {
     lazy val swaggerAkkaHttp = "com.github.swagger-akka-http" %% "swagger-akka-http"    % "0.14.0"
   }
 
-  object akka_contrib {
-    lazy val version   = "0.9"
-    lazy val namespace = "com.typesafe.akka"
-    lazy val contrib   = namespace %% "akka-stream-contrib" % version
-  }
-
   object kamon {
     lazy val kamonVersion = "2.0.3"
     lazy val kamonPrometheusVersion = "2.0.0"
@@ -136,7 +130,7 @@ object Dependencies {
   }
 
   object lucene {
-    lazy val version     = "8.2.0"
+    lazy val version     = "8.3.1"
     lazy val namespace   = "org.apache.lucene"
     lazy val core        = namespace % "lucene-core" % version
     lazy val queryParser = namespace % "lucene-queryparser" % version
@@ -311,7 +305,7 @@ object Dependencies {
     lazy val libraries = Seq(
       akka.stream,
       akka_http.default,
-      akka_contrib.contrib,
+      akka.stream,
       json4s.jackson,
       akka_http.sprayJson,
       javaWebsocket.javaWebsocket,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,4 @@ addSbtPlugin("com.typesafe.sbt"                  % "sbt-multi-jvm"       % "0.4.
 addSbtPlugin("io.gatling"                        % "gatling-sbt"         % "3.0.0")
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-native-packager" % "1.3.2")
 addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"        % "0.9.4")
+addSbtPlugin("io.kamon"                          % "sbt-kanela-runner"   % "2.0.3")


### PR DESCRIPTION
This PR enable a monitoring system powered by kamon (https://kamon.io/)

It's configured to sink data to an embedded prometheus target

Inside `monitoring.conf` it's possible to enable the monitoring system 
