### PR TITLE
[HOTFIX] Add nsdb version as api response header

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,11 @@ lazy val `nsdb-common` = project
   .settings(Commons.crossScalaVersionSettings: _*)
   .settings(PublishSettings.settings: _*)
   .enablePlugins(AutomateHeaderPlugin)
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
+    buildInfoKeys := Seq[BuildInfoKey](version),
+    buildInfoPackage := "io.radicalbit.nsdb"
+  )
   .settings(LicenseHeader.settings: _*)
   .settings(libraryDependencies ++= Dependencies.Common.libraries)
 

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiSupport.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiSupport.scala
@@ -23,9 +23,9 @@ import akka.http.scaladsl.server.Route
 /**
   * Allows Cross-Origin call to exposed Http Apis.
   */
-trait CorsSupport {
+object CORSSupport {
 
-  val optionsSupport = {
+  val optionsSupport: Route = {
     options { complete("") }
   }
 
@@ -40,5 +40,19 @@ trait CorsSupport {
   )
 
   def withCors(route: Route) = respondWithHeaders(corsHeaders) { route ~ optionsSupport }
+
+}
+
+/**
+  * Adds a custom header containing NSDb version
+  */
+object VersionHeader {
+  import io.radicalbit.nsdb.{BuildInfo => NSDbBuildInfo}
+
+  final val NSDbVersionHeaderKey = "NSDb-Version"
+
+  final val versionHeader = List(RawHeader(NSDbVersionHeaderKey, NSDbBuildInfo.version))
+
+  def withNSDbVersion(route: Route) = respondWithHeaders(versionHeader) { route }
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,4 @@ addSbtPlugin("io.gatling"                        % "gatling-sbt"         % "3.0.
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-native-packager" % "1.3.2")
 addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"        % "0.9.4")
 addSbtPlugin("io.kamon"                          % "sbt-kanela-runner"   % "2.0.3")
+addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"       % "0.9.0")


### PR DESCRIPTION
This PR adds a custom header to any http api response in order to communicate the current nsdb version to an http client