### PR TITLE
Write node choice Algorithm

### DIFF
--- a/nsdb-cluster/src/main/resources/nsdb.conf
+++ b/nsdb-cluster/src/main/resources/nsdb.conf
@@ -64,6 +64,7 @@ nsdb {
     # metrics-selector = cpu
     # metrics-selector = mix
     metrics-selector = disk
+    metrics-selector = ${?METRIC_SELECTOR}
     mode = native
     mode = ${?CLUSTER_MODE}
     required-contact-point-nr = 1

--- a/nsdb-cluster/src/main/resources/nsdb.conf
+++ b/nsdb-cluster/src/main/resources/nsdb.conf
@@ -58,6 +58,12 @@ nsdb {
     replication-factor = ${?REPLICATION_FACTOR}
     consistency-level = 1
     consistency-level = ${?CONSISTENCY_LEVEL}
+    # Router parameter specific for metrics extension.
+    # metrics-selector = heap
+    # metrics-selector = load
+    # metrics-selector = cpu
+    # metrics-selector = mix
+    metrics-selector = disk
     mode = native
     mode = ${?CLUSTER_MODE}
     required-contact-point-nr = 1

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
@@ -62,13 +62,6 @@ trait NSDbActors {
 
     lazy val nodeName: String = createNodeName(Cluster(system).selfMember)
 
-    system.actorOf(
-      ClusterListener.props(
-        NodeActorsGuardian.props(
-          system.actorOf(Props[ReplicatedMetadataCache], s"metadata-cache-$nodeName"),
-          system.actorOf(Props[ReplicatedSchemaCache], s"schema-cache-$nodeName")
-        )),
-      name = s"cluster-listener_${createNodeName(Cluster(system).selfMember)}"
-    )
+    system.actorOf(Props[ClusterListener], name = s"cluster-listener_${createNodeName(Cluster(system).selfMember)}")
   }
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
@@ -60,8 +60,6 @@ trait NSDbActors {
       name = "databaseActorGuardianProxy"
     )
 
-    lazy val nodeName: String = createNodeName(Cluster(system).selfMember)
-
     system.actorOf(Props[ClusterListener], name = s"cluster-listener_${createNodeName(Cluster(system).selfMember)}")
   }
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
@@ -28,7 +28,7 @@ import akka.pattern.ask
 import akka.remote.RemoteScope
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.PubSubTopics._
-import io.radicalbit.nsdb.cluster.actor.ClusterListener.DiskOccupationChanged
+import io.radicalbit.nsdb.cluster.actor.ClusterListener.{DiskOccupationChanged, GetNodeMetrics, NodeMetricsGot}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{AddLocations, RemoveNodeMetadata}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.util.{ErrorManagementUtils, FileUtils}
@@ -173,6 +173,8 @@ class ClusterListener() extends Actor with ActorLogging {
         case _: NoSuchFileException =>
           mediator ! Publish(NSDB_METRICS_TOPIC, DiskOccupationChanged(selfNodeName, 100, 100))
       }
+    case GetNodeMetrics =>
+      sender() ! NodeMetricsGot((akkaClusterMetrics ++ nsdbMetrics).values.flatten.toSet)
   }
 }
 
@@ -185,5 +187,8 @@ object ClusterListener {
     * @param totalSpace total disk space.
     */
   case class DiskOccupationChanged(nodeName: String, usableSpace: Long, totalSpace: Long)
+
+  case object GetNodeMetrics
+  case class NodeMetricsGot(nodeMetrics: Set[NodeMetrics])
 
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
@@ -46,9 +46,8 @@ import scala.util.{Failure, Success, Try}
 
 /**
   * Actor subscribed to akka cluster events. It creates all the actors needed when a node joins the cluster
-  * @param nodeActorsGuardianProps props of NodeActorGuardian actor.
   */
-class ClusterListener(nodeActorsGuardianProps: Props) extends Actor with ActorLogging {
+class ClusterListener() extends Actor with ActorLogging {
 
   private lazy val cluster             = Cluster(context.system)
   private lazy val clusterMetricSystem = ClusterMetricsExtension(context.system)
@@ -90,7 +89,7 @@ class ClusterListener(nodeActorsGuardianProps: Props) extends Actor with ActorLo
       val nodeName = createNodeName(member)
 
       val nodeActorsGuardian =
-        context.system.actorOf(nodeActorsGuardianProps.withDeploy(Deploy(scope = RemoteScope(member.address))),
+        context.system.actorOf(NodeActorsGuardian.props(self).withDeploy(Deploy(scope = RemoteScope(member.address))),
                                name = s"guardian_$nodeName")
 
       (nodeActorsGuardian ? GetNodeChildActors)
@@ -187,6 +186,4 @@ object ClusterListener {
     */
   case class DiskOccupationChanged(nodeName: String, usableSpace: Long, totalSpace: Long)
 
-  def props(nodeActorsGuardianProps: Props): Props =
-    Props(new ClusterListener(nodeActorsGuardianProps))
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -34,7 +34,6 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.createNodeName
 import io.radicalbit.nsdb.cluster.index.MetricInfoIndex
 import io.radicalbit.nsdb.cluster.logic.CapacityWriteNodesSelectionLogic
-import io.radicalbit.nsdb.cluster.metrics.DiskMetricsSelector
 import io.radicalbit.nsdb.cluster.util.ErrorManagementUtils._
 import io.radicalbit.nsdb.cluster.util.FileUtils
 import io.radicalbit.nsdb.commit_log.CommitLogWriterActor._
@@ -432,7 +431,8 @@ class MetadataCoordinator(clusterListener: ActorRef,
 
                     val nodes =
                       if (nodeMetrics.nodeMetrics.nonEmpty)
-                        new CapacityWriteNodesSelectionLogic(DiskMetricsSelector)
+                        new CapacityWriteNodesSelectionLogic(
+                          CapacityWriteNodesSelectionLogic.fromConfigValue("nsdb.cluster.metric-selector"))
                           .selectWriteNodes(nodeMetrics.nodeMetrics, replicationFactor)
                       else {
                         Random

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/CapacityWriteNodesSelectionLogic.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/CapacityWriteNodesSelectionLogic.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.logic
+
+import akka.cluster.metrics.{CapacityMetricsSelector, NodeMetrics}
+import io.radicalbit.nsdb.cluster._
+
+/**
+  * Node selection logic based on nodes capacity, that is retrieved from the node metrics and a selector
+  * @param metricsSelector selects a certain metric (e.g. disk, heap) and calculates the nodes capacity based on it.
+  */
+class CapacityWriteNodesSelectionLogic(metricsSelector: CapacityMetricsSelector) extends WriteNodesSelectionLogic {
+
+  override def selectWriteNodes(nodeMetrics: Set[NodeMetrics], replicationFactor: Int): Seq[String] = {
+    metricsSelector.capacity(nodeMetrics).toList.sortBy { case (_, m) => m }.reverse.take(replicationFactor).map {
+      case (address, _) => createNodeName(address)
+    }
+  }
+}

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/CapacityWriteNodesSelectionLogic.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/CapacityWriteNodesSelectionLogic.scala
@@ -41,6 +41,12 @@ class CapacityWriteNodesSelectionLogic(metricsSelector: CapacityMetricsSelector)
 
 object CapacityWriteNodesSelectionLogic {
 
+  /**
+    * Provides a metric selector from a config value.
+    * @param configValue the config value provided in the NSDb configuration file
+    * @return the specified metric selector
+    * @throws IllegalArgumentException the configuration is not among the allowed values.
+    */
   def fromConfigValue(configValue: String): CapacityMetricsSelector = {
     configValue match {
       case "heap" => HeapMetricsSelector

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/WriteNodesSelectionLogic.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/WriteNodesSelectionLogic.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.logic
+
+import akka.cluster.metrics.NodeMetrics
+
+/**
+  * Contains the method to select write nodes in a cluster.
+  */
+trait WriteNodesSelectionLogic {
+
+  /**
+    * Applies the selection logic for the given set of metrics.
+    * @param nodeMetrics the metrics collected for the nodes.
+    * @param replicationFactor number of replicas configured.
+    * @return the selected node names sequence.
+    */
+  def selectWriteNodes(nodeMetrics: Set[NodeMetrics], replicationFactor: Int): Seq[String]
+}

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/metrics/DiskMetricsSelector.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/metrics/DiskMetricsSelector.scala
@@ -31,7 +31,7 @@ case object DiskMetricsSelector extends CapacityMetricsSelector {
   override def capacity(nodeMetrics: Set[NodeMetrics]): Map[Address, Double] = {
     nodeMetrics.collect {
       case Disk(address, freeSpace, totalSpace) =>
-        val capacity = 1.0 - freeSpace.toDouble / totalSpace
+        val capacity = freeSpace.toDouble / totalSpace
         (address, capacity)
     }.toMap
   }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/metrics/NSDbMixMetricSelector.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/metrics/NSDbMixMetricSelector.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.metrics
+
+import akka.cluster.metrics.{
+  CpuMetricsSelector,
+  HeapMetricsSelector,
+  MixMetricsSelectorBase,
+  SystemLoadAverageMetricsSelector
+}
+
+/**
+  * NSDb mix metric selector.
+  * It is completely inspired by [[akka.cluster.metrics.MixMetricsSelector]].
+  * The only difference is that [[DiskMetricsSelector]] is added to the metric selectors to be mixed.
+  */
+case object NSDbMixMetricSelector
+    extends MixMetricsSelectorBase(
+      Vector(HeapMetricsSelector, CpuMetricsSelector, SystemLoadAverageMetricsSelector, DiskMetricsSelector))

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
@@ -1,6 +1,6 @@
 package io.radicalbit.nsdb.cluster.actor
 
-import akka.actor.{Actor, ActorLogging, Deploy, Props}
+import akka.actor.{Actor, ActorLogging, Deploy}
 import akka.cluster.Cluster
 import akka.cluster.ClusterEvent.{InitialStateAsEvents, MemberEvent, MemberUp, UnreachableMember}
 import akka.cluster.pubsub.DistributedPubSub
@@ -9,7 +9,7 @@ import akka.remote.RemoteScope
 import io.radicalbit.nsdb.cluster.PubSubTopics.NODE_GUARDIANS_TOPIC
 import io.radicalbit.nsdb.cluster.createNodeName
 
-class ClusterListenerTestActor(nodeActorsGuardianProps: Props)  extends Actor with ActorLogging {
+class ClusterListenerTestActor()  extends Actor with ActorLogging {
 
   private lazy val cluster             = Cluster(context.system)
   private lazy val mediator = DistributedPubSub(context.system).mediator
@@ -24,15 +24,10 @@ class ClusterListenerTestActor(nodeActorsGuardianProps: Props)  extends Actor wi
       val nodeName = createNodeName(member)
 
       val nodeActorsGuardian =
-        context.system.actorOf(nodeActorsGuardianProps.withDeploy(Deploy(scope = RemoteScope(member.address))),
+        context.system.actorOf(NodeActorsGuardian.props(self).withDeploy(Deploy(scope = RemoteScope(member.address))),
           name = s"guardian_$nodeName")
 
       mediator ! Subscribe(NODE_GUARDIANS_TOPIC, nodeActorsGuardian)
   }
 
-}
-
-object ClusterListenerTestActor {
-  def props(nodeActorsGuardianProps: Props): Props =
-    Props(new ClusterListenerTestActor(nodeActorsGuardianProps))
 }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -110,10 +110,7 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
 
   implicit val timeout: Timeout = Timeout(5.seconds)
 
-  lazy val metadataCache = system.actorOf(Props[ReplicatedMetadataCache], s"metadata-cache-$nodeName")
-  lazy val schemaCache   = system.actorOf(Props[ReplicatedSchemaCache], s"schema-cache-$nodeName")
-
-  system.actorOf(ClusterListenerTestActor.props(NodeActorsGuardian.props(metadataCache, schemaCache)), name = "clusterListener")
+  system.actorOf(Props[ClusterListenerTestActor], name = "clusterListener")
 
   lazy val nodeName = s"${cluster.selfAddress.host.getOrElse("noHost")}_${cluster.selfAddress.port.getOrElse(2552)}"
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
@@ -19,7 +19,7 @@ package io.radicalbit.nsdb.cluster.actor
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
@@ -50,7 +50,7 @@ class MetricsDataActorSpec()
   val namespace1 = "namespace1"
 
   val fakeMetadataCoordinator =
-    system.actorOf(LocalMetadataCoordinator.props(system.actorOf(LocalMetadataCache.props)))
+    system.actorOf(LocalMetadataCoordinator.props(system.actorOf(Props[LocalMetadataCache])))
 
   val metricsDataActor =
     system.actorOf(MetricsDataActor.props(basePath, "testNode", ActorRef.noSender))

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -22,6 +22,7 @@ import akka.pattern._
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import io.radicalbit.nsdb.cluster.actor.ClusterListener
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.ExecuteDeleteStatementInternalInLocations
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands._
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
@@ -64,9 +65,11 @@ class MetadataCoordinatorSpec
   val schemaCoordinator =
     system.actorOf(SchemaCoordinator.props(system.actorOf(Props[FakeSchemaCache])), "schemacoordinator")
   val metricsDataActorProbe = TestProbe()
-  val metadataCache         = system.actorOf(LocalMetadataCache.props)
+  val metadataCache         = system.actorOf(Props[LocalMetadataCache])
+  val clusterListener       = system.actorOf(Props[ClusterListener])
+
   val metadataCoordinator =
-    system.actorOf(MetadataCoordinator.props(probe.ref, metadataCache, schemaCoordinator, probe.ref))
+    system.actorOf(MetadataCoordinator.props(clusterListener, metadataCache, schemaCoordinator, probe.ref))
 
   val db        = "testDb"
   val namespace = "testNamespace"

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -65,7 +65,8 @@ class MetadataCoordinatorSpec
     system.actorOf(SchemaCoordinator.props(system.actorOf(Props[FakeSchemaCache])), "schemacoordinator")
   val metricsDataActorProbe = TestProbe()
   val metadataCache         = system.actorOf(LocalMetadataCache.props)
-  val metadataCoordinator   = system.actorOf(MetadataCoordinator.props(metadataCache, schemaCoordinator, probe.ref))
+  val metadataCoordinator =
+    system.actorOf(MetadataCoordinator.props(probe.ref, metadataCache, schemaCoordinator, probe.ref))
 
   val db        = "testDb"
   val namespace = "testNamespace"

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
@@ -98,7 +98,7 @@ class RetentionSpec
   val metadataCoordinator =
     system.actorOf(
       MetadataCoordinator
-        .props(localMetadataCache, schemaCoordinator, system.actorOf(Props.empty))
+        .props(system.actorOf(Props.empty), localMetadataCache, schemaCoordinator, system.actorOf(Props.empty))
         .withDispatcher("akka.actor.control-aware-dispatcher"),
       "metadata-coordinator"
     )

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
@@ -22,7 +22,7 @@ import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
-import io.radicalbit.nsdb.cluster.actor.MetricsDataActor
+import io.radicalbit.nsdb.cluster.actor.{ClusterListener, MetricsDataActor}
 import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache.{
   AllMetricInfoWithRetentionGot,
   GetAllMetricInfoWithRetention
@@ -98,7 +98,10 @@ class RetentionSpec
   val metadataCoordinator =
     system.actorOf(
       MetadataCoordinator
-        .props(system.actorOf(Props.empty), localMetadataCache, schemaCoordinator, system.actorOf(Props.empty))
+        .props(system.actorOf(Props[ClusterListener]),
+               localMetadataCache,
+               schemaCoordinator,
+               system.actorOf(Props.empty))
         .withDispatcher("akka.actor.control-aware-dispatcher"),
       "metadata-coordinator"
     )

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
@@ -18,7 +18,7 @@ package io.radicalbit.nsdb.cluster.coordinator.mockedActors
 
 import java.util.concurrent.ConcurrentHashMap
 
-import akka.actor.{Actor, Props}
+import akka.actor.Actor
 import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache._
 import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.Coordinates
@@ -94,8 +94,6 @@ class LocalMetadataCache extends Actor {
 }
 
 object LocalMetadataCache {
-  def props: Props = Props(new LocalMetadataCache)
-
   case object DeleteAll
   case object DeleteDone
 }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/logic/CapacityWriteNodesSelectionLogicSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/logic/CapacityWriteNodesSelectionLogicSpec.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.logic
+
+import akka.cluster.metrics._
+import akka.actor.Address
+import io.radicalbit.nsdb.cluster.metrics.{DiskMetricsSelector, NSDbMixMetricSelector}
+import org.scalatest.{Matchers, WordSpec}
+
+/**
+  * only the disk metric selector is tested because the other selectors have been already accurately tested inside the akka project.
+  */
+class CapacityWriteNodesSelectionLogicSpec extends WordSpec with Matchers {
+
+  def akkaClusterMetric: Set[Metric] =
+    Set(
+      Metric("heap-memory-used", 68038160, Some(EWMA(6.774968476043373E7, 0.438770294474789))),
+      Metric("heap-memory-max", 7635730432L, None),
+      Metric("cpu-combined", 0.2065661194900425, Some(EWMA(0.1316384958460451, 0.438770294474789))),
+      Metric("processors", 12, None),
+      Metric("system-load-average", 4.23193359375, None),
+      Metric("heap-memory-committed", 660602880, Some(EWMA(6.6060288E8, 0.438770294474789))),
+      Metric("cpu-stolen", 0.0, Some(EWMA(0.0, 0.438770294474789)))
+    )
+
+  val nodeMetricsEqualDiskCapacity = Set(
+    NodeMetrics(
+      Address("akka", "NSDb", "127.0.0.1", 2552),
+      System.currentTimeMillis(),
+      akkaClusterMetric ++
+        Set(Metric("disk_free_space", 344051822592L, None), Metric("disk_total_space", 500000000000L, None))
+    ),
+    NodeMetrics(
+      Address("akka", "NSDb", "127.0.0.3", 2552),
+      System.currentTimeMillis(),
+      akkaClusterMetric ++
+        Set(Metric("disk_free_space", 344051822592L, None), Metric("disk_total_space", 499963174912L, None))
+    ),
+    NodeMetrics(
+      Address("akka", "NSDb", "127.0.0.2", 2552),
+      System.currentTimeMillis(),
+      akkaClusterMetric ++
+        Set(Metric("disk_free_space", 344051822592L, None), Metric("disk_total_space", 499963174912L, None))
+    )
+  )
+
+  val fullDiskNode = NodeMetrics(
+    Address("akka", "NSDb", "127.0.0.2", 2552),
+    System.currentTimeMillis(),
+    akkaClusterMetric ++
+      Set(Metric("disk_free_space", 0, None), Metric("disk_total_space", 500000000000L, None))
+  )
+
+  val emptyDiskNode = NodeMetrics(
+    Address("akka", "NSDb", "127.0.0.2", 2552),
+    System.currentTimeMillis(),
+    akkaClusterMetric ++
+      Set(Metric("disk_free_space", 500000000000L, None), Metric("disk_total_space", 500000000000L, None))
+  )
+
+  val ordinaryNodeMetrics = Set(
+    NodeMetrics(
+      Address("akka", "NSDb", "127.0.0.1", 2552),
+      System.currentTimeMillis(),
+      akkaClusterMetric ++
+        Set(Metric("disk_free_space", 350000000000L, None), Metric("disk_total_space", 500000000000L, None))
+    ),
+    NodeMetrics(
+      Address("akka", "NSDb", "127.0.0.3", 2552),
+      System.currentTimeMillis(),
+      akkaClusterMetric ++
+        Set(Metric("disk_free_space", 200000000000L, None), Metric("disk_total_space", 500000000000L, None))
+    )
+  )
+
+  "CapacityWriteNodesSelectionLogic" should {
+    "select metric selector from config" in {
+      CapacityWriteNodesSelectionLogic.fromConfigValue("heap") shouldBe HeapMetricsSelector
+      CapacityWriteNodesSelectionLogic.fromConfigValue("load") shouldBe SystemLoadAverageMetricsSelector
+      CapacityWriteNodesSelectionLogic.fromConfigValue("cpu") shouldBe CpuMetricsSelector
+      CapacityWriteNodesSelectionLogic.fromConfigValue("disk") shouldBe DiskMetricsSelector
+      CapacityWriteNodesSelectionLogic.fromConfigValue("mix") shouldBe NSDbMixMetricSelector
+      an[IllegalArgumentException] should be thrownBy CapacityWriteNodesSelectionLogic.fromConfigValue("wrong")
+    }
+  }
+
+  "CapacityWriteNodesSelectionLogic" when {
+    "cluster nodes have the same disk capacity" should {
+      "select write nodes based on DiskMetricsSelector" in {
+        //just test that the method return the correct amount of elements
+        new CapacityWriteNodesSelectionLogic(DiskMetricsSelector)
+          .selectWriteNodes(nodeMetricsEqualDiskCapacity, 2)
+          .size shouldBe 2
+      }
+    }
+
+    "one cluster node has got 0 capacity" should {
+      "select nodes with the highest disk" in {
+        new CapacityWriteNodesSelectionLogic(DiskMetricsSelector)
+          .selectWriteNodes(ordinaryNodeMetrics + fullDiskNode, 2) shouldBe Seq("127.0.0.1_2552", "127.0.0.3_2552")
+      }
+    }
+
+    "one cluster node has got full capacity" should {
+      "select nodes with the highest disk" in {
+        new CapacityWriteNodesSelectionLogic(DiskMetricsSelector)
+          .selectWriteNodes(ordinaryNodeMetrics + emptyDiskNode, 2) shouldBe Seq("127.0.0.2_2552", "127.0.0.1_2552")
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a solid write node choice algorithm that is based on nodes capacity.
The user can configure which metric should be used to calculate the node capacity, i.e. the weight used to choose a set of nodes to write replicas in.

This implementation has been largely inspired by the Akka adaptive load balancing

https://doc.akka.io/docs/akka/current/cluster-metrics.html#adaptive-load-balancing

The metrics collected and the logic used above to route a message in a set of routees, here in NSDb is used to retrieve a set of nodes based on its capacity.

Allowed metrics are:

heap, load, cpu, disk, mix

All those metrics have already been implemented in the Akka project except for the disk one, which has been implemented ad hoc and measures the free disk ration (aka disk capacity).

This implementation is compliant with a dynamic cluster scenario (e.g. Kubernetes cluster) because it is resilient to a new node added or to a capacity degradation because metrics are continuously updated and influence each and every write-record operation. For example, a new node with reasonably more capacity than the older ones will be always put on top of the list, while a poor capacity node will be discarded or put at the end of the chosen nodes list.