### PR TITLE
[Hotfix] Uniform Json formatters inheritance

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
@@ -21,7 +21,8 @@ import akka.event.{Logging, LoggingAdapter}
 import com.typesafe.config.Config
 import io.radicalbit.nsdb.cluster.endpoint.GrpcEndpoint
 import io.radicalbit.nsdb.security.NsdbSecurity
-import io.radicalbit.nsdb.web.WebResources
+import io.radicalbit.nsdb.web.{BitSerializer, CustomSerializers, WebResources}
+import org.json4s.{DefaultFormats, Formats}
 
 /**
   * Class responsible to instantiate all the node endpoints (e.g. grpc, http and ws).
@@ -40,6 +41,8 @@ class NsdbNodeEndpoint(readCoordinator: ActorRef,
   new GrpcEndpoint(readCoordinator = readCoordinator,
                    writeCoordinator = writeCoordinator,
                    metadataCoordinator = metadataCoordinator)
+
+  implicit val formats: Formats = DefaultFormats ++ CustomSerializers.customSerializers + BitSerializer
 
   initWebEndpoint(writeCoordinator, readCoordinator, metadataCoordinator, publisher)
 

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -44,7 +44,7 @@ sealed trait Expression
   * Simple Not expression.
   * @param expression the expression to negate.
   */
-final case class NotExpression(expression: Expression) extends Expression
+final case class NotExpression(expression: Expression, operator: LogicalOperator = NotOperator) extends Expression
 
 /**
   * A couple of simple expressions having a [[TupledLogicalOperator]] applied.
@@ -106,6 +106,7 @@ sealed trait LogicalOperator
 sealed trait TupledLogicalOperator extends LogicalOperator
 case object AndOperator            extends TupledLogicalOperator
 case object OrOperator             extends TupledLogicalOperator
+case object NotOperator            extends LogicalOperator
 
 /**
   * Comparison operators to be used in [[ComparisonExpression]].

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializer.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializer.scala
@@ -86,7 +86,7 @@ class StandardCommitLogSerializer extends CommitLogSerializer with TypeSupport {
     dimensions.map {
       case (n, t, v) =>
         val i = Class.forName(t).newInstance().asInstanceOf[IndexType[_]]
-        n -> i.deserialize(v).asInstanceOf[NSDbType]
+        n -> i.deserialize(v)
     }.toMap
 
   /**
@@ -168,7 +168,7 @@ class StandardCommitLogSerializer extends CommitLogSerializer with TypeSupport {
       case `unaryLogicalExpressionClassName` =>
         val expClass = readByteBuffer.read
         val exp      = createExpression(expClass)
-        clazz.getConstructor(classOf[Expression]).newInstance(exp)
+        clazz.getConstructor(classOf[Expression], classOf[LogicalOperator]).newInstance(exp, NotOperator)
 
       case `tupleLogicalExpressionClassName` =>
         val expClass1 = readByteBuffer.read
@@ -219,7 +219,7 @@ class StandardCommitLogSerializer extends CommitLogSerializer with TypeSupport {
         writeBuffer.write(value.toString)
       case NullableExpression(dimension) =>
         writeBuffer.write(dimension)
-      case NotExpression(expression1) =>
+      case NotExpression(expression1, _) =>
         extractExpression(expression1)
       case TupledLogicalExpression(expression1, tupledLogicalOperator, expression2) =>
         extractExpression(expression1)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
@@ -47,7 +47,7 @@ object ExpressionParser {
       case Some(RangeExpression(dimension, ComparisonValue(value1), ComparisonValue(value2))) =>
         rangeExpression(schema, dimension, value1, value2)
 
-      case Some(NotExpression(expression)) => unaryLogicalExpression(schema, expression)
+      case Some(NotExpression(expression, _)) => unaryLogicalExpression(schema, expression)
 
       case Some(TupledLogicalExpression(expression1, operator: TupledLogicalOperator, expression2: Expression)) =>
         tupledLogicalExpression(schema, expression1, operator, expression2)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/TimeRangeManager.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/TimeRangeManager.scala
@@ -39,9 +39,9 @@ object TimeRangeManager {
           case LessThanOperator         => List(Interval.openUpper(0, value))
           case LessOrEqualToOperator    => List(Interval.closed(0, value))
         }
-      case Some(RangeExpression("timestamp", ComparisonValue(v1: Long), ComparisonValue(v2: Long))) =>
-        List(Interval.closed(v1, v2))
-      case Some(NotExpression(expression)) => extractTimeRange(Some(expression)).flatMap(i => ~i)
+      case Some(RangeExpression("timestamp", ComparisonValue(v1), ComparisonValue(v2))) =>
+        List(Interval.closed(v1.toString.toLong, v2.toString.toLong))
+      case Some(NotExpression(expression, _)) => extractTimeRange(Some(expression)).flatMap(i => ~i)
       case Some(TupledLogicalExpression(expression1, operator: TupledLogicalOperator, expression2: Expression)) =>
         val intervals = extractTimeRange(Some(expression1)) ++ extractTimeRange(Some(expression2))
         if (intervals.isEmpty)

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
@@ -30,6 +30,7 @@ import io.radicalbit.nsdb.security.http.NSDBAuthProvider
 import io.radicalbit.nsdb.web.routes._
 import io.radicalbit.nsdb.web.swagger.SwaggerDocService
 import io.radicalbit.nsdb.web.validation.FieldErrorInfo
+import org.json4s.Formats
 import spray.json._
 
 import scala.concurrent.ExecutionContext
@@ -126,7 +127,8 @@ class ApiResources(val publisherActor: ActorRef,
                    val metadataCoordinator: ActorRef,
                    val authenticationProvider: NSDBAuthProvider)(override implicit val timeout: Timeout,
                                                                  implicit val logger: LoggingAdapter,
-                                                                 override implicit val ec: ExecutionContext)
+                                                                 override implicit val ec: ExecutionContext,
+                                                                 override implicit val formats: Formats)
     extends CommandApi
     with QueryApi
     with QueryValidationApi

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
@@ -28,7 +28,6 @@ import akka.util.Timeout
 import com.typesafe.config.Config
 import io.radicalbit.nsdb.security.NsdbSecurity
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel._
-import org.json4s.DefaultFormats
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -44,8 +43,6 @@ trait WebResources extends WsResources with SSLSupport { this: NsdbSecurity =>
   import VersionHeader._
 
   def config: Config
-
-  implicit val formats = DefaultFormats
 
   implicit lazy val materializer = ActorMaterializer()
   implicit lazy val dispatcher   = system.dispatcher

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
@@ -32,12 +32,10 @@ import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.security.http.NSDBAuthProvider
 import io.radicalbit.nsdb.security.model.Metric
 import io.radicalbit.nsdb.sql.parser.SQLStatementParser
-import io.radicalbit.nsdb.web.BitSerializer
-import io.radicalbit.nsdb.web.CustomSerializers
 import io.swagger.annotations._
 import javax.ws.rs.Path
 import org.json4s.jackson.Serialization.write
-import org.json4s.{DefaultFormats, Formats}
+import org.json4s.Formats
 
 import scala.annotation.meta.field
 import scala.util.{Failure, Success}
@@ -115,7 +113,6 @@ trait QueryApi {
   def authenticationProvider: NSDBAuthProvider
 
   implicit val timeout: Timeout
-  implicit val formats: Formats = DefaultFormats ++ CustomSerializers.customSerializers + BitSerializer
 
   @ApiModel(description = "Query Response")
   case class QueryResponse(
@@ -140,7 +137,7 @@ trait QueryApi {
       new ApiResponse(code = 500, message = "Internal server error"),
       new ApiResponse(code = 400, message = "statement is invalid")
     ))
-  def queryApi()(implicit logger: LoggingAdapter): Route = {
+  def queryApi()(implicit logger: LoggingAdapter, format: Formats): Route = {
     path("query") {
       post {
         entity(as[QueryBody]) { qb =>


### PR DESCRIPTION
This PR aims to fix the inheritance of json formatter objects.

Now, the concrete definition is made on the last child.

Also, the serialization of the NotExression has been improved 