### PR TITLE
Introduce NSDb Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ mainRunner
 # docker-compose example not traced volumes
 data
 certs
+native

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
 sudo: required
-dist: precise
 language: scala
 scala:
   - 2.11.11
 jdk:
-  - oraclejdk8
+  - openjdk8
 before_cache:
   - find $HOME/.ivy2 -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt  -name "*.lock"               -print -delete
 cache:
   directories:
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot
+    - $HOME/.sbt
     - $HOME/.custom-cache
 script:
   - sbt -jvm-opts .jvmopts-travis clean coverage ++$TRAVIS_SCALA_VERSION fixCheck test coverageReport coverageAggregate

--- a/nsdb-cluster/src/main/resources/application-common.conf
+++ b/nsdb-cluster/src/main/resources/application-common.conf
@@ -35,17 +35,18 @@ akka {
     }
   }
 
-  extensions = ["akka.cluster.pubsub.DistributedPubSub", "io.radicalbit.nsdb.cluster.extension.RemoteAddress"]
+  extensions = ["akka.cluster.pubsub.DistributedPubSub", "io.radicalbit.nsdb.cluster.extension.RemoteAddress", "akka.cluster.metrics.ClusterMetricsExtension"]
 
   cluster {
-    distributed-data {
-      durable {
-        keys = ["schema-cache-*", "metric-info-cache-*"]
-        lmdb.dir = ""
-        lmdb.write-behind-interval = 200 ms
+      metrics.collector.sample-interval = 10s
+      distributed-data {
+        durable {
+          keys = ["schema-cache-*", "metric-info-cache-*"]
+          lmdb.dir = ""
+          lmdb.write-behind-interval = 200 ms
+        }
       }
     }
-  }
 
   log-dead-letters = 10
   log-dead-letters-during-shutdown = on

--- a/nsdb-cluster/src/main/resources/application-common.conf
+++ b/nsdb-cluster/src/main/resources/application-common.conf
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+// populated from higher level configs
 storageBaseDir = ""
 
 akka {
@@ -42,6 +43,7 @@ akka {
       distributed-data {
         durable {
           keys = ["schema-cache-*", "metric-info-cache-*"]
+          // populated from higher level configs
           lmdb.dir = ""
           lmdb.write-behind-interval = 200 ms
         }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
@@ -66,6 +66,7 @@ class ClusterListener(nodeActorsGuardianProps: Props) extends Actor with ActorLo
     cluster.subscribe(self, initialStateMode = InitialStateAsEvents, classOf[MemberEvent], classOf[UnreachableMember])
     log.info("Created ClusterListener at path {} and subscribed to member events", self.path)
     clusterMetricSystem.subscribe(self)
+    mediator ! Subscribe(LOCATIONS_METRIC_TOPIC, self)
 
   }
 
@@ -138,6 +139,7 @@ class ClusterListener(nodeActorsGuardianProps: Props) extends Actor with ActorLo
 
     case _: MemberEvent => // ignore
     case LocationsMetricChanged(nodeName, locations) =>
+      log.debug(s"received location metric $locations for nodeName $nodeName")
       clusterMetrics.put((nodeName, "locations"), locations)
     case ClusterMetricsChanged(nodeMetrics) =>
       log.debug(s"received metrics $nodeMetrics")

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
@@ -229,9 +229,9 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
     case EvictLocation(db, namespace, loc @ Location(metric, node, from, to)) =>
       val metricKey = MetricLocationsCacheKey(db, namespace, metric)
       val f = for {
-        remove <- replicator ? Update(metricLocationsKey(metricKey), ORSet(), WriteMajority(writeDuration))(
+        remove <- replicator ? Update(metricLocationsKey(metricKey), ORSet(), WriteAll(writeDuration))(
           _ remove loc)
-        _ <- replicator ? Update(nodeLocationsKey(node), ORSet(), WriteMajority(writeDuration))(
+        _ <- replicator ? Update(nodeLocationsKey(node), ORSet(), WriteAll(writeDuration))(
           _ remove (db, namespace, loc))
       } yield remove
       f.map {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
@@ -229,8 +229,7 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
     case EvictLocation(db, namespace, loc @ Location(metric, node, from, to)) =>
       val metricKey = MetricLocationsCacheKey(db, namespace, metric)
       val f = for {
-        remove <- replicator ? Update(metricLocationsKey(metricKey), ORSet(), WriteAll(writeDuration))(
-          _ remove loc)
+        remove <- replicator ? Update(metricLocationsKey(metricKey), ORSet(), WriteAll(writeDuration))(_ remove loc)
         _ <- replicator ? Update(nodeLocationsKey(node), ORSet(), WriteAll(writeDuration))(
           _ remove (db, namespace, loc))
       } yield remove

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -349,7 +349,7 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
         }
         .recoverWith {
           case t =>
-            log.error(t, "")
+            log.error(t, s"Error in Execute Statement $statement")
             Future(SelectStatementFailed(statement, "Generic error occurred"))
         }
         .pipeToWithEffect(sender()) { _ =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
@@ -375,7 +375,7 @@ class GrpcEndpoint(readCoordinator: ActorRef, writeCoordinator: ActorRef, metada
                 }
                 .recoverWith {
                   case t =>
-                    log.error("", t)
+                    log.error(s"Error in executing statement $statement", t)
                     Future.successful(
                       SQLStatementResponse(
                         db = requestDb,

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/package.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/package.scala
@@ -27,8 +27,9 @@ package object cluster {
     s"${address.host.getOrElse("noHost")}_${address.port.getOrElse(2552)}"
 
   final object PubSubTopics {
-    final val COORDINATORS_TOPIC   = "coordinators"
-    final val NODE_GUARDIANS_TOPIC = "node-guardians"
+    final val COORDINATORS_TOPIC     = "coordinators"
+    final val NODE_GUARDIANS_TOPIC   = "node-guardians"
+    final val LOCATIONS_METRIC_TOPIC = "locations-metric"
   }
 
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/package.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/package.scala
@@ -27,9 +27,12 @@ package object cluster {
     s"${address.host.getOrElse("noHost")}_${address.port.getOrElse(2552)}"
 
   final object PubSubTopics {
-    final val COORDINATORS_TOPIC     = "coordinators"
-    final val NODE_GUARDIANS_TOPIC   = "node-guardians"
-    final val LOCATIONS_METRIC_TOPIC = "locations-metric"
+    final val COORDINATORS_TOPIC   = "coordinators"
+    final val NODE_GUARDIANS_TOPIC = "node-guardians"
+    final val NSDB_METRICS_TOPIC   = "nsdb-metrics"
   }
 
+  final object Metrics {
+    final val DISK_OCCUPATION = "disk_occupation"
+  }
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/package.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/package.scala
@@ -15,12 +15,16 @@
  */
 
 package io.radicalbit.nsdb
+import akka.actor.Address
 import akka.cluster.Member
 
 package object cluster {
 
   def createNodeName(member: Member) =
     s"${member.address.host.getOrElse("noHost")}_${member.address.port.getOrElse(2552)}"
+
+  def createNodeName(address: Address) =
+    s"${address.host.getOrElse("noHost")}_${address.port.getOrElse(2552)}"
 
   final object PubSubTopics {
     final val COORDINATORS_TOPIC   = "coordinators"

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/util/FileUtils.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/util/FileUtils.scala
@@ -92,7 +92,7 @@ object FileUtils {
     * @param nodeName the node name that will be used for creating locations.
     *                 @return a list of [[LocationWithCoordinates]].
     */
-  def getLocationFromFilesystem(basePath: String, nodeName: String): List[LocationWithCoordinates] =
+  def getLocationsFromFilesystem(basePath: String, nodeName: String): List[LocationWithCoordinates] =
     FileUtils
       .getSubDirs(Paths.get(basePath))
       .flatMap { databaseDir =>

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
@@ -1,0 +1,38 @@
+package io.radicalbit.nsdb.cluster.actor
+
+import akka.actor.{Actor, ActorLogging, Deploy, Props}
+import akka.cluster.Cluster
+import akka.cluster.ClusterEvent.{InitialStateAsEvents, MemberEvent, MemberUp, UnreachableMember}
+import akka.cluster.pubsub.DistributedPubSub
+import akka.cluster.pubsub.DistributedPubSubMediator.Subscribe
+import akka.remote.RemoteScope
+import io.radicalbit.nsdb.cluster.PubSubTopics.NODE_GUARDIANS_TOPIC
+import io.radicalbit.nsdb.cluster.createNodeName
+
+class ClusterListenerTestActor(nodeActorsGuardianProps: Props)  extends Actor with ActorLogging {
+
+  private lazy val cluster             = Cluster(context.system)
+  private lazy val mediator = DistributedPubSub(context.system).mediator
+
+  override def preStart(): Unit = {
+    cluster.subscribe(self, initialStateMode = InitialStateAsEvents, classOf[MemberEvent], classOf[UnreachableMember])
+  }
+
+  override def receive: Receive = {
+    case MemberUp(member) if member == cluster.selfMember =>
+
+      val nodeName = createNodeName(member)
+
+      val nodeActorsGuardian =
+        context.system.actorOf(nodeActorsGuardianProps.withDeploy(Deploy(scope = RemoteScope(member.address))),
+          name = s"guardian_$nodeName")
+
+      mediator ! Subscribe(NODE_GUARDIANS_TOPIC, nodeActorsGuardian)
+  }
+
+}
+
+object ClusterListenerTestActor {
+  def props(nodeActorsGuardianProps: Props): Props =
+    Props(new ClusterListenerTestActor(nodeActorsGuardianProps))
+}

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -113,7 +113,7 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
   lazy val metadataCache = system.actorOf(Props[ReplicatedMetadataCache], s"metadata-cache-$nodeName")
   lazy val schemaCache   = system.actorOf(Props[ReplicatedSchemaCache], s"schema-cache-$nodeName")
 
-  system.actorOf(ClusterListener.props(NodeActorsGuardian.props(metadataCache, schemaCache)), name = "clusterListener")
+  system.actorOf(ClusterListenerTestActor.props(NodeActorsGuardian.props(metadataCache, schemaCache)), name = "clusterListener")
 
   lazy val nodeName = s"${cluster.selfAddress.host.getOrElse("noHost")}_${cluster.selfAddress.port.getOrElse(2552)}"
 

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -462,6 +462,8 @@ class ReplicatedMetadataCacheSpec
         }
       }
 
+      enterBarrier("after-add-multiple-node-location")
+
       awaitAssert {
         replicatedCache ! GetLocationsFromCache(db, namespace, metric)
         expectMsgType[LocationsCached].value.size shouldBe 22

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
@@ -30,7 +30,6 @@ import io.radicalbit.nsdb.util.ConfigKeys
 import io.radicalbit.nsdb.web.routes._
 import io.radicalbit.nsdb.web.swagger.SwaggerDocService
 import io.radicalbit.nsdb.web.validation.FieldErrorInfo
-import org.json4s.DefaultFormats
 import spray.json._
 
 import scala.concurrent.ExecutionContext

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
@@ -30,7 +30,7 @@ import io.radicalbit.nsdb.security.http.NSDBAuthProvider
 import io.radicalbit.nsdb.security.model.{Db, Metric, Namespace}
 import io.swagger.annotations._
 import javax.ws.rs.Path
-import org.json4s.{DefaultFormats, Formats}
+import org.json4s.Formats
 import org.json4s.jackson.Serialization.write
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/DataApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/DataApi.scala
@@ -30,7 +30,7 @@ import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{InputMapped, RecordRe
 import io.radicalbit.nsdb.security.http.NSDBAuthProvider
 import io.radicalbit.nsdb.security.model.Metric
 import io.swagger.annotations._
-import org.json4s.{DefaultFormats, Formats}
+import org.json4s.Formats
 
 import scala.annotation.meta.field
 import scala.util.{Failure, Success}

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryValidationApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryValidationApi.scala
@@ -32,7 +32,7 @@ import io.radicalbit.nsdb.security.model.Metric
 import io.radicalbit.nsdb.sql.parser.SQLStatementParser
 import io.swagger.annotations._
 import javax.ws.rs.Path
-import org.json4s.{DefaultFormats, Formats}
+import org.json4s.Formats
 
 import scala.annotation.meta.field
 import scala.util.{Failure, Success}

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/WebSocketSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/WebSocketSpec.scala
@@ -18,7 +18,7 @@ package io.radicalbit.nsdb.web
 
 import akka.actor.{Actor, Props}
 import akka.event.LoggingAdapter
-import akka.http.scaladsl.model.{HttpProtocol, StatusCodes}
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.testkit.{ScalatestRouteTest, WSProbe}
 import io.radicalbit.nsdb.actors.PublisherActor

--- a/nsdb-it/src/test/resources/application-common.conf
+++ b/nsdb-it/src/test/resources/application-common.conf
@@ -36,6 +36,7 @@ akka {
   extensions = ["akka.cluster.pubsub.DistributedPubSub", "io.radicalbit.nsdb.cluster.extension.RemoteAddress"]
 
   cluster {
+    metrics.collector.enabled = off
     distributed-data {
       durable {
         keys = ["schema-cache-*", "metric-info-cache-*"]

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NsdbMiniCluster.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/minicluster/NsdbMiniCluster.scala
@@ -20,7 +20,6 @@ import java.io.File
 import java.time.Duration
 import java.util.UUID
 
-import com.typesafe.config.ConfigRenderOptions
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.io.FileUtils
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,6 +64,7 @@ object Dependencies {
     lazy val sharding        = namespace %% "akka-sharding"           % version
     lazy val slf4j           = namespace %% "akka-slf4j"              % version
     lazy val clusterTools    = namespace %% "akka-cluster-tools"      % version
+    lazy val clusterMetrics  = namespace %% "akka-cluster-metrics"    % version
     lazy val multiNode       = namespace %% "akka-multi-node-testkit" % version
     lazy val discovery       = namespace %% "akka-discovery"          % version
   }
@@ -105,10 +106,13 @@ object Dependencies {
   }
 
   object kamon {
+    lazy val namespace= "io.kamon"
     lazy val kamonVersion = "2.0.3"
     lazy val kamonPrometheusVersion = "2.0.0"
-    lazy val bundle = "io.kamon" %% "kamon-bundle" % kamonVersion
-    lazy val prometheus = "io.kamon" %% "kamon-prometheus" %  kamonPrometheusVersion
+    lazy val sigarVersion = "1.6.6-rev002"
+    lazy val bundle = namespace %% "kamon-bundle" % kamonVersion
+    lazy val prometheus = namespace %% "kamon-prometheus" %  kamonPrometheusVersion
+    lazy val sigarLoader = namespace % "sigar-loader" % sigarVersion
   }
 
   object swagger {
@@ -246,6 +250,7 @@ object Dependencies {
     lazy val libraries = Seq(
       akka.cluster,
       akka.clusterTools,
+      akka.clusterMetrics,
       akka.discovery,
       akka_management.cluster_bootstrap,
       akka_management.cluster_http,
@@ -255,6 +260,7 @@ object Dependencies {
       akka.slf4j,
       kamon.bundle,
       kamon.prometheus,
+      kamon.sigarLoader,
       logback.logback,
       scalatest.core % Test,
       akka.testkit   % Test,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,3 +1,1 @@
-#sbt.version=0.13.16
-#sbt.version=1.2.7
 sbt.version=1.1.1


### PR DESCRIPTION
This PR introduces NSDb metrics.

Basically, it leverages Akka cluster metrics and akka distributed publish-subscribe in order to collect inside the cluster listener actor, the usable space in percentage.

This metrics will be essential in order to determine the node to use for writing operations 