### PR TITLE
[HOTFIX] Serialization propaedeutic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ jdk:
 before_cache:
   - find $HOME/.ivy2 -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt  -name "*.lock"               -print -delete
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
+    - $HOME/.custom-cache
 script:
   - sbt -jvm-opts .jvmopts-travis clean coverage fixCheck test coverageReport coverageAggregate
 after_success:

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
@@ -99,8 +99,8 @@ class ClusterListener() extends Actor with ActorLogging {
             val locationsToAdd: Seq[LocationWithCoordinates] =
               FileUtils.getLocationsFromFilesystem(indexPath, nodeName)
 
-            val locationsGroupedBy: Map[(String, String), Seq[(String, String, Location)]] = locationsToAdd.groupBy {
-              case (database, namespace, _) => (database, namespace)
+            val locationsGroupedBy: Map[(String, String), Seq[LocationWithCoordinates]] = locationsToAdd.groupBy {
+              case LocationWithCoordinates(database, namespace, _) => (database, namespace)
             }
 
             Future
@@ -108,7 +108,7 @@ class ClusterListener() extends Actor with ActorLogging {
                 locationsGroupedBy.map {
                   case ((db, namespace), locations) =>
                     metadataCoordinator ? AddLocations(db, namespace, locations.map {
-                      case (_, _, location) => location
+                      case LocationWithCoordinates(_, _, location) => location
                     })
                 }
               }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
@@ -34,8 +34,7 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.util.{ErrorManagementUtils, FileUtils}
 import io.radicalbit.nsdb.cluster._
 import io.radicalbit.nsdb.cluster.metrics.NSDbMetrics
-import io.radicalbit.nsdb.model.Location
-import io.radicalbit.nsdb.model.Location.LocationWithCoordinates
+import io.radicalbit.nsdb.model.LocationWithCoordinates
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel._
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/util/FileUtils.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/util/FileUtils.scala
@@ -20,8 +20,7 @@ import java.io._
 import java.nio.file.{Path, Paths}
 import java.util.zip.{ZipEntry, ZipFile}
 
-import io.radicalbit.nsdb.model.Location
-import io.radicalbit.nsdb.model.Location.LocationWithCoordinates
+import io.radicalbit.nsdb.model.{Location, LocationWithCoordinates}
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
@@ -106,7 +105,9 @@ object FileUtils {
                 .collect {
                   case file if file.getName.split("_").length == 3 =>
                     val Array(metric, from, to) = file.getName.split("_")
-                    (database, namespaceDir.getName, Location(metric, nodeName, from.toLong, to.toLong))
+                    LocationWithCoordinates(database,
+                                            namespaceDir.getName,
+                                            Location(metric, nodeName, from.toLong, to.toLong))
                 }
           }
       }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorAggregatedStatementsSpec.scala
@@ -88,7 +88,7 @@ class ReadCoordinatorAggregatedStatementsSpec extends AbstractReadCoordinatorSpe
                                namespace = namespace,
                                metric = "nonexisting",
                                distinct = false,
-                               fields = AllFields,
+                               fields = AllFields(),
                                limit = Some(LimitOperator(5)))
           )
         )

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSimpleStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSimpleStatementsSpec.scala
@@ -39,7 +39,7 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
                                namespace = namespace,
                                metric = LongMetric.name,
                                distinct = false,
-                               fields = AllFields,
+                               fields = AllFields(),
                                limit = Some(LimitOperator(2)))
           )
         )
@@ -62,7 +62,7 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
               namespace = namespace,
               metric = LongMetric.name,
               distinct = false,
-              fields = AllFields,
+              fields = AllFields(),
               limit = Some(LimitOperator(2)),
               order = Some(DescOrderOperator("timestamp"))
             )
@@ -85,7 +85,7 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
               namespace = namespace,
               metric = LongMetric.name,
               distinct = false,
-              fields = AllFields,
+              fields = AllFields(),
               limit = Some(LimitOperator(2)),
               order = Some(DescOrderOperator("value"))
             )
@@ -107,7 +107,7 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
                                namespace = namespace,
                                metric = LongMetric.name,
                                distinct = false,
-                               fields = AllFields,
+                               fields = AllFields(),
                                limit = Some(LimitOperator(3)),
                                order = Some(DescOrderOperator("name")))
           )
@@ -425,7 +425,7 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
                                namespace = namespace,
                                metric = LongMetric.name,
                                distinct = false,
-                               fields = AllFields,
+                               fields = AllFields(),
                                limit = Some(LimitOperator(6)))
           )
         )
@@ -443,7 +443,7 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
                                namespace = namespace,
                                metric = LongMetric.name,
                                distinct = true,
-                               fields = AllFields,
+                               fields = AllFields(),
                                limit = Some(LimitOperator(6)))
           )
         )
@@ -641,8 +641,7 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
                   UnaryLogicalExpression(
                     ComparisonExpression(dimension = "timestamp",
                                          comparison = GreaterOrEqualToOperator,
-                                         value = AbsoluteComparisonValue(10L)),
-                    NotOperator
+                                         value = AbsoluteComparisonValue(10L))
                   ))),
               limit = Some(LimitOperator(6))
             )

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSimpleStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSimpleStatementsSpec.scala
@@ -638,7 +638,7 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
               fields = ListFields(List(Field("name", None))),
               condition = Some(
                 Condition(
-                  UnaryLogicalExpression(
+                  NotExpression(
                     ComparisonExpression(dimension = "timestamp",
                                          comparison = GreaterOrEqualToOperator,
                                          value = AbsoluteComparisonValue(10L))

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorValidateStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorValidateStatementsSpec.scala
@@ -36,7 +36,7 @@ class ReadCoordinatorValidateStatementsSpec extends AbstractReadCoordinatorSpec 
                                namespace = namespace,
                                metric = LongMetric.name,
                                distinct = false,
-                               fields = AllFields,
+                               fields = AllFields(),
                                limit = Some(LimitOperator(2)))
           )
         )
@@ -73,7 +73,7 @@ class ReadCoordinatorValidateStatementsSpec extends AbstractReadCoordinatorSpec 
               namespace = namespace,
               metric = LongMetric.name,
               distinct = false,
-              fields = AllFields,
+              fields = AllFields(),
               groupBy = Some(SimpleGroupByAggregation("dimension")),
               limit = Some(LimitOperator(2))
             )

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -125,7 +125,7 @@ trait WriteCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers 
         namespace = namespace,
         metric = "testMetric",
         distinct = false,
-        fields = AllFields,
+        fields = AllFields(),
         condition = Some(
           Condition(
             ComparisonExpression(dimension = "timestamp",

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -32,24 +32,19 @@ final case class Field(name: String, aggregation: Option[Aggregation])
   * [[ListFields]] if a list of fields are specified in the query.
   */
 sealed trait SelectedFields
-case object AllFields                            extends SelectedFields
+case class AllFields()                           extends SelectedFields
 final case class ListFields(fields: List[Field]) extends SelectedFields
 
 final case class ListAssignment(fields: Map[String, JSerializable])
 final case class Condition(expression: Expression)
 
-/**
-  * Where condition expression for queries.
-  * [[ComparisonExpression]] simple comparison expression.
-  */
 sealed trait Expression
 
 /**
-  * Simple expression having a [[SingleLogicalOperator]] applied.
+  * Simple expression having a [[NotOperator]] applied.
   * @param expression the simple expression.
-  * @param operator the operator to be applied to the expression.
   */
-final case class UnaryLogicalExpression(expression: Expression, operator: SingleLogicalOperator) extends Expression
+final case class UnaryLogicalExpression(expression: Expression) extends Expression
 
 /**
   * A couple of simple expressions having a [[TupledLogicalOperator]] applied.
@@ -108,8 +103,7 @@ sealed trait LogicalOperator
 /**
   * Logical operator that can be applied only to 1 expression e.g. [[NotOperator]].
   */
-sealed trait SingleLogicalOperator extends LogicalOperator
-case object NotOperator            extends SingleLogicalOperator
+case object NotOperator extends LogicalOperator
 
 /**
   * Logical operators that can be applied only to 2 expressions e.g. [[AndOperator]] and [[OrOperator]].
@@ -269,7 +263,7 @@ final case class SelectSQLStatement(override val db: String,
       case "<"         => Some(ComparisonExpression(dimension, LessThanOperator, value.map(AbsoluteComparisonValue(_)).get))
       case "LIKE"      => Some(LikeExpression(dimension, value.get.asInstanceOf[String]))
       case "ISNULL"    => Some(NullableExpression(dimension))
-      case "ISNOTNULL" => Some(UnaryLogicalExpression(NullableExpression(dimension), NotOperator))
+      case "ISNOTNULL" => Some(UnaryLogicalExpression(NullableExpression(dimension)))
       case op @ _ =>
         logger.warn("Ignored filter with invalid operator: {}", op)
         None

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -41,10 +41,10 @@ final case class Condition(expression: Expression)
 sealed trait Expression
 
 /**
-  * Simple expression having a [[NotOperator]] applied.
-  * @param expression the simple expression.
+  * Simple Not expression.
+  * @param expression the expression to negate.
   */
-final case class UnaryLogicalExpression(expression: Expression) extends Expression
+final case class NotExpression(expression: Expression) extends Expression
 
 /**
   * A couple of simple expressions having a [[TupledLogicalOperator]] applied.
@@ -99,11 +99,6 @@ final case class NullableExpression(dimension: String) extends Expression
   * Logical operators that can be applied to 1 or 2 expressions.
   */
 sealed trait LogicalOperator
-
-/**
-  * Logical operator that can be applied only to 1 expression e.g. [[NotOperator]].
-  */
-case object NotOperator extends LogicalOperator
 
 /**
   * Logical operators that can be applied only to 2 expressions e.g. [[AndOperator]] and [[OrOperator]].
@@ -263,7 +258,7 @@ final case class SelectSQLStatement(override val db: String,
       case "<"         => Some(ComparisonExpression(dimension, LessThanOperator, value.map(AbsoluteComparisonValue(_)).get))
       case "LIKE"      => Some(LikeExpression(dimension, value.get.asInstanceOf[String]))
       case "ISNULL"    => Some(NullableExpression(dimension))
-      case "ISNOTNULL" => Some(UnaryLogicalExpression(NullableExpression(dimension)))
+      case "ISNOTNULL" => Some(NotExpression(NullableExpression(dimension)))
       case op @ _ =>
         logger.warn("Ignored filter with invalid operator: {}", op)
         None

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
@@ -210,7 +210,7 @@ class MetricAccumulatorActor(val basePath: String,
       StatementParser.parseStatement(statement, schema) match {
         case Success(ParsedDeleteQuery(ns, metric, q)) =>
           keys.foreach { key =>
-            opBufferMap += (UUID.randomUUID().toString -> DeleteShardQueryOperation(ns, key, q))
+            opBufferMap += (UUID.randomUUID().toString -> DeleteShardQueryOperation(ns, key, statement, schema))
           }
           sender() ! DeleteStatementExecuted(db, namespace, metric)
         case Failure(ex) =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
@@ -27,6 +27,7 @@ import io.radicalbit.nsdb.common.exception.TooManyRetriesException
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.index.AllFacetIndexes
 import io.radicalbit.nsdb.model.Location
+import io.radicalbit.nsdb.statement.StatementParser
 import io.radicalbit.nsdb.util.ActorPathLogging
 import org.apache.lucene.index.IndexWriter
 
@@ -106,12 +107,14 @@ class MetricPerformerActor(val basePath: String,
                   log.error(t, s"error during delete of Bit: $bit")
               }
             //FIXME add compensation logic here as well
-            case DeleteShardQueryOperation(_, _, q) =>
-              index.delete(q)(writer) match {
-                case Success(_) =>
-                  facetIndexes.delete(q)(facetsIndexWriter)
-                case Failure(t) =>
-                  log.error(t, s"error during delete by query $q")
+            case DeleteShardQueryOperation(_, _, statement, schema) =>
+              (for {
+                parsedQuery      <- StatementParser.parseStatement(statement, schema)
+                _                <- index.delete(parsedQuery.q)(writer)
+                facetIndexResult <- facetIndexes.delete(parsedQuery.q)(facetsIndexWriter).head
+              } yield facetIndexResult).recover {
+                case t: Throwable =>
+                  log.error(t, s"error during delete by statement $statement")
               }
           }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardOperation.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardOperation.scala
@@ -17,8 +17,8 @@
 package io.radicalbit.nsdb.actors
 
 import io.radicalbit.nsdb.common.protocol.Bit
-import io.radicalbit.nsdb.model.Location
-import org.apache.lucene.search.Query
+import io.radicalbit.nsdb.common.statement.DeleteSQLStatement
+import io.radicalbit.nsdb.model.{Location, Schema}
 
 /**
   * shard operations accumulated by [[MetricAccumulatorActor]] and performed by [[MetricPerformerActor]]
@@ -43,9 +43,13 @@ sealed trait ShardOperation {
   val location: Location
 }
 
-case class DeleteShardRecordOperation(namespace: String, location: Location, bit: Bit)    extends ShardOperation
-case class DeleteShardQueryOperation(namespace: String, location: Location, query: Query) extends ShardOperation
-case class WriteShardOperation(namespace: String, location: Location, bit: Bit)           extends ShardOperation
+case class DeleteShardRecordOperation(namespace: String, location: Location, bit: Bit) extends ShardOperation
+case class DeleteShardQueryOperation(namespace: String,
+                                     location: Location,
+                                     deleteStatement: DeleteSQLStatement,
+                                     schema: Schema)
+    extends ShardOperation
+case class WriteShardOperation(namespace: String, location: Location, bit: Bit) extends ShardOperation
 
 object ShardOperation {
 
@@ -58,7 +62,7 @@ object ShardOperation {
     action match {
       case DeleteShardRecordOperation(namespace, location, bit) =>
         Some(WriteShardOperation(namespace, location, bit))
-      case DeleteShardQueryOperation(_, _, _) =>
+      case DeleteShardQueryOperation(_, _, _, _) =>
         None
       case WriteShardOperation(namespace, location, bit) =>
         Some(DeleteShardRecordOperation(namespace, location, bit))

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializer.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializer.scala
@@ -168,12 +168,7 @@ class StandardCommitLogSerializer extends CommitLogSerializer with TypeSupport {
       case `unaryLogicalExpressionClassName` =>
         val expClass = readByteBuffer.read
         val exp      = createExpression(expClass)
-        val opClazz  = readByteBuffer.read
-        val module   = runtimeMirror.staticModule(opClazz)
-        val operator = runtimeMirror.reflectModule(module).instance.asInstanceOf[SingleLogicalOperator]
-        clazz
-          .getConstructor(classOf[Expression], classOf[SingleLogicalOperator])
-          .newInstance(exp, operator)
+        clazz.getConstructor(classOf[Expression]).newInstance(exp)
 
       case `tupleLogicalExpressionClassName` =>
         val expClass1 = readByteBuffer.read
@@ -224,9 +219,8 @@ class StandardCommitLogSerializer extends CommitLogSerializer with TypeSupport {
         writeBuffer.write(value.toString)
       case NullableExpression(dimension) =>
         writeBuffer.write(dimension)
-      case UnaryLogicalExpression(expression1, unaryLogicalOperator) =>
+      case UnaryLogicalExpression(expression1) =>
         extractExpression(expression1)
-        writeBuffer.write(unaryLogicalOperator.getClass.getCanonicalName)
       case TupledLogicalExpression(expression1, tupledLogicalOperator, expression2) =>
         extractExpression(expression1)
         writeBuffer.write(tupledLogicalOperator.getClass.getCanonicalName)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializer.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializer.scala
@@ -42,7 +42,7 @@ class StandardCommitLogSerializer extends CommitLogSerializer with TypeSupport {
   private final val equalityExpressionClassName     = classOf[EqualityExpression[_]].getCanonicalName
   private final val likeExpressionClassName         = classOf[LikeExpression].getCanonicalName
   private final val nullableExpressionClassName     = classOf[NullableExpression].getCanonicalName
-  private final val unaryLogicalExpressionClassName = classOf[UnaryLogicalExpression].getCanonicalName
+  private final val unaryLogicalExpressionClassName = classOf[NotExpression].getCanonicalName
   private final val tupleLogicalExpressionClassName = classOf[TupledLogicalExpression].getCanonicalName
 
   /**
@@ -219,7 +219,7 @@ class StandardCommitLogSerializer extends CommitLogSerializer with TypeSupport {
         writeBuffer.write(value.toString)
       case NullableExpression(dimension) =>
         writeBuffer.write(dimension)
-      case UnaryLogicalExpression(expression1) =>
+      case NotExpression(expression1) =>
         extractExpression(expression1)
       case TupledLogicalExpression(expression1, tupledLogicalOperator, expression2) =>
         extractExpression(expression1)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Location.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Location.scala
@@ -37,12 +37,12 @@ case class Location(metric: String, node: String, from: Long, to: Long) {
 object Location {
 
   /**
-    * type alias to enrich a Location with a database and a namespace that contain it.
-    */
-  type LocationWithCoordinates = (String, String, Location)
-
-  /**
     * @return an empty location
     */
-  def empty = Location("", "", 0, 0)
+  def empty: Location = Location("", "", 0, 0)
 }
+
+/**
+  * Enriches a Location with a database and a namespace that contains it.
+  */
+case class LocationWithCoordinates(db: String, namespace: String, location: Location)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
@@ -47,7 +47,7 @@ object ExpressionParser {
       case Some(RangeExpression(dimension, ComparisonValue(value1), ComparisonValue(value2))) =>
         rangeExpression(schema, dimension, value1, value2)
 
-      case Some(UnaryLogicalExpression(expression)) => unaryLogicalExpression(schema, expression)
+      case Some(NotExpression(expression)) => unaryLogicalExpression(schema, expression)
 
       case Some(TupledLogicalExpression(expression1, operator: TupledLogicalOperator, expression2: Expression)) =>
         tupledLogicalExpression(schema, expression1, operator, expression2)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
@@ -47,7 +47,7 @@ object ExpressionParser {
       case Some(RangeExpression(dimension, ComparisonValue(value1), ComparisonValue(value2))) =>
         rangeExpression(schema, dimension, value1, value2)
 
-      case Some(UnaryLogicalExpression(expression, _)) => unaryLogicalExpression(schema, expression)
+      case Some(UnaryLogicalExpression(expression)) => unaryLogicalExpression(schema, expression)
 
       case Some(TupledLogicalExpression(expression1, operator: TupledLogicalOperator, expression2: Expression)) =>
         tupledLogicalExpression(schema, expression1, operator, expression2)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
@@ -83,7 +83,7 @@ object StatementParser {
 
     val expParsed = ExpressionParser.parseExpression(statement.condition.map(_.expression), schema.fieldsMap)
     val fieldList = statement.fields match {
-      case AllFields => Success(List.empty)
+      case AllFields() => Success(List.empty)
       case ListFields(list) =>
         val metricDimensions     = schema.fieldsMap.values.map(_.name).toSeq
         val projectionDimensions = list.map(_.name).filterNot(_ == "*")

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/TimeRangeManager.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/TimeRangeManager.scala
@@ -41,7 +41,7 @@ object TimeRangeManager {
         }
       case Some(RangeExpression("timestamp", ComparisonValue(v1: Long), ComparisonValue(v2: Long))) =>
         List(Interval.closed(v1, v2))
-      case Some(UnaryLogicalExpression(expression, _)) => extractTimeRange(Some(expression)).flatMap(i => ~i)
+      case Some(UnaryLogicalExpression(expression)) => extractTimeRange(Some(expression)).flatMap(i => ~i)
       case Some(TupledLogicalExpression(expression1, operator: TupledLogicalOperator, expression2: Expression)) =>
         val intervals = extractTimeRange(Some(expression1)) ++ extractTimeRange(Some(expression2))
         if (intervals.isEmpty)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/TimeRangeManager.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/TimeRangeManager.scala
@@ -41,7 +41,7 @@ object TimeRangeManager {
         }
       case Some(RangeExpression("timestamp", ComparisonValue(v1: Long), ComparisonValue(v2: Long))) =>
         List(Interval.closed(v1, v2))
-      case Some(UnaryLogicalExpression(expression)) => extractTimeRange(Some(expression)).flatMap(i => ~i)
+      case Some(NotExpression(expression)) => extractTimeRange(Some(expression)).flatMap(i => ~i)
       case Some(TupledLogicalExpression(expression1, operator: TupledLogicalOperator, expression2: Expression)) =>
         val intervals = extractTimeRange(Some(expression1)) ++ extractTimeRange(Some(expression2))
         if (intervals.isEmpty)

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -57,7 +57,7 @@ class PublisherActorSpec
     namespace = "registry",
     metric = "people",
     distinct = false,
-    fields = AllFields,
+    fields = AllFields(),
     condition = Some(
       Condition(
         ComparisonExpression(dimension = "timestamp",

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializerSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializerSpec.scala
@@ -321,10 +321,8 @@ class StandardCommitLogSerializerSpec extends WordSpec with Matchers {
         val ts        = 1500909299161L
         val metric    = "test-metric"
         val expression =
-          UnaryLogicalExpression(ComparisonExpression("dimension",
-                                                      GreaterOrEqualToOperator,
-                                                      AbsoluteComparisonValue("dimValue")),
-                                 NotOperator)
+          UnaryLogicalExpression(
+            ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue("dimValue")))
         val originalEntry =
           DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializerSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializerSpec.scala
@@ -321,7 +321,7 @@ class StandardCommitLogSerializerSpec extends WordSpec with Matchers {
         val ts        = 1500909299161L
         val metric    = "test-metric"
         val expression =
-          UnaryLogicalExpression(
+          NotExpression(
             ComparisonExpression("dimension", GreaterOrEqualToOperator, AbsoluteComparisonValue("dimValue")))
         val originalEntry =
           DeleteEntry(db = db, namespace = namespace, metric = metric, timestamp = ts, expression = expression)

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
@@ -483,7 +483,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             fields = ListFields(List(Field("name", None))),
             condition = Some(
               Condition(
-                UnaryLogicalExpression(
+                NotExpression(
                   expression = TupledLogicalExpression(
                     expression1 = ComparisonExpression(dimension = "timestamp",
                                                        comparison = GreaterOrEqualToOperator,
@@ -532,7 +532,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             fields = ListFields(List(Field("name", None))),
             condition = Some(
               Condition(
-                UnaryLogicalExpression(
+                NotExpression(
                   expression = TupledLogicalExpression(
                     expression1 = ComparisonExpression(dimension = "timestamp",
                                                        comparison = GreaterOrEqualToOperator,
@@ -579,7 +579,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             fields = ListFields(List(Field("name", None))),
             condition = Some(
               Condition(
-                UnaryLogicalExpression(
+                NotExpression(
                   expression = TupledLogicalExpression(
                     expression1 = ComparisonExpression(dimension = "timestamp",
                                                        comparison = GreaterOrEqualToOperator,
@@ -812,7 +812,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("value", None))),
-            condition = Some(Condition(UnaryLogicalExpression(NullableExpression(dimension = "name")))),
+            condition = Some(Condition(NotExpression(NullableExpression(dimension = "name")))),
             limit = Some(LimitOperator(5))
           ),
           schema
@@ -876,7 +876,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("value", None))),
-            condition = Some(Condition(UnaryLogicalExpression(NullableExpression(dimension = "value")))),
+            condition = Some(Condition(NotExpression(NullableExpression(dimension = "value")))),
             limit = Some(LimitOperator(5))
           ),
           schema
@@ -941,7 +941,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("value", None))),
-            condition = Some(Condition(UnaryLogicalExpression(NullableExpression(dimension = "creationDate")))),
+            condition = Some(Condition(NotExpression(NullableExpression(dimension = "creationDate")))),
             limit = Some(LimitOperator(5))
           ),
           schema

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
@@ -52,7 +52,7 @@ class StatementParserSpec extends WordSpec with Matchers {
                              namespace = "registry",
                              metric = "people",
                              distinct = false,
-                             fields = AllFields,
+                             fields = AllFields(),
                              limit = Some(LimitOperator(4))),
           schema
         ) should be(
@@ -93,7 +93,7 @@ class StatementParserSpec extends WordSpec with Matchers {
                                namespace = "registry",
                                metric = "people",
                                distinct = true,
-                               fields = AllFields,
+                               fields = AllFields(),
                                limit = Some(LimitOperator(4))),
             schema
           )
@@ -481,18 +481,19 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(UnaryLogicalExpression(
-              expression = TupledLogicalExpression(
-                expression1 = ComparisonExpression(dimension = "timestamp",
-                                                   comparison = GreaterOrEqualToOperator,
-                                                   value = AbsoluteComparisonValue(2L)),
-                operator = OrOperator,
-                expression2 = ComparisonExpression(dimension = "timestamp",
-                                                   comparison = LessThanOperator,
-                                                   value = AbsoluteComparisonValue(4L))
-              ),
-              operator = NotOperator
-            ))),
+            condition = Some(
+              Condition(
+                UnaryLogicalExpression(
+                  expression = TupledLogicalExpression(
+                    expression1 = ComparisonExpression(dimension = "timestamp",
+                                                       comparison = GreaterOrEqualToOperator,
+                                                       value = AbsoluteComparisonValue(2L)),
+                    operator = OrOperator,
+                    expression2 = ComparisonExpression(dimension = "timestamp",
+                                                       comparison = LessThanOperator,
+                                                       value = AbsoluteComparisonValue(4L))
+                  )
+                ))),
             limit = Some(LimitOperator(4))
           ),
           schema
@@ -529,16 +530,17 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(UnaryLogicalExpression(
-              expression = TupledLogicalExpression(
-                expression1 = ComparisonExpression(dimension = "timestamp",
-                                                   comparison = GreaterOrEqualToOperator,
-                                                   value = AbsoluteComparisonValue(2L)),
-                operator = OrOperator,
-                expression2 = EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("$john$"))
-              ),
-              operator = NotOperator
-            ))),
+            condition = Some(
+              Condition(
+                UnaryLogicalExpression(
+                  expression = TupledLogicalExpression(
+                    expression1 = ComparisonExpression(dimension = "timestamp",
+                                                       comparison = GreaterOrEqualToOperator,
+                                                       value = AbsoluteComparisonValue(2L)),
+                    operator = OrOperator,
+                    expression2 = EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("$john$"))
+                  )
+                ))),
             limit = Some(LimitOperator(4))
           ),
           schema
@@ -575,16 +577,17 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(UnaryLogicalExpression(
-              expression = TupledLogicalExpression(
-                expression1 = ComparisonExpression(dimension = "timestamp",
-                                                   comparison = GreaterOrEqualToOperator,
-                                                   value = AbsoluteComparisonValue(2L)),
-                operator = OrOperator,
-                expression2 = LikeExpression(dimension = "name", value = "$john$")
-              ),
-              operator = NotOperator
-            ))),
+            condition = Some(
+              Condition(
+                UnaryLogicalExpression(
+                  expression = TupledLogicalExpression(
+                    expression1 = ComparisonExpression(dimension = "timestamp",
+                                                       comparison = GreaterOrEqualToOperator,
+                                                       value = AbsoluteComparisonValue(2L)),
+                    operator = OrOperator,
+                    expression2 = LikeExpression(dimension = "name", value = "$john$")
+                  )
+                ))),
             limit = Some(LimitOperator(4))
           ),
           schema
@@ -619,7 +622,7 @@ class StatementParserSpec extends WordSpec with Matchers {
                              namespace = "registry",
                              metric = "people",
                              distinct = false,
-                             fields = AllFields,
+                             fields = AllFields(),
                              order = Some(AscOrderOperator("name")),
                              limit = Some(LimitOperator(4))),
           schema
@@ -645,7 +648,7 @@ class StatementParserSpec extends WordSpec with Matchers {
                              namespace = "registry",
                              metric = "people",
                              distinct = false,
-                             fields = AllFields,
+                             fields = AllFields(),
                              order = Some(AscOrderOperator("value")),
                              limit = Some(LimitOperator(4))),
           schema
@@ -703,7 +706,7 @@ class StatementParserSpec extends WordSpec with Matchers {
                                                           namespace = "registry",
                                                           metric = "people",
                                                           distinct = false,
-                                                          fields = AllFields),
+                                                          fields = AllFields()),
                                        schema) should be(
           Right(
             ParsedSimpleQuery("registry", "people", new MatchAllDocsQuery(), false, Int.MaxValue)
@@ -809,7 +812,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("value", None))),
-            condition = Some(Condition(UnaryLogicalExpression(NullableExpression(dimension = "name"), NotOperator))),
+            condition = Some(Condition(UnaryLogicalExpression(NullableExpression(dimension = "name")))),
             limit = Some(LimitOperator(5))
           ),
           schema
@@ -873,7 +876,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("value", None))),
-            condition = Some(Condition(UnaryLogicalExpression(NullableExpression(dimension = "value"), NotOperator))),
+            condition = Some(Condition(UnaryLogicalExpression(NullableExpression(dimension = "value")))),
             limit = Some(LimitOperator(5))
           ),
           schema
@@ -938,8 +941,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("value", None))),
-            condition =
-              Some(Condition(UnaryLogicalExpression(NullableExpression(dimension = "creationDate"), NotOperator))),
+            condition = Some(Condition(UnaryLogicalExpression(NullableExpression(dimension = "creationDate")))),
             limit = Some(LimitOperator(5))
           ),
           schema

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
@@ -138,7 +138,7 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
       "parse it successfully of a NOT condition" in {
         TimeRangeManager.extractTimeRange(
           Some(
-            UnaryLogicalExpression(
+            NotExpression(
               expression = ComparisonExpression(dimension = "timestamp",
                                                 comparison = GreaterThanOperator,
                                                 value = AbsoluteComparisonValue(2L))
@@ -149,7 +149,7 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
 
         TimeRangeManager.extractTimeRange(
           Some(
-            UnaryLogicalExpression(
+            NotExpression(
               expression = RangeExpression("timestamp", AbsoluteComparisonValue(2L), AbsoluteComparisonValue(4L))
             )
           )) shouldBe List(
@@ -161,7 +161,7 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
       "parse it successfully in case of a GTE OR a LT selection" in {
         TimeRangeManager.extractTimeRange(
           Some(
-            UnaryLogicalExpression(
+            NotExpression(
               expression = TupledLogicalExpression(
                 expression1 = ComparisonExpression(dimension = "timestamp",
                                                    comparison = GreaterOrEqualToOperator,

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
@@ -141,8 +141,7 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
             UnaryLogicalExpression(
               expression = ComparisonExpression(dimension = "timestamp",
                                                 comparison = GreaterThanOperator,
-                                                value = AbsoluteComparisonValue(2L)),
-              operator = NotOperator
+                                                value = AbsoluteComparisonValue(2L))
             )
           )) shouldBe List(
           Interval.fromBounds(Unbound(), Closed(2))
@@ -151,8 +150,7 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
         TimeRangeManager.extractTimeRange(
           Some(
             UnaryLogicalExpression(
-              expression = RangeExpression("timestamp", AbsoluteComparisonValue(2L), AbsoluteComparisonValue(4L)),
-              operator = NotOperator
+              expression = RangeExpression("timestamp", AbsoluteComparisonValue(2L), AbsoluteComparisonValue(4L))
             )
           )) shouldBe List(
           Interval.fromBounds(Unbound(), Open(2)),
@@ -172,8 +170,7 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
                 expression2 = ComparisonExpression(dimension = "timestamp",
                                                    comparison = LessThanOperator,
                                                    value = AbsoluteComparisonValue(4L))
-              ),
-              operator = NotOperator
+              )
             )
           )) shouldBe List(
           Interval.fromBounds(Unbound(), Open(0))

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
@@ -74,13 +74,11 @@ object CustomSerializers {
         ({
           case JString(logical) =>
             logical.toLowerCase match {
-              case "not" => NotOperator
               case "and" => AndOperator
               case "or"  => OrOperator
             }
           case JNull => null
         }, {
-          case NotOperator => JString("not")
           case AndOperator => JString("and")
           case OrOperator  => JString("or")
         }))

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryEnrichmentTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryEnrichmentTest.scala
@@ -395,10 +395,10 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
           ListFields(List(Field("name", None))),
           Some(
             Condition(
-              TupledLogicalExpression(LikeExpression("surname", "poe"),
-                                      OrOperator,
-                                      UnaryLogicalExpression(EqualityExpression("number", AbsoluteComparisonValue(1.0)),
-                                                             NotOperator)))),
+              TupledLogicalExpression(
+                LikeExpression("surname", "poe"),
+                OrOperator,
+                UnaryLogicalExpression(EqualityExpression("number", AbsoluteComparisonValue(1.0)))))),
           None,
           None,
           Some(LimitOperator(1))
@@ -419,7 +419,7 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
                   TupledLogicalExpression(
                     LikeExpression("surname", "poe"),
                     OrOperator,
-                    UnaryLogicalExpression(EqualityExpression("number", AbsoluteComparisonValue(1.0)), NotOperator)),
+                    UnaryLogicalExpression(EqualityExpression("number", AbsoluteComparisonValue(1.0)))),
                   AndOperator,
                   TupledLogicalExpression(
                     ComparisonExpression("age", GreaterThanOperator, AbsoluteComparisonValue(1L)),
@@ -485,7 +485,7 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
             "people",
             false,
             ListFields(List(Field("name", None))),
-            Some(Condition(UnaryLogicalExpression(NullableExpression("age"), NotOperator))),
+            Some(Condition(UnaryLogicalExpression(NullableExpression("age")))),
             None,
             None,
             Some(LimitOperator(1))
@@ -518,7 +518,7 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
               Condition(
                 TupledLogicalExpression(NullableExpression("age"),
                                         AndOperator,
-                                        UnaryLogicalExpression(NullableExpression("height"), NotOperator)))),
+                                        UnaryLogicalExpression(NullableExpression("height"))))),
             None,
             None,
             Some(LimitOperator(1))

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryEnrichmentTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryEnrichmentTest.scala
@@ -395,10 +395,9 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
           ListFields(List(Field("name", None))),
           Some(
             Condition(
-              TupledLogicalExpression(
-                LikeExpression("surname", "poe"),
-                OrOperator,
-                UnaryLogicalExpression(EqualityExpression("number", AbsoluteComparisonValue(1.0)))))),
+              TupledLogicalExpression(LikeExpression("surname", "poe"),
+                                      OrOperator,
+                                      NotExpression(EqualityExpression("number", AbsoluteComparisonValue(1.0)))))),
           None,
           None,
           Some(LimitOperator(1))
@@ -416,10 +415,9 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
             Some(
               Condition(
                 TupledLogicalExpression(
-                  TupledLogicalExpression(
-                    LikeExpression("surname", "poe"),
-                    OrOperator,
-                    UnaryLogicalExpression(EqualityExpression("number", AbsoluteComparisonValue(1.0)))),
+                  TupledLogicalExpression(LikeExpression("surname", "poe"),
+                                          OrOperator,
+                                          NotExpression(EqualityExpression("number", AbsoluteComparisonValue(1.0)))),
                   AndOperator,
                   TupledLogicalExpression(
                     ComparisonExpression("age", GreaterThanOperator, AbsoluteComparisonValue(1L)),
@@ -485,7 +483,7 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
             "people",
             false,
             ListFields(List(Field("name", None))),
-            Some(Condition(UnaryLogicalExpression(NullableExpression("age")))),
+            Some(Condition(NotExpression(NullableExpression("age")))),
             None,
             None,
             Some(LimitOperator(1))
@@ -518,7 +516,7 @@ class QueryEnrichmentTest extends WordSpec with Matchers {
               Condition(
                 TupledLogicalExpression(NullableExpression("age"),
                                         AndOperator,
-                                        UnaryLogicalExpression(NullableExpression("height"))))),
+                                        NotExpression(NullableExpression("height"))))),
             None,
             None,
             Some(LimitOperator(1))

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -166,8 +166,8 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
 
   private lazy val unaryLogicalExpression = notUnaryLogicalExpression
 
-  private lazy val notUnaryLogicalExpression: PackratParser[UnaryLogicalExpression] =
-    (Not ~> expression) ^^ (expression => UnaryLogicalExpression(expression))
+  private lazy val notUnaryLogicalExpression: PackratParser[NotExpression] =
+    (Not ~> expression) ^^ (expression => NotExpression(expression))
 
   private lazy val tupledLogicalExpression: PackratParser[TupledLogicalExpression] =
     andTupledLogicalExpression | orTupledLogicalExpression
@@ -196,7 +196,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
 
   lazy val nullableExpression: PackratParser[Expression] =
     (dimension <~ Is) ~ (Not ?) ~ Null ^^ {
-      case dim ~ Some(_) ~ _ => UnaryLogicalExpression(NullableExpression(dim))
+      case dim ~ Some(_) ~ _ => NotExpression(NullableExpression(dim))
       case dim ~ None ~ _    => NullableExpression(dim)
     }
 

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -141,7 +141,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
   private val selectFields = (Distinct ?) ~ (All | aggField | field) ~ rep(Comma ~> (aggField | field)) ^^ {
     case _ ~ f ~ fs =>
       f match {
-        case All      => AllFields
+        case All      => AllFields()
         case f: Field => ListFields(f +: fs)
       }
   }
@@ -167,7 +167,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
   private lazy val unaryLogicalExpression = notUnaryLogicalExpression
 
   private lazy val notUnaryLogicalExpression: PackratParser[UnaryLogicalExpression] =
-    (Not ~> expression) ^^ (expression => UnaryLogicalExpression(expression, NotOperator))
+    (Not ~> expression) ^^ (expression => UnaryLogicalExpression(expression))
 
   private lazy val tupledLogicalExpression: PackratParser[TupledLogicalExpression] =
     andTupledLogicalExpression | orTupledLogicalExpression
@@ -196,7 +196,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
 
   lazy val nullableExpression: PackratParser[Expression] =
     (dimension <~ Is) ~ (Not ?) ~ Null ^^ {
-      case dim ~ Some(_) ~ _ => UnaryLogicalExpression(NullableExpression(dim), NotOperator)
+      case dim ~ Some(_) ~ _ => UnaryLogicalExpression(NullableExpression(dim))
       case dim ~ None ~ _    => NullableExpression(dim)
     }
 
@@ -222,8 +222,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
       case d ~ v1 ~ v2 => RangeExpression(dimension = d, value1 = v1, value2 = v2)
     }
 
-  lazy val select
-    : PackratParser[~[Option[String], SelectedFields with Product with Serializable]] = Select ~> Distinct.? ~ selectFields
+  lazy val select: PackratParser[~[Option[String], SelectedFields]] = Select ~> Distinct.? ~ selectFields
 
   lazy val from: PackratParser[String] = From ~> metric
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
@@ -113,8 +113,7 @@ class DeleteSQLStatementSpec extends WordSpec with Matchers {
                 expression2 = ComparisonExpression(dimension = "timestamp",
                                                    comparison = LessThanOperator,
                                                    value = AbsoluteComparisonValue(4L))
-              ),
-              operator = NotOperator
+              )
             ))
           )))
       }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
@@ -104,7 +104,7 @@ class DeleteSQLStatementSpec extends WordSpec with Matchers {
             db = "db",
             namespace = "registry",
             metric = "people",
-            condition = Condition(UnaryLogicalExpression(
+            condition = Condition(NotExpression(
               expression = TupledLogicalExpression(
                 expression1 = ComparisonExpression(dimension = "timestamp",
                                                    comparison = GreaterOrEqualToOperator,

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
@@ -176,8 +176,7 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
                 expression2 = ComparisonExpression(dimension = "timestamp",
                                                    comparison = LessThanOperator,
                                                    value = AbsoluteComparisonValue(4L))
-              ),
-              operator = NotOperator
+              )
             )))
           )))
       }
@@ -194,8 +193,7 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             condition = Some(Condition(TupledLogicalExpression(
               expression1 = UnaryLogicalExpression(ComparisonExpression(dimension = "timestamp",
                                                                         comparison = GreaterOrEqualToOperator,
-                                                                        value = AbsoluteComparisonValue(2L)),
-                                                   operator = NotOperator),
+                                                                        value = AbsoluteComparisonValue(2L))),
               operator = OrOperator,
               expression2 = ComparisonExpression(dimension = "timestamp",
                                                  comparison = LessThanOperator,
@@ -222,10 +220,8 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
                 operator = OrOperator,
                 expression2 = UnaryLogicalExpression(ComparisonExpression(dimension = "timestamp",
                                                                           comparison = LessThanOperator,
-                                                                          value = AbsoluteComparisonValue(4L)),
-                                                     operator = NotOperator)
-              ),
-              operator = NotOperator
+                                                                          value = AbsoluteComparisonValue(4L)))
+              )
             )))
           )))
       }
@@ -302,12 +298,14 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
               namespace = "registry",
               metric = "AreaOccupancy",
               distinct = false,
-              fields = AllFields,
-              condition = Some(Condition(TupledLogicalExpression(
-                EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("MeetingArea")),
-                AndOperator,
-                UnaryLogicalExpression(NullableExpression("name"), NotOperator)
-              ))),
+              fields = AllFields(),
+              condition = Some(
+                Condition(
+                  TupledLogicalExpression(
+                    EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("MeetingArea")),
+                    AndOperator,
+                    UnaryLogicalExpression(NullableExpression("name"))
+                  ))),
               order = Some(DescOrderOperator(dimension = "timestamp")),
               limit = Some(LimitOperator(1))
             ))
@@ -326,7 +324,7 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
               namespace = "registry",
               metric = "AreaOccupancy",
               distinct = false,
-              fields = AllFields,
+              fields = AllFields(),
               condition = Some(
                 Condition(
                   TupledLogicalExpression(
@@ -334,10 +332,10 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
                       expression1 =
                         EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("MeetingArea")),
                       operator = AndOperator,
-                      expression2 = UnaryLogicalExpression(NullableExpression("name"), NotOperator)
+                      expression2 = UnaryLogicalExpression(NullableExpression("name"))
                     ),
                     operator = OrOperator,
-                    expression2 = UnaryLogicalExpression(NullableExpression("floor"), NotOperator)
+                    expression2 = UnaryLogicalExpression(NullableExpression("floor"))
                   )
                 )),
               order = Some(DescOrderOperator(dimension = "timestamp")),
@@ -372,7 +370,7 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
                                               value1 = AbsoluteComparisonValue(2),
                                               value2 = AbsoluteComparisonValue(4))
               ),
-              expression2 = UnaryLogicalExpression(NullableExpression("code"), NotOperator),
+              expression2 = UnaryLogicalExpression(NullableExpression("code")),
               operator = AndOperator
             ))),
             order = Some(DescOrderOperator(dimension = "name")),

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
@@ -167,7 +167,7 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(UnaryLogicalExpression(
+            condition = Some(Condition(NotExpression(
               expression = TupledLogicalExpression(
                 expression1 = ComparisonExpression(dimension = "timestamp",
                                                    comparison = GreaterOrEqualToOperator,
@@ -191,9 +191,9 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             distinct = false,
             fields = ListFields(List(Field("name", None))),
             condition = Some(Condition(TupledLogicalExpression(
-              expression1 = UnaryLogicalExpression(ComparisonExpression(dimension = "timestamp",
-                                                                        comparison = GreaterOrEqualToOperator,
-                                                                        value = AbsoluteComparisonValue(2L))),
+              expression1 = NotExpression(ComparisonExpression(dimension = "timestamp",
+                                                               comparison = GreaterOrEqualToOperator,
+                                                               value = AbsoluteComparisonValue(2L))),
               operator = OrOperator,
               expression2 = ComparisonExpression(dimension = "timestamp",
                                                  comparison = LessThanOperator,
@@ -212,15 +212,15 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(UnaryLogicalExpression(
+            condition = Some(Condition(NotExpression(
               expression = TupledLogicalExpression(
                 expression1 = ComparisonExpression(dimension = "timestamp",
                                                    comparison = GreaterOrEqualToOperator,
                                                    value = AbsoluteComparisonValue(2L)),
                 operator = OrOperator,
-                expression2 = UnaryLogicalExpression(ComparisonExpression(dimension = "timestamp",
-                                                                          comparison = LessThanOperator,
-                                                                          value = AbsoluteComparisonValue(4L)))
+                expression2 = NotExpression(ComparisonExpression(dimension = "timestamp",
+                                                                 comparison = LessThanOperator,
+                                                                 value = AbsoluteComparisonValue(4L)))
               )
             )))
           )))
@@ -304,7 +304,7 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
                   TupledLogicalExpression(
                     EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("MeetingArea")),
                     AndOperator,
-                    UnaryLogicalExpression(NullableExpression("name"))
+                    NotExpression(NullableExpression("name"))
                   ))),
               order = Some(DescOrderOperator(dimension = "timestamp")),
               limit = Some(LimitOperator(1))
@@ -332,10 +332,10 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
                       expression1 =
                         EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("MeetingArea")),
                       operator = AndOperator,
-                      expression2 = UnaryLogicalExpression(NullableExpression("name"))
+                      expression2 = NotExpression(NullableExpression("name"))
                     ),
                     operator = OrOperator,
-                    expression2 = UnaryLogicalExpression(NullableExpression("floor"))
+                    expression2 = NotExpression(NullableExpression("floor"))
                   )
                 )),
               order = Some(DescOrderOperator(dimension = "timestamp")),
@@ -370,7 +370,7 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
                                               value1 = AbsoluteComparisonValue(2),
                                               value2 = AbsoluteComparisonValue(4))
               ),
-              expression2 = UnaryLogicalExpression(NullableExpression("code")),
+              expression2 = NotExpression(NullableExpression("code")),
               operator = AndOperator
             ))),
             order = Some(DescOrderOperator(dimension = "name")),

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
@@ -35,7 +35,7 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
                                namespace = "registry",
                                metric = "people",
                                distinct = false,
-                               fields = AllFields)))
+                               fields = AllFields())))
       }
     }
 
@@ -47,7 +47,7 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
                                namespace = "registry",
                                metric = "people",
                                distinct = true,
-                               fields = AllFields)))
+                               fields = AllFields())))
       }
     }
 
@@ -353,8 +353,7 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
                 expression2 = ComparisonExpression(dimension = "timestamp",
                                                    comparison = LessThanOperator,
                                                    value = AbsoluteComparisonValue(4L))
-              ),
-              operator = NotOperator
+              )
             )))
           )))
       }
@@ -368,7 +367,7 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
                                namespace = "registry",
                                metric = "people",
                                distinct = false,
-                               fields = AllFields,
+                               fields = AllFields(),
                                order = Some(AscOrderOperator("name")))))
       }
     }
@@ -381,7 +380,7 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
                                namespace = "registry",
                                metric = "people",
                                distinct = false,
-                               fields = AllFields,
+                               fields = AllFields(),
                                limit = Some(LimitOperator(10)))))
       }
     }
@@ -465,7 +464,7 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             namespace = "registry",
             metric = "AreaOccupancy",
             distinct = false,
-            fields = AllFields,
+            fields = AllFields(),
             condition = Some(Condition(EqualityExpression(dimension = "name", AbsoluteComparisonValue("MeetingArea")))),
             order = Some(DescOrderOperator(dimension = "timestamp")),
             limit = Some(LimitOperator(1))
@@ -483,7 +482,7 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             namespace = "registry",
             metric = "AreaOccupancy",
             distinct = false,
-            fields = AllFields,
+            fields = AllFields(),
             condition = Some(
               Condition(
                 TupledLogicalExpression(EqualityExpression(dimension = "name", AbsoluteComparisonValue("MeetingArea")),
@@ -506,12 +505,14 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             namespace = "registry",
             metric = "AreaOccupancy",
             distinct = false,
-            fields = AllFields,
-            condition = Some(Condition(TupledLogicalExpression(
-              EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("MeetingArea")),
-              AndOperator,
-              UnaryLogicalExpression(NullableExpression("name"), NotOperator)
-            ))),
+            fields = AllFields(),
+            condition = Some(
+              Condition(
+                TupledLogicalExpression(
+                  EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("MeetingArea")),
+                  AndOperator,
+                  UnaryLogicalExpression(NullableExpression("name"))
+                ))),
             order = Some(DescOrderOperator(dimension = "timestamp")),
             limit = Some(LimitOperator(1))
           ))
@@ -530,14 +531,14 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             namespace = "registry",
             metric = "AreaOccupancy",
             distinct = false,
-            fields = AllFields,
+            fields = AllFields(),
             condition = Some(Condition(TupledLogicalExpression(
               EqualityExpression(dimension = "name", AbsoluteComparisonValue("MeetingArea")),
               AndOperator,
               TupledLogicalExpression(
-                UnaryLogicalExpression(NullableExpression("name"), NotOperator),
+                UnaryLogicalExpression(NullableExpression("name")),
                 OrOperator,
-                UnaryLogicalExpression(NullableExpression("floor"), NotOperator)
+                UnaryLogicalExpression(NullableExpression("floor"))
               )
             ))),
             order = Some(DescOrderOperator(dimension = "timestamp")),

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
@@ -344,7 +344,7 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(UnaryLogicalExpression(
+            condition = Some(Condition(NotExpression(
               expression = TupledLogicalExpression(
                 expression1 = ComparisonExpression(dimension = "timestamp",
                                                    comparison = GreaterOrEqualToOperator,
@@ -511,7 +511,7 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
                 TupledLogicalExpression(
                   EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("MeetingArea")),
                   AndOperator,
-                  UnaryLogicalExpression(NullableExpression("name"))
+                  NotExpression(NullableExpression("name"))
                 ))),
             order = Some(DescOrderOperator(dimension = "timestamp")),
             limit = Some(LimitOperator(1))
@@ -536,9 +536,9 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
               EqualityExpression(dimension = "name", AbsoluteComparisonValue("MeetingArea")),
               AndOperator,
               TupledLogicalExpression(
-                UnaryLogicalExpression(NullableExpression("name")),
+                NotExpression(NullableExpression("name")),
                 OrOperator,
-                UnaryLogicalExpression(NullableExpression("floor"))
+                NotExpression(NullableExpression("floor"))
               )
             ))),
             order = Some(DescOrderOperator(dimension = "timestamp")),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,6 @@ object Dependencies {
     lazy val distributedData        = namespace %% "akka-distributed-data"       % version
     lazy val cluster                = namespace %% "akka-cluster"                % version
     lazy val sharding               = namespace %% "akka-sharding"               % version
-    lazy val jackson_serialization  = namespace %% "akka-serialization-jackson"  % version
     lazy val slf4j                  = namespace %% "akka-slf4j"                  % version
     lazy val clusterTools           = namespace %% "akka-cluster-tools"          % version
     lazy val clusterMetrics         = namespace %% "akka-cluster-metrics"        % version
@@ -227,7 +226,6 @@ object Dependencies {
     val libraries = Seq(
       scala_logging.scala_logging,
       config.core,
-      akka.jackson_serialization,
       scalatest.core % Test
     )
   }
@@ -247,7 +245,6 @@ object Dependencies {
       akka.clusterTools,
       akka.clusterMetrics,
       akka.discovery,
-      akka.jackson_serialization,
       akka_management.cluster_bootstrap,
       akka_management.cluster_http,
       akka_discovery.kubernetes_api,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,18 +56,19 @@ object Dependencies {
     lazy val version   = "2.6.1"
     lazy val namespace = "com.typesafe.akka"
 
-    lazy val actor           = namespace %% "akka-actor"              % version
-    lazy val testkit         = namespace %% "akka-testkit"            % version
-    lazy val stream          = namespace %% "akka-stream"             % version
-    lazy val stream_testkit  = namespace %% "akka-stream-testkit"     % version
-    lazy val distributedData = namespace %% "akka-distributed-data"   % version
-    lazy val cluster         = namespace %% "akka-cluster"            % version
-    lazy val sharding        = namespace %% "akka-sharding"           % version
-    lazy val slf4j           = namespace %% "akka-slf4j"              % version
-    lazy val clusterTools    = namespace %% "akka-cluster-tools"      % version
-    lazy val clusterMetrics  = namespace %% "akka-cluster-metrics"    % version
-    lazy val multiNode       = namespace %% "akka-multi-node-testkit" % version
-    lazy val discovery       = namespace %% "akka-discovery"          % version
+    lazy val actor                  = namespace %% "akka-actor"                  % version
+    lazy val testkit                = namespace %% "akka-testkit"                % version
+    lazy val stream                 = namespace %% "akka-stream"                 % version
+    lazy val stream_testkit         = namespace %% "akka-stream-testkit"         % version
+    lazy val distributedData        = namespace %% "akka-distributed-data"       % version
+    lazy val cluster                = namespace %% "akka-cluster"                % version
+    lazy val sharding               = namespace %% "akka-sharding"               % version
+    lazy val jackson_serialization  = namespace %% "akka-serialization-jackson"  % version
+    lazy val slf4j                  = namespace %% "akka-slf4j"                  % version
+    lazy val clusterTools           = namespace %% "akka-cluster-tools"          % version
+    lazy val clusterMetrics         = namespace %% "akka-cluster-metrics"        % version
+    lazy val multiNode              = namespace %% "akka-multi-node-testkit"     % version
+    lazy val discovery              = namespace %% "akka-discovery"              % version
   }
 
   object akka_management {
@@ -97,7 +98,7 @@ object Dependencies {
     lazy val default         = namespace                      %% "akka-http"            % version
     lazy val testkit         = namespace                      %% "akka-http-testkit"    % version % Test
     lazy val sprayJson       = "com.typesafe.akka"            %% "akka-http-spray-json" % version
-    lazy val swaggerAkkaHttp = "com.github.swagger-akka-http" %% "swagger-akka-http"    % "0.14.0"
+    lazy val swaggerAkkaHttp = "com.github.swagger-akka-http" %% "swagger-akka-http"    % "2.0.4"
   }
 
   object kamon {
@@ -123,7 +124,7 @@ object Dependencies {
   }
 
   object json4s {
-    lazy val version   = "3.5.4"
+    lazy val version   = "3.6.7"
     lazy val namespace = "org.json4s"
     lazy val jackson   = namespace %% "json4s-jackson" % version
   }
@@ -226,6 +227,7 @@ object Dependencies {
     val libraries = Seq(
       scala_logging.scala_logging,
       config.core,
+      akka.jackson_serialization,
       scalatest.core % Test
     )
   }
@@ -245,6 +247,7 @@ object Dependencies {
       akka.clusterTools,
       akka.clusterMetrics,
       akka.discovery,
+      akka.jackson_serialization,
       akka_management.cluster_bootstrap,
       akka_management.cluster_http,
       akka_discovery.kubernetes_api,


### PR DESCRIPTION
This PR aims to make the codebase more serialization friendly.

In particular, the following guidelines have been applied
- uniform (in favour of case classes) all the ADTs with a mixture of case classes and object as children.
- remove usage of tuples in favour of case classes
- upgrade Json and serialization related dependencies in order to avoid any possible clash