### PR TITLE
Remove scala 2.11 support 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: scala
 scala:
-  - 2.11.11
+  - 2.12.12
 jdk:
   - openjdk8
 before_cache:
@@ -13,7 +13,7 @@ cache:
     - $HOME/.sbt
     - $HOME/.custom-cache
 script:
-  - sbt -jvm-opts .jvmopts-travis clean coverage ++$TRAVIS_SCALA_VERSION fixCheck test coverageReport coverageAggregate
+  - sbt -jvm-opts .jvmopts-travis clean coverage fixCheck test coverageReport coverageAggregate
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ jdk:
 before_cache:
   - find $HOME/.ivy2 -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt  -name "*.lock"               -print -delete
-cache:
-  directories:
-    - $HOME/.ivy2/cache
-    - $HOME/.sbt
-    - $HOME/.custom-cache
 script:
   - sbt -jvm-opts .jvmopts-travis clean coverage fixCheck test coverageReport coverageAggregate
 after_success:

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,6 @@ import Path.relativeTo
 lazy val root = project
   .in(file("."))
   .settings(
-    crossScalaVersions := Nil,
     name := "nsdb",
     publish := {},
     publishLocal := {}
@@ -53,7 +52,7 @@ addCommandAlias("deb", "packageDeb")
 addCommandAlias("rpm", "packageRpm")
 
 lazy val `nsdb-common` = project
-  .settings(Commons.crossScalaVersionSettings: _*)
+  .settings(Commons.settings: _*)
   .settings(PublishSettings.settings: _*)
   .enablePlugins(AutomateHeaderPlugin)
   .enablePlugins(BuildInfoPlugin)
@@ -65,7 +64,7 @@ lazy val `nsdb-common` = project
   .settings(libraryDependencies ++= Dependencies.Common.libraries)
 
 lazy val `nsdb-core` = project
-  .settings(Commons.crossScalaVersionSettings: _*)
+  .settings(Commons.settings: _*)
   .settings(PublishSettings.dontPublish: _*)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(LicenseHeader.settings: _*)
@@ -73,7 +72,7 @@ lazy val `nsdb-core` = project
   .dependsOn(`nsdb-common`)
 
 lazy val `nsdb-http` = project
-  .settings(Commons.crossScalaVersionSettings: _*)
+  .settings(Commons.settings: _*)
   .settings(PublishSettings.dontPublish: _*)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(LicenseHeader.settings: _*)
@@ -81,7 +80,7 @@ lazy val `nsdb-http` = project
   .dependsOn(`nsdb-core`, `nsdb-sql`, `nsdb-security`)
 
 lazy val `nsdb-rpc` = project
-  .settings(Commons.crossScalaVersionSettings: _*)
+  .settings(Commons.settings: _*)
   .settings(PublishSettings.settings: _*)
   .settings(libraryDependencies ++= Dependencies.RPC.libraries)
   .settings(coverageExcludedPackages := "io\\.radicalbit\\.nsdb.*")
@@ -93,7 +92,7 @@ lazy val `nsdb-rpc` = project
   .dependsOn(`nsdb-sql`)
 
 lazy val `nsdb-cluster` = project
-  .settings(Commons.crossScalaVersionSettings: _*)
+  .settings(Commons.settings: _*)
   .settings(PublishSettings.dontPublish: _*)
   .enablePlugins(JavaServerAppPackaging, SbtNativePackager)
   .settings(libraryDependencies ++= Dependencies.Cluster.libraries)
@@ -232,7 +231,7 @@ lazy val `nsdb-cluster` = project
   .dependsOn(`nsdb-security`, `nsdb-http`, `nsdb-rpc`, `nsdb-cli`)
 
 lazy val `nsdb-security` = project
-  .settings(Commons.crossScalaVersionSettings: _*)
+  .settings(Commons.settings: _*)
   .settings(PublishSettings.settings: _*)
   .settings(libraryDependencies ++= Dependencies.Security.libraries)
   .enablePlugins(AutomateHeaderPlugin)
@@ -240,7 +239,7 @@ lazy val `nsdb-security` = project
   .dependsOn(`nsdb-common`)
 
 lazy val `nsdb-sql` = project
-  .settings(Commons.crossScalaVersionSettings: _*)
+  .settings(Commons.settings: _*)
   .settings(PublishSettings.settings: _*)
   .settings(libraryDependencies ++= Dependencies.SQL.libraries)
   .enablePlugins(AutomateHeaderPlugin)
@@ -248,8 +247,7 @@ lazy val `nsdb-sql` = project
   .dependsOn(`nsdb-common`)
 
 lazy val `nsdb-java-api` = project
-  .settings(Commons.crossScalaVersionSettings: _*)
-  .settings(scalaVersion := "2.11.11")
+  .settings(Commons.settings: _*)
   .settings(crossPaths := false)
   .settings(PublishSettings.settings: _*)
   .settings(libraryDependencies ++= Dependencies.JavaAPI.libraries)
@@ -258,7 +256,7 @@ lazy val `nsdb-java-api` = project
   .dependsOn(`nsdb-rpc`)
 
 lazy val `nsdb-scala-api` = project
-  .settings(Commons.crossScalaVersionSettings: _*)
+  .settings(Commons.settings: _*)
   .settings(PublishSettings.settings: _*)
   .settings(libraryDependencies ++= Dependencies.ScalaAPI.libraries)
   .enablePlugins(AutomateHeaderPlugin)
@@ -266,7 +264,7 @@ lazy val `nsdb-scala-api` = project
   .dependsOn(`nsdb-rpc`)
 
 lazy val `nsdb-cli` = project
-  .settings(Commons.crossScalaVersionSettings: _*)
+  .settings(Commons.settings: _*)
   .settings(PublishSettings.dontPublish: _*)
   .settings(libraryDependencies ++= Dependencies.CLI.libraries)
   .settings(coverageExcludedPackages := "io\\.radicalbit\\.nsdb.*")
@@ -276,7 +274,7 @@ lazy val `nsdb-cli` = project
   .dependsOn(`nsdb-rpc`)
 
 lazy val `nsdb-perf` = (project in file("nsdb-perf"))
-  .settings(Commons.crossScalaVersionSettings: _*)
+  .settings(Commons.settings: _*)
   .settings(PublishSettings.dontPublish: _*)
   .settings(libraryDependencies ++= Dependencies.Performance.libraries)
   .enablePlugins(AutomateHeaderPlugin)
@@ -284,7 +282,7 @@ lazy val `nsdb-perf` = (project in file("nsdb-perf"))
   .enablePlugins(GatlingPlugin)
 
 lazy val `nsdb-it` = (project in file("nsdb-it"))
-  .settings(Commons.crossScalaVersionSettings: _*)
+  .settings(Commons.settings: _*)
   .settings(PublishSettings.dontPublish: _*)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(LicenseHeader.settings: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -278,7 +278,6 @@ lazy val `nsdb-cli` = project
 lazy val `nsdb-perf` = (project in file("nsdb-perf"))
   .settings(Commons.crossScalaVersionSettings: _*)
   .settings(PublishSettings.dontPublish: _*)
-  .settings(scalaVersion := "2.11.11")
   .settings(libraryDependencies ++= Dependencies.Performance.libraries)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(LicenseHeader.settings: _*)

--- a/nsdb-it/src/test/scala/io/radicalbit/nsdb/cluster/WriteCoordinatorClusterSpec.scala
+++ b/nsdb-it/src/test/scala/io/radicalbit/nsdb/cluster/WriteCoordinatorClusterSpec.scala
@@ -75,12 +75,9 @@ class WriteCoordinatorClusterSpec extends MiniClusterSpec {
       .timestamp(timestamp)
       .value(new java.math.BigDecimal("13"))
       .dimension("city", "Mouseton")
-      .dimension("notimportant", None)
-      .dimension("Someimportant", Some(2))
       .tag("gender", "M")
       .dimension("bigDecimalLong", new java.math.BigDecimal("12"))
       .dimension("bigDecimalDouble", new java.math.BigDecimal("12.5"))
-      .dimension("OptionBigDecimal", Some(new java.math.BigDecimal("15.5")))
 
     eventually {
       val res = Await.result(nsdb.write(bit), 10.seconds)

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/example/NSDBInitMetric.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/example/NSDBInitMetric.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+package io.radicalbit.nsdb.api.java.example;
 import io.radicalbit.nsdb.api.java.DescribeMetricResult;
 import io.radicalbit.nsdb.api.java.InitMetricResult;
 import io.radicalbit.nsdb.api.java.NSDB;

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/example/NSDBRead.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/example/NSDBRead.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+package io.radicalbit.nsdb.api.java.example;
 import io.radicalbit.nsdb.api.java.NSDB;
 import io.radicalbit.nsdb.api.java.QueryResult;
 

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/example/NSDBWrite.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/example/NSDBWrite.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+package io.radicalbit.nsdb.api.java.example;
 import io.radicalbit.nsdb.api.java.InsertResult;
 import io.radicalbit.nsdb.api.java.NSDB;
 

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDB.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDB.scala
@@ -346,20 +346,6 @@ case class Bit protected (db: String,
   def tag(k: String, d: java.math.BigDecimal): Bit =
     if (d.scale() > 0) tag(k, d.doubleValue()) else tag(k, d.longValue())
 
-  @deprecated(
-    "It's not fully type safe and it's not possible to make it due to our best friend Jvm type erasure. It's better to be removed in order to prevent a non correct usage of the apis",
-    "0.7.0"
-  )
-  def dimension[T](k: String, d: Option[T]): Bit =
-    d match {
-      case Some(v: java.math.BigDecimal) => dimension(k, v)
-      case Some(v: Long)                 => dimension(k, v)
-      case Some(v: Int)                  => dimension(k, v)
-      case Some(v: Double)               => dimension(k, v)
-      case Some(v: String)               => dimension(k, v)
-      case _                             => this
-    }
-
   /**
     * Adds a Long timestamp to the bit.
     * @param v the timestamp.

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
@@ -37,12 +37,9 @@ object NSDBMainWrite extends App {
     .metric("people")
     .value(new java.math.BigDecimal("13.5"))
     .dimension("city", "Mouseton")
-    .dimension("notimportant", None)
-    .dimension("Someimportant", Some(2))
     .tag("gender", "M")
     .dimension("bigDecimalLong", new java.math.BigDecimal("12"))
     .dimension("bigDecimalDouble", new java.math.BigDecimal("12.5"))
-    .dimension("OptionBigDecimal", Some(new java.math.BigDecimal("15.5")))
 
   val res: Future[RPCInsertResult] = nsdb.write(series)
 

--- a/project/Commons.scala
+++ b/project/Commons.scala
@@ -25,7 +25,7 @@ object Commons {
 
   val scalaVer = "2.12.7"
 
-  val nonCrossSettings: Seq[Def.Setting[_]] = Seq(
+  val settings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := scalaVer,
     addCompilerPlugin(scalafixSemanticdb),
     scalacOptions ++= Seq(
@@ -60,6 +60,4 @@ object Commons {
         oldStrategy(x)
     }
   )
-
-  val crossScalaVersionSettings = nonCrossSettings :+ (crossScalaVersions := Seq("2.11.11", "2.12.7"))
 }


### PR DESCRIPTION
I'm glad to announce that this PR removes the support for scala 2.11

This means that, starting from 1.0.0 release candidates version, all the artifacts will be packaged for scala 2.12