### PR TITLE
[HOTFIX] fix for not and null serializers for tokenized query

### DIFF
--- a/docs/RestApis.md
+++ b/docs/RestApis.md
@@ -157,7 +157,7 @@ Filter object is defines as below:
 
 ## Parsed Query
 
-Adding a `parsed = true` parameter in the request body, the query response will be enriched with the destructured query.
+Adding a `parsed = true` parameter in the request body, the query response will be enriched with the tokenized query.
 
 **Data example**
 
@@ -171,7 +171,7 @@ Adding a `parsed = true` parameter in the request body, the query response will 
 }
 ```
 
-The response will be a json array with `records` object as result and `parsed` for the destructured query
+The response will be a json array with `records` object as result and `parsed` for the tokenized query
 
 ```json
 {

--- a/docs/RestApis.md
+++ b/docs/RestApis.md
@@ -42,7 +42,7 @@ Filter elements are combined through `AND` operator.
     "queryString": "[string]",
     "from": "[optional timestamp in epoch format]",
     "to": "[optional timestamp in epoch format]",
-    "filters": "[ optional array of Filter] "
+    "filters": "[optional array of Filter]"
 }
 ```
 Filter object is defines as below:
@@ -154,6 +154,49 @@ Filter object is defines as below:
 **Code** : `500 INTERNAL SERVER ERROR`
 
 **Content** : `Error message`
+
+## Parsed Query
+
+Adding a `parsed = true` parameter in the request body, the query response will be enriched with the destructured query.
+
+**Data example**
+
+```json
+{
+  "db": "db",
+  "namespace": "namespace",
+  "metric": "metric",
+  "queryString": "select count(*) from metric",
+  "parsed": true
+}
+```
+
+The response will be a json array with `records` object as result and `parsed` for the destructured query
+
+```json
+{
+  "records": [{
+    "timestamp": 0,
+    "value": 1,
+    "dimensions": {},
+    "tags": {
+      "count(*)": 1
+    }
+  }],
+  "parsed" : {
+    "db" : "db",
+    "namespace" : "namespace",
+    "metric" : "metric",
+    "distinct" : false,
+    "fields" : {
+      "fields" : [ {
+        "name" : "*",
+        "aggregation" : "count"
+      } ]
+    }
+  }
+}
+```
 
 # Query Validate APIs
 

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
@@ -27,6 +27,7 @@ object CustomSerializers {
     ComparisonOperatorSerializer,
     LogicalOperatorSerializer,
     OrderOperatorSerializer,
+    NullableExpressionSerializer,
     LikeExpressionSerializer,
     EqualityExpressionSerializer
   )
@@ -76,11 +77,13 @@ object CustomSerializers {
             logical.toLowerCase match {
               case "and" => AndOperator
               case "or"  => OrOperator
+              case "not" => NotOperator
             }
           case JNull => null
         }, {
           case AndOperator => JString("and")
           case OrOperator  => JString("or")
+          case NotOperator => JString("not")
         }))
 
   case object OrderOperatorSerializer
@@ -102,7 +105,7 @@ object CustomSerializers {
   case object NullableExpressionSerializer
       extends CustomSerializer[NullableExpression](_ =>
         ({
-          case JObject(List(JField(_, JString(dimension)), JField(_, JString("like")))) => NullableExpression(dimension)
+          case JObject(List(JField(_, JString(dimension)), JField(_, JString("null")))) => NullableExpression(dimension)
         }, {
           case NullableExpression(dimension) =>
             JObject(List(JField("dimension", JString(dimension)), JField("comparison", JString("null"))))
@@ -113,7 +116,7 @@ object CustomSerializers {
         ({
           case JObject(
               List(JField("dimension", JString(dimension)),
-                   JField("comparison", JString("null")),
+                   JField("comparison", JString("like")),
                    JField("value", JString(value)))) =>
             LikeExpression(dimension, value)
         }, {

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
@@ -32,8 +32,6 @@ object CustomSerializers {
     EqualityExpressionSerializer
   )
 
-  val customSerializersForTesting = customSerializers ++ List(RelativeComparisonSerializerForTesting)
-
   case object AggregationSerializer
       extends CustomSerializer[Aggregation](_ =>
         ({
@@ -169,24 +167,4 @@ object CustomSerializers {
                 )
               ))
         }))
-
-  case object RelativeComparisonSerializerForTesting
-      extends CustomSerializer[RelativeComparisonValue[_]](_ =>
-        ({
-          case JObject(
-              List(JField("value", JLong(0L)),
-                   JField("operator", JString(operator)),
-                   JField("quantity", JLong(quantity)),
-                   JField("unitMeasure", JString(unitMeasure)))) =>
-            RelativeComparisonValue(0L, operator, quantity, unitMeasure)
-        }, {
-          case RelativeComparisonValue(_, operator, quantity: Long, unitMeasure) =>
-            JObject(
-              List(JField("value", JLong(0L)),
-                   JField("operator", JString(operator)),
-                   JField("quantity", JLong(quantity)),
-                   JField("unitMeasure", JString(unitMeasure))))
-
-        }))
-
 }

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CustomSerializerForTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CustomSerializerForTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.web
+
+import io.radicalbit.nsdb.common.statement.RelativeComparisonValue
+import org.json4s.{CustomSerializer, JObject, JString}
+import org.json4s.JsonAST.{JField, JLong}
+
+case object CustomSerializerForTest
+    extends CustomSerializer[RelativeComparisonValue[_]](_ =>
+      ({
+        case JObject(
+            List(JField("value", JLong(0L)),
+                 JField("operator", JString(operator)),
+                 JField("quantity", JLong(quantity)),
+                 JField("unitMeasure", JString(unitMeasure)))) =>
+          RelativeComparisonValue(0L, operator, quantity, unitMeasure)
+      }, {
+        case RelativeComparisonValue(_, operator, quantity: Long, unitMeasure) =>
+          JObject(
+            List(JField("value", JLong(0L)),
+                 JField("operator", JString(operator)),
+                 JField("quantity", JLong(quantity)),
+                 JField("unitMeasure", JString(unitMeasure))))
+
+      }))

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
@@ -53,7 +53,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
   val emptyAuthenticationProvider: EmptyAuthorization = new EmptyAuthorization
 
   /*
-        add to formats a CustomSerializerForTest that serializes relative timestamp (now) with a fake
+        adds to formats a CustomSerializerForTest that serializes relative timestamp (now) with a fake
         fixed timestamp (0L) in order to make the unit test time-independent
    */
   implicit val formats

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
@@ -53,10 +53,11 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
   val emptyAuthenticationProvider: EmptyAuthorization = new EmptyAuthorization
 
   /*
-        override formats with custom serializer for testing purposes that serializes relative timestamp (now) with a fake
-        fixed timestamp in order to make the test time-independent
+        add to formats a CustomSerializerForTest that serializes relative timestamp (now) with a fake
+        fixed timestamp (0L) in order to make the unit test time-independent
    */
-  implicit val formats: Formats = DefaultFormats ++ CustomSerializers.customSerializersForTesting + BitSerializer
+  implicit val formats
+    : Formats = DefaultFormats ++ CustomSerializers.customSerializers + CustomSerializerForTest + BitSerializer
 
   val secureQueryApi = new QueryApi {
     override def authenticationProvider: NSDBAuthProvider = secureAuthenticationProvider
@@ -286,14 +287,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
   "QueryApi called with optional parameter parsed = true" should
     "correctly query the db with a very simple query and return the parsed query" in {
     val q =
-      QueryBody("db",
-        "namespace",
-        "metric",
-        "select count(*) from metric",
-        None,
-        None,
-        None,
-        Some(true))
+      QueryBody("db", "namespace", "metric", "select count(*) from metric", None, None, None, Some(true))
 
     Post("/query", q) ~> testRoutes ~> check {
       status shouldBe OK

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
@@ -284,6 +284,198 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
   }
 
   "QueryApi called with optional parameter parsed = true" should
+    "correctly query the db with a very simple query and return the parsed query" in {
+    val q =
+      QueryBody("db",
+        "namespace",
+        "metric",
+        "select count(*) from metric",
+        None,
+        None,
+        None,
+        Some(true))
+
+    Post("/query", q) ~> testRoutes ~> check {
+      status shouldBe OK
+      val entity       = entityAs[String]
+      val recordString = pretty(render(parse(entity)))
+
+      recordString shouldBe
+        """{
+          |  "records" : [ {
+          |    "timestamp" : 0,
+          |    "value" : 1,
+          |    "dimensions" : {
+          |      "name" : "name",
+          |      "number" : 2
+          |    },
+          |    "tags" : {
+          |      "country" : "country"
+          |    }
+          |  }, {
+          |    "timestamp" : 2,
+          |    "value" : 3,
+          |    "dimensions" : {
+          |      "name" : "name",
+          |      "number" : 2
+          |    },
+          |    "tags" : {
+          |      "country" : "country"
+          |    }
+          |  } ],
+          |  "parsed" : {
+          |    "db" : "db",
+          |    "namespace" : "namespace",
+          |    "metric" : "metric",
+          |    "distinct" : false,
+          |    "fields" : {
+          |      "fields" : [ {
+          |        "name" : "*",
+          |        "aggregation" : "count"
+          |      } ]
+          |    }
+          |  }
+          |}""".stripMargin
+
+    }
+  }
+
+  "QueryApi called with optional parameter parsed = true" should
+    "correctly query the db with a not null condition and return the parsed query" in {
+    val q =
+      QueryBody("db",
+                "namespace",
+                "metric",
+                "select count(*) from metric where name is not null limit 1",
+                None,
+                None,
+                None,
+                Some(true))
+
+    Post("/query", q) ~> testRoutes ~> check {
+      status shouldBe OK
+      val entity       = entityAs[String]
+      val recordString = pretty(render(parse(entity)))
+
+      recordString shouldBe
+        """{
+          |  "records" : [ {
+          |    "timestamp" : 0,
+          |    "value" : 1,
+          |    "dimensions" : {
+          |      "name" : "name",
+          |      "number" : 2
+          |    },
+          |    "tags" : {
+          |      "country" : "country"
+          |    }
+          |  }, {
+          |    "timestamp" : 2,
+          |    "value" : 3,
+          |    "dimensions" : {
+          |      "name" : "name",
+          |      "number" : 2
+          |    },
+          |    "tags" : {
+          |      "country" : "country"
+          |    }
+          |  } ],
+          |  "parsed" : {
+          |    "db" : "db",
+          |    "namespace" : "namespace",
+          |    "metric" : "metric",
+          |    "distinct" : false,
+          |    "fields" : {
+          |      "fields" : [ {
+          |        "name" : "*",
+          |        "aggregation" : "count"
+          |      } ]
+          |    },
+          |    "condition" : {
+          |      "expression" : {
+          |        "expression" : {
+          |          "dimension" : "name",
+          |          "comparison" : "null"
+          |        },
+          |        "operator" : "not"
+          |      }
+          |    },
+          |    "limit" : {
+          |      "value" : 1
+          |    }
+          |  }
+          |}""".stripMargin
+
+    }
+  }
+
+  "QueryApi called with optional parameter parsed = true" should
+    "correctly query the db with a null condition and return the parsed query" in {
+    val q =
+      QueryBody("db",
+                "namespace",
+                "metric",
+                "select count(*) from metric where name is null limit 1",
+                None,
+                None,
+                None,
+                Some(true))
+
+    Post("/query", q) ~> testRoutes ~> check {
+      status shouldBe OK
+      val entity       = entityAs[String]
+      val recordString = pretty(render(parse(entity)))
+
+      recordString shouldBe
+        """{
+          |  "records" : [ {
+          |    "timestamp" : 0,
+          |    "value" : 1,
+          |    "dimensions" : {
+          |      "name" : "name",
+          |      "number" : 2
+          |    },
+          |    "tags" : {
+          |      "country" : "country"
+          |    }
+          |  }, {
+          |    "timestamp" : 2,
+          |    "value" : 3,
+          |    "dimensions" : {
+          |      "name" : "name",
+          |      "number" : 2
+          |    },
+          |    "tags" : {
+          |      "country" : "country"
+          |    }
+          |  } ],
+          |  "parsed" : {
+          |    "db" : "db",
+          |    "namespace" : "namespace",
+          |    "metric" : "metric",
+          |    "distinct" : false,
+          |    "fields" : {
+          |      "fields" : [ {
+          |        "name" : "*",
+          |        "aggregation" : "count"
+          |      } ]
+          |    },
+          |    "condition" : {
+          |      "expression" : {
+          |        "dimension" : "name",
+          |        "comparison" : "null"
+          |      }
+          |    },
+          |    "limit" : {
+          |      "value" : 1
+          |    }
+          |  }
+          |}""".stripMargin
+
+    }
+  }
+
+  "QueryApi called with optional parameter parsed = true" should
     "correctly query the db with a simple count aggregation query and return the parsed query" in {
     val q =
       QueryBody("db", "namespace", "metric", "select count(*) from metric limit 1", None, None, None, Some(true))


### PR DESCRIPTION
This PR is a hotfix for PR #109 in to correctly align the parsed query http api with the new serialization mechanism.

Furthermore:
- bugfix because I forgot to add to the custom serializer list the NullableExpressionSerializer
- some tests that check not and null serializers
- moved the CustomSerializerForTesting to test folder because that serializer is only for test and so it shouldn't be in the same file of all custom serializers.
- add docs for parsed query http api (please check if it's correct and in the correct place)