### PR TITLE
Improve Unsubscription

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
@@ -133,13 +133,15 @@ class ClusterListener() extends Actor with ActorLogging {
     case MemberRemoved(member, previousStatus) =>
       log.info("Member is Removed: {} after {}", member.address, previousStatus)
 
+      log.info("trying to get metadatacoordinator {}", s"/user/guardian_$selfNodeName")
       (context.actorSelection(s"/user/guardian_$selfNodeName") ? GetNodeChildActors)
         .map {
           case NodeChildActorsGot(metadataCoordinator, _, _, _) =>
+            log.info("trying to remove fro mmetadatacoordinator {}", metadataCoordinator)
             (metadataCoordinator ? RemoveNodeMetadata(createNodeName(member))).map {
-              case Right(NodeMetadataRemoved(nodeName)) =>
+              case NodeMetadataRemoved(nodeName) =>
                 log.info(s"metadata successfully removed for node $nodeName")
-              case Left(RemoveNodeMetadataFailed(nodeName)) =>
+              case RemoveNodeMetadataFailed(nodeName) =>
                 log.error(s"RemoveNodeMetadataFailed for node $nodeName")
             }
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
@@ -38,6 +38,11 @@ import io.radicalbit.nsdb.model.LocationWithCoordinates
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel._
 import io.radicalbit.nsdb.common.protocol.NSDbSerializable
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{
+  CommitLogCoordinatorUnSubscribed,
+  MetricsDataActorUnSubscribed,
+  PublisherUnSubscribed
+}
 
 import scala.collection.mutable
 import scala.concurrent.duration._
@@ -131,27 +136,27 @@ class ClusterListener() extends Actor with ActorLogging {
     case UnreachableMember(member) =>
       log.info("Member detected as unreachable: {}", member)
 
-      log.info("trying to get metadata coordinator {}", s"/user/guardian_$selfNodeName")
-      (context.actorSelection(s"/user/guardian_$selfNodeName") ? GetNodeChildActors)
-        .map {
-          case NodeChildActorsGot(metadataCoordinator, writeCoordinator, readCoordinator, _) =>
-            log.info("trying to remove from metadata coordinator {}", metadataCoordinator)
-            (metadataCoordinator ? RemoveNodeMetadata(createNodeName(member))).map {
-              case NodeMetadataRemoved(nodeName) =>
-                log.info(s"metadata successfully removed for node $nodeName")
-              case RemoveNodeMetadataFailed(nodeName) =>
-                log.error(s"RemoveNodeMetadataFailed for node $nodeName")
-            }
-
-            readCoordinator ! UnsubscribeMetricsDataActor(createNodeName(member))
-            writeCoordinator ! UnSubscribeCommitLogCoordinator(createNodeName(member))
-            writeCoordinator ! UnSubscribePublisher(createNodeName(member))
-            metadataCoordinator ! UnsubscribeMetricsDataActor(createNodeName(member))
-            metadataCoordinator ! UnSubscribeCommitLogCoordinator(createNodeName(member))
-
-          case unknownResponse =>
-            log.error(s"unknown response from nodeActorsGuardian ? GetNodeChildActors $unknownResponse")
-        }
+      (for {
+        NodeChildActorsGot(metadataCoordinator, writeCoordinator, readCoordinator, _) <- (context.actorSelection(
+          s"/user/guardian_$selfNodeName") ? GetNodeChildActors).mapTo[NodeChildActorsGot]
+        _ <- (readCoordinator ? UnsubscribeMetricsDataActor(createNodeName(member))).mapTo[MetricsDataActorUnSubscribed]
+        _ <- (writeCoordinator ? UnSubscribeCommitLogCoordinator(createNodeName(member)))
+          .mapTo[CommitLogCoordinatorUnSubscribed]
+        _ <- (writeCoordinator ? UnSubscribePublisher(createNodeName(member))).mapTo[PublisherUnSubscribed]
+        _ <- (writeCoordinator ? UnsubscribeMetricsDataActor(createNodeName(member)))
+          .mapTo[MetricsDataActorUnSubscribed]
+        _ <- (metadataCoordinator ? UnsubscribeMetricsDataActor(createNodeName(member)))
+          .mapTo[MetricsDataActorUnSubscribed]
+        _ <- (metadataCoordinator ? UnSubscribeCommitLogCoordinator(createNodeName(member)))
+          .mapTo[CommitLogCoordinatorUnSubscribed]
+        removeNodeMetadataResponse <- (metadataCoordinator ? RemoveNodeMetadata(createNodeName(member)))
+          .mapTo[RemoveNodeMetadataResponse]
+      } yield removeNodeMetadataResponse).map {
+        case NodeMetadataRemoved(nodeName) =>
+          log.info(s"metadata successfully removed for node $nodeName")
+        case RemoveNodeMetadataFailed(nodeName) =>
+          log.error(s"RemoveNodeMetadataFailed for node $nodeName")
+      }
 
     case MemberRemoved(member, previousStatus) =>
       log.info("Member is Removed: {} after {}", member.address, previousStatus)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
@@ -241,7 +241,9 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
       f.map {
           case UpdateSuccess(_, _) =>
             Right(LocationEvicted(db, namespace, Location(metric, node, from, to)))
-          case _ => Left(EvictLocationFailed(db, namespace, Location(metric, node, from, to)))
+          case e =>
+            log.error(s"unexpected result during location eviction $e")
+            Left(EvictLocationFailed(db, namespace, Location(metric, node, from, to)))
         }
         .pipeTo(sender)
     case EvictLocationsInNode(nodeName) =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -477,6 +477,7 @@ class MetadataCoordinator(clusterListener: ActorRef,
         }
         .pipeTo(sender)
     case RemoveNodeMetadata(nodeName) =>
+      log.info(s"remove locations for node $nodeName")
       (metadataCache ? EvictLocationsInNode(nodeName))
         .map {
           case Left(EvictLocationsInNodeFailed(_)) => RemoveNodeMetadataFailed(nodeName)
@@ -575,8 +576,9 @@ object MetadataCoordinator {
 
     case class MetricInfosMigrated(infos: Seq[MetricInfo]) extends NSDbSerializable
 
-    case class NodeMetadataRemoved(nodeName: String)      extends NSDbSerializable
-    case class RemoveNodeMetadataFailed(nodeName: String) extends NSDbSerializable
+    trait RemoveNodeMetadataResponse                      extends NSDbSerializable
+    case class NodeMetadataRemoved(nodeName: String)      extends RemoveNodeMetadataResponse
+    case class RemoveNodeMetadataFailed(nodeName: String) extends RemoveNodeMetadataResponse
   }
 
   def props(clusterListener: ActorRef,

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -381,6 +381,14 @@ class MetadataCoordinator(clusterListener: ActorRef,
         log.info(s"subscribed commit log actor for node $nodeName")
       }
       sender() ! CommitLogCoordinatorSubscribed(actor, nodeName)
+
+    case UnsubscribeMetricsDataActor(nodeName) =>
+      metricsDataActors -= nodeName
+      log.info(s"metric data actor removed for node $nodeName")
+    case UnSubscribeCommitLogCoordinator(nodeName) =>
+      commitLogCoordinators -= nodeName
+      log.info(s"unsubscribed commit log actor for node $nodeName")
+
     case GetDbs =>
       (metadataCache ? GetDbsFromCache)
         .mapTo[DbsFromCacheGot]

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -385,10 +385,11 @@ class MetadataCoordinator(clusterListener: ActorRef,
     case UnsubscribeMetricsDataActor(nodeName) =>
       metricsDataActors -= nodeName
       log.info(s"metric data actor removed for node $nodeName")
+      sender() ! MetricsDataActorUnSubscribed(nodeName)
     case UnSubscribeCommitLogCoordinator(nodeName) =>
       commitLogCoordinators -= nodeName
       log.info(s"unsubscribed commit log actor for node $nodeName")
-
+      sender() ! CommitLogCoordinatorUnSubscribed(nodeName)
     case GetDbs =>
       (metadataCache ? GetDbsFromCache)
         .mapTo[DbsFromCacheGot]

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -151,10 +151,11 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
         metricsDataActors += (nodeName -> actor)
         log.info(s"subscribed data actor for node $nodeName")
       }
-      sender() ! MetricsDataActorSubscribed(actor, nodeName)
+      sender ! MetricsDataActorSubscribed(actor, nodeName)
     case UnsubscribeMetricsDataActor(nodeName) =>
       metricsDataActors -= nodeName
       log.info(s"metric data actor removed for node $nodeName")
+      sender ! MetricsDataActorUnSubscribed(nodeName)
     case GetConnectedDataNodes =>
       sender ! ConnectedDataNodesGot(metricsDataActors.keys.toSeq)
     case GetDbs =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -152,6 +152,9 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
         log.info(s"subscribed data actor for node $nodeName")
       }
       sender() ! MetricsDataActorSubscribed(actor, nodeName)
+    case UnsubscribeMetricsDataActor(nodeName) =>
+      metricsDataActors -= nodeName
+      log.info(s"metric data actor removed for node $nodeName")
     case GetConnectedDataNodes =>
       sender ! ConnectedDataNodesGot(metricsDataActors.keys.toSeq)
     case GetDbs =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
@@ -432,13 +432,18 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
       }
       sender() ! PublisherSubscribed(actor, nodeName)
 
+    case UnsubscribeMetricsDataActor(nodeName) =>
+      metricsDataActors -= nodeName
+      log.info(s"unsubscribed data actor for node $nodeName")
+      sender() ! MetricsDataActorUnSubscribed(nodeName)
     case UnSubscribeCommitLogCoordinator(nodeName) =>
       commitLogCoordinators -= nodeName
       log.info(s"unsubscribed commit log actor for node $nodeName")
+      sender() ! CommitLogCoordinatorUnSubscribed(nodeName)
     case UnSubscribePublisher(nodeName) =>
       publishers -= nodeName
       log.info(s"unsubscribed publisher actor for node $nodeName")
-
+      sender() ! PublisherUnSubscribed(nodeName)
     case GetConnectedDataNodes =>
       sender ! ConnectedDataNodesGot(metricsDataActors.keys.toSeq)
     case MapInput(_, db, namespace, metric, _) if ackPendingMetrics.contains(AckPendingMetric(db, namespace, metric)) =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
@@ -431,6 +431,14 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
         log.info(s"subscribed publisher actor for node $nodeName")
       }
       sender() ! PublisherSubscribed(actor, nodeName)
+
+    case UnSubscribeCommitLogCoordinator(nodeName) =>
+      commitLogCoordinators -= nodeName
+      log.info(s"unsubscribed commit log actor for node $nodeName")
+    case UnSubscribePublisher(nodeName) =>
+      publishers -= nodeName
+      log.info(s"unsubscribed publisher actor for node $nodeName")
+
     case GetConnectedDataNodes =>
       sender ! ConnectedDataNodesGot(metricsDataActors.keys.toSeq)
     case MapInput(_, db, namespace, metric, _) if ackPendingMetrics.contains(AckPendingMetric(db, namespace, metric)) =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -200,6 +200,10 @@ object MessageProtocol {
     case class MetricsDataActorSubscribed(actor: ActorRef, nodeName: String)     extends NSDbSerializable
     case class PublisherSubscribed(actor: ActorRef, nodeName: String)            extends NSDbSerializable
 
+    case class CommitLogCoordinatorUnSubscribed(nodeName: String) extends NSDbSerializable
+    case class MetricsDataActorUnSubscribed(nodeName: String)     extends NSDbSerializable
+    case class PublisherUnSubscribed(nodeName: String)            extends NSDbSerializable
+
     case class ConnectedDataNodesGot(nodes: Seq[String]) extends NSDbSerializable
 
     case class MigrationStarted(inputPath: String) extends NSDbSerializable

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -88,8 +88,11 @@ object MessageProtocol {
         extends NSDbSerializable
 
     case class SubscribeMetricsDataActor(actor: ActorRef, nodeName: String)     extends NSDbSerializable
+    case class UnsubscribeMetricsDataActor(nodeName: String)                    extends NSDbSerializable
     case class SubscribeCommitLogCoordinator(actor: ActorRef, nodeName: String) extends NSDbSerializable
+    case class UnSubscribeCommitLogCoordinator(nodeName: String)                extends NSDbSerializable
     case class SubscribePublisher(actor: ActorRef, nodeName: String)            extends NSDbSerializable
+    case class UnSubscribePublisher(nodeName: String)                           extends NSDbSerializable
 
     case object GetConnectedDataNodes extends NSDbSerializable
 


### PR DESCRIPTION
This PR Improves the coordinators unsubscription mechanism making it explicit the removal command in the `Unreacheable` callback of the `ClusterListener` 