### PR TITLE
Add DiskMetricsSelector

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/metrics/DiskMetricsCollector.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/metrics/DiskMetricsCollector.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.metrics
+
+import akka.actor.Address
+import akka.cluster.metrics.{CapacityMetricsSelector, NodeMetrics}
+import io.radicalbit.nsdb.cluster.metrics.NSDbMetrics.Disk
+
+case object DiskMetricsCollector extends CapacityMetricsSelector {
+
+  /**
+    * Remaining capacity for each node. The value is between
+    * 0.0 and 1.0, where 0.0 means no remaining capacity (full
+    * utilization) and 1.0 means full remaining capacity (zero
+    * utilization).
+    */
+  override def capacity(nodeMetrics: Set[NodeMetrics]): Map[Address, Double] = {
+    nodeMetrics.collect {
+      case Disk(address, freeSpace, totalSpace) =>
+        val capacity = 1.0 - freeSpace / totalSpace
+        (address, capacity)
+    }.toMap
+  }
+}

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/metrics/DiskMetricsSelector.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/metrics/DiskMetricsSelector.scala
@@ -20,7 +20,7 @@ import akka.actor.Address
 import akka.cluster.metrics.{CapacityMetricsSelector, NodeMetrics}
 import io.radicalbit.nsdb.cluster.metrics.NSDbMetrics.Disk
 
-case object DiskMetricsCollector extends CapacityMetricsSelector {
+case object DiskMetricsSelector extends CapacityMetricsSelector {
 
   /**
     * Remaining capacity for each node. The value is between
@@ -31,7 +31,7 @@ case object DiskMetricsCollector extends CapacityMetricsSelector {
   override def capacity(nodeMetrics: Set[NodeMetrics]): Map[Address, Double] = {
     nodeMetrics.collect {
       case Disk(address, freeSpace, totalSpace) =>
-        val capacity = 1.0 - freeSpace / totalSpace
+        val capacity = 1.0 - freeSpace.toDouble / totalSpace
         (address, capacity)
     }.toMap
   }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/metrics/NSDbMetrics.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/metrics/NSDbMetrics.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.metrics
+
+import akka.actor.Address
+import akka.cluster.metrics.NodeMetrics
+
+object NSDbMetrics {
+
+  final val DiskTotalSpace = "disk_total_space"
+  final val DiskFreeSpace  = "disk_free_space"
+
+  object Disk {
+
+    /**
+      * Given a NodeMetrics it returns the Disk data if the nodeMetrics contains
+      * necessary disk metrics.
+      *
+      * @return if possible a tuple matching the Disk constructor parameters
+      */
+    def unapply(nodeMetrics: NodeMetrics): Option[(Address, Long, Long)] = {
+      for {
+        diskTotalSpace <- nodeMetrics.metric(DiskTotalSpace)
+        diskFreeSpace  <- nodeMetrics.metric(DiskFreeSpace)
+      } yield (nodeMetrics.address, diskFreeSpace.value.longValue(), diskTotalSpace.value.longValue())
+    }
+  }
+
+}

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/package.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/package.scala
@@ -26,13 +26,21 @@ package object cluster {
   def createNodeName(address: Address) =
     s"${address.host.getOrElse("noHost")}_${address.port.getOrElse(2552)}"
 
+  /**
+    * Creates a fake address with a dedicated (and invented) `nsdb` protocol
+    * @param nodeName the node name [host]_[port]
+    */
+  def createAddress(nodeName: String): Address = {
+    val splittedNodeName = nodeName.split("_")
+    Address("nsdb",
+            "NSDb",
+            Option(splittedNodeName(0)).getOrElse("noHost"),
+            Option(splittedNodeName(1)).map(_.toInt).getOrElse(2552))
+  }
+
   final object PubSubTopics {
     final val COORDINATORS_TOPIC   = "coordinators"
     final val NODE_GUARDIANS_TOPIC = "node-guardians"
     final val NSDB_METRICS_TOPIC   = "nsdb-metrics"
-  }
-
-  final object Metrics {
-    final val DISK_OCCUPATION = "disk_occupation"
   }
 }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/metrics/DiskMetricsSelectorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/metrics/DiskMetricsSelectorSpec.scala
@@ -1,0 +1,53 @@
+package io.radicalbit.nsdb.cluster.metrics
+
+import akka.actor.Address
+import akka.cluster.metrics.StandardMetrics._
+import akka.cluster.metrics.{Metric, NodeMetrics}
+import io.radicalbit.nsdb.cluster.metrics.NSDbMetrics._
+import org.scalatest.{Matchers, WordSpec}
+
+class DiskMetricsSelectorSpec extends WordSpec with Matchers {
+
+  val node1 = Address("nsdb", "NSDb", "node1", 2552)
+  val node2 = Address("nsdb", "NSDb", "node2", 2552)
+  val node3 = Address("nsdb", "NSDb", "node3", 2552)
+
+  val nodeMetrics1 = NodeMetrics(
+    node1,
+    System.currentTimeMillis,
+    Set(
+      Metric.create(DiskTotalSpace, 1000000, None),
+      Metric.create(DiskFreeSpace, 100, None),
+      Metric.create(HeapMemoryMax, 512, None),
+      Metric.create(CpuCombined, 0.2, None),
+      Metric.create(CpuStolen, 0.1, None),
+      Metric.create(SystemLoadAverage, 0.5, None),
+      Metric.create(Processors, 8, None)).flatten
+  )
+
+  val nodeMetrics2 = NodeMetrics(
+    node2,
+    System.currentTimeMillis,
+    Set(
+      Metric.create(DiskTotalSpace, 1000000, None),
+      Metric.create(DiskFreeSpace, 750000, None)).flatten
+    )
+
+  val nodeMetrics3 = NodeMetrics(
+    node3,
+    System.currentTimeMillis,
+    Set()
+  )
+
+  val nodeMetrics = Set(nodeMetrics1, nodeMetrics2, nodeMetrics3)
+
+  "DiskMetricsSelector" must {
+    "calculate capacity of heap metrics" in {
+      val capacity = DiskMetricsSelector.capacity(nodeMetrics)
+      capacity.get(node1) shouldBe Some(0.9999)
+      capacity.get(node2) shouldBe Some(0.25)
+      capacity.get(node3) shouldBe None
+    }
+  }
+
+}

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/metrics/DiskMetricsSelectorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/metrics/DiskMetricsSelectorSpec.scala
@@ -1,16 +1,39 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.radicalbit.nsdb.cluster.metrics
+
+import java.nio.file.{Files, Paths}
 
 import akka.actor.Address
 import akka.cluster.metrics.StandardMetrics._
 import akka.cluster.metrics.{Metric, NodeMetrics}
 import io.radicalbit.nsdb.cluster.metrics.NSDbMetrics._
 import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.OptionValues._
 
 class DiskMetricsSelectorSpec extends WordSpec with Matchers {
 
-  val node1 = Address("nsdb", "NSDb", "node1", 2552)
-  val node2 = Address("nsdb", "NSDb", "node2", 2552)
-  val node3 = Address("nsdb", "NSDb", "node3", 2552)
+  val node1    = Address("nsdb", "NSDb", "node1", 2552)
+  val node2    = Address("nsdb", "NSDb", "node2", 2552)
+  val node3    = Address("nsdb", "NSDb", "node3", 2552)
+  val node4    = Address("nsdb", "NSDb", "node4", 2552)
+  val realNode = Address("nsdb", "NSDb", "real", 2552)
+
+  val fs = Files.getFileStore(Paths.get("."))
 
   val nodeMetrics1 = NodeMetrics(
     node1,
@@ -22,31 +45,46 @@ class DiskMetricsSelectorSpec extends WordSpec with Matchers {
       Metric.create(CpuCombined, 0.2, None),
       Metric.create(CpuStolen, 0.1, None),
       Metric.create(SystemLoadAverage, 0.5, None),
-      Metric.create(Processors, 8, None)).flatten
+      Metric.create(Processors, 8, None)
+    ).flatten
   )
 
   val nodeMetrics2 = NodeMetrics(
     node2,
     System.currentTimeMillis,
-    Set(
-      Metric.create(DiskTotalSpace, 1000000, None),
-      Metric.create(DiskFreeSpace, 750000, None)).flatten
-    )
+    Set(Metric.create(DiskTotalSpace, 1000000, None), Metric.create(DiskFreeSpace, 750000, None)).flatten
+  )
 
   val nodeMetrics3 = NodeMetrics(
+    node3,
+    System.currentTimeMillis,
+    Set(Metric.create(DiskTotalSpace, 1000000, None), Metric.create(DiskFreeSpace, 1000000, None)).flatten
+  )
+
+  val nodeMetrics4 = NodeMetrics(
     node3,
     System.currentTimeMillis,
     Set()
   )
 
-  val nodeMetrics = Set(nodeMetrics1, nodeMetrics2, nodeMetrics3)
+  val realNodeMetrics = NodeMetrics(
+    realNode,
+    System.currentTimeMillis,
+    Set(Metric.create(DiskTotalSpace, fs.getTotalSpace, None), Metric.create(DiskFreeSpace, fs.getUsableSpace, None)).flatten
+  )
+
+  val nodeMetrics = Set(nodeMetrics1, nodeMetrics2, nodeMetrics3, nodeMetrics4, realNodeMetrics)
 
   "DiskMetricsSelector" must {
     "calculate capacity of heap metrics" in {
       val capacity = DiskMetricsSelector.capacity(nodeMetrics)
       capacity.get(node1) shouldBe Some(0.9999)
       capacity.get(node2) shouldBe Some(0.25)
-      capacity.get(node3) shouldBe None
+      capacity.get(node3) shouldBe Some(0)
+      capacity.get(node4) shouldBe None
+      //for a real node the capacity must be between 0 and 1. There's no way to estimate a reasonable capacity value and mocking is not the point here
+      capacity.get(realNode).value shouldBe >(0.0)
+      capacity.get(realNode).value shouldBe <(1.0)
     }
   }
 


### PR DESCRIPTION
This PR introduces the `DiskMetricsSelector` entity, which is responsible to collect all the metrics related to the disk utilization and to calculate a node capacity in terms of the disk.

If the capacity is 0.0, it means that all the disk has been used, 1.0 if all the disk is free