### PR TITLE
insert in conf write consistency: all or majority

### DIFF
--- a/nsdb-cluster/src/main/resources/nsdb.conf
+++ b/nsdb-cluster/src/main/resources/nsdb.conf
@@ -71,8 +71,8 @@ nsdb {
     mode = ${?CLUSTER_MODE}
     required-contact-point-nr = 1
     required-contact-point-nr = ${?CONTACT_POINT_NR}
-    write-consistency = "all"
-    write-consistency = ${?WRITE_CONSISTENCY}
+    metadata-write-consistency = "all"
+    metadata-write-consistency = ${?METADATA_WRITE_CONSISTENCY}
     endpoints = [
       {
         host = ${nsdb.node.hostname}

--- a/nsdb-cluster/src/main/resources/nsdb.conf
+++ b/nsdb-cluster/src/main/resources/nsdb.conf
@@ -55,7 +55,7 @@ nsdb {
     passivate-after = ${?PASSIVATION_PERIOD}
   }
 
-  cluster{
+  cluster {
     replication-factor = 2
     replication-factor = ${?REPLICATION_FACTOR}
     consistency-level = 1
@@ -71,6 +71,8 @@ nsdb {
     mode = ${?CLUSTER_MODE}
     required-contact-point-nr = 1
     required-contact-point-nr = ${?CONTACT_POINT_NR}
+    write-consistency = "all"
+    write-consistency = ${?WRITE_CONSISTENCY}
     endpoints = [
       {
         host = ${nsdb.node.hostname}

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
@@ -23,6 +23,7 @@ import akka.cluster.ddata._
 import akka.dispatch.ControlMessage
 import akka.pattern.{ask, pipe}
 import akka.util.Timeout
+import io.radicalbit.nsdb.cluster.logic.WriteConsistencyLogic
 import io.radicalbit.nsdb.cluster.util.ErrorManagementUtils
 import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.{Coordinates, NSDbSerializable}
@@ -138,6 +139,8 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
 
   val replicator: ActorRef = DistributedData(context.system).replicator
 
+  private val config = context.system.settings.config
+
   implicit val address: SelfUniqueAddress = DistributedData(context.system).selfUniqueAddress
 
   /**
@@ -184,9 +187,12 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
     TimeUnit.SECONDS)
   import context.dispatcher
 
+  private val writeConsistency: WriteConsistency =
+    WriteConsistencyLogic.fromConfigValue(config.getString("nsdb.cluster.write-consistency"))(writeDuration)
+
   def receive: Receive = {
     case PutCoordinateInCache(db, namespace, metric) =>
-      (replicator ? Update(coordinatesKey, ORSet(), WriteAll(writeDuration))(_ :+ Coordinates(db, namespace, metric)))
+      (replicator ? Update(coordinatesKey, ORSet(), writeConsistency)(_ :+ Coordinates(db, namespace, metric)))
         .map {
           case UpdateSuccess(_, _) =>
             CoordinateCached(db, namespace, metric)
@@ -197,7 +203,7 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
     case PutLocationInCache(db, namespace, metric, location) =>
       val metricKey = MetricLocationsCacheKey(db, namespace, metric)
       (for {
-        loc <- (replicator ? Update(metricLocationsKey(metricKey), ORSet(), WriteAll(writeDuration))(_ :+ location))
+        loc <- (replicator ? Update(metricLocationsKey(metricKey), ORSet(), writeConsistency)(_ :+ location))
           .map {
             case UpdateSuccess(_, _) =>
               LocationCached(db, namespace, metric, location)
@@ -205,10 +211,9 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
               log.error(s"error in put location in cache $e")
               PutLocationInCacheFailed(db, namespace, metric, location)
           }
-        _ <- replicator ? Update(nodeLocationsKey(location.node), ORSet(), WriteAll(writeDuration))(
+        _ <- replicator ? Update(nodeLocationsKey(location.node), ORSet(), writeConsistency)(
           _ :+ LocationWithCoordinates(db, namespace, location))
-        _ <- replicator ? Update(coordinatesKey, ORSet(), WriteAll(writeDuration))(
-          _ :+ Coordinates(db, namespace, metric))
+        _ <- replicator ? Update(coordinatesKey, ORSet(), writeConsistency)(_ :+ Coordinates(db, namespace, metric))
       } yield loc).pipeTo(sender())
     case PutMetricInfoInCache(metricInfo @ MetricInfo(db, namespace, metric, _, _)) =>
       val key = MetricInfoCacheKey(db, namespace, metric)
@@ -222,9 +227,8 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
                 Future(MetricInfoAlreadyExisting(key, metricInfo))
               case None =>
                 (for {
-                  _ <- replicator ? Update(allMetricInfoKey, ORSet(), WriteAll(writeDuration))(_ :+ metricInfo)
-                  res <- replicator ? Update(metricInfoKey(key), LWWMap(), WriteAll(writeDuration))(
-                    _ :+ (key -> metricInfo))
+                  _   <- replicator ? Update(allMetricInfoKey, ORSet(), writeConsistency)(_ :+ metricInfo)
+                  res <- replicator ? Update(metricInfoKey(key), LWWMap(), writeConsistency)(_ :+ (key -> metricInfo))
                 } yield res)
                   .map {
                     case UpdateSuccess(_, _) =>
@@ -234,9 +238,8 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
             }
           case NotFound(_, _) =>
             (for {
-              _ <- replicator ? Update(allMetricInfoKey, ORSet(), WriteAll(writeDuration))(_ :+ metricInfo)
-              res <- replicator ? Update(metricInfoKey(key), LWWMap(), WriteAll(writeDuration))(
-                _ :+ (key -> metricInfo))
+              _   <- replicator ? Update(allMetricInfoKey, ORSet(), writeConsistency)(_ :+ metricInfo)
+              res <- replicator ? Update(metricInfoKey(key), LWWMap(), writeConsistency)(_ :+ (key -> metricInfo))
             } yield res)
               .map {
                 case UpdateSuccess(_, _) =>
@@ -249,8 +252,8 @@ class ReplicatedMetadataCache extends Actor with ActorLogging {
     case EvictLocation(db, namespace, loc @ Location(metric, node, from, to)) =>
       val metricKey = MetricLocationsCacheKey(db, namespace, metric)
       val f = for {
-        remove <- replicator ? Update(metricLocationsKey(metricKey), ORSet(), WriteAll(writeDuration))(_ remove loc)
-        _ <- replicator ? Update(nodeLocationsKey(node), ORSet(), WriteAll(writeDuration))(
+        remove <- replicator ? Update(metricLocationsKey(metricKey), ORSet(), writeConsistency)(_ remove loc)
+        _ <- replicator ? Update(nodeLocationsKey(node), ORSet(), writeConsistency)(
           _ remove LocationWithCoordinates(db, namespace, loc))
       } yield remove
       f.map {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/WriteConsistencyLogic.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/WriteConsistencyLogic.scala
@@ -16,9 +16,20 @@
 
 package io.radicalbit.nsdb.cluster.logic
 
+import akka.actor.Actor
 import akka.cluster.ddata.Replicator.{WriteAll, WriteConsistency, WriteMajority}
 
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+
+trait WriteConsistencyLogic { this: Actor =>
+  private val config = context.system.settings.config
+
+  private val writeDuration = 5.seconds
+
+  protected val writeConsistency: WriteConsistency =
+    WriteConsistencyLogic.fromConfigValue(config.getString("nsdb.cluster.write-consistency"))(writeDuration)
+}
 
 object WriteConsistencyLogic {
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/WriteConsistencyLogic.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/WriteConsistencyLogic.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.logic
+
+import akka.cluster.ddata.Replicator.{WriteAll, WriteConsistency, WriteMajority}
+
+import scala.concurrent.duration.FiniteDuration
+
+object WriteConsistencyLogic {
+
+  /**
+    * Provides a Write Consistency policy from a config value.
+    * @param configValue the config value provided in the NSDb configuration file
+    * @param timeout writing timeout
+    * @throws IllegalArgumentException the configuration is not among the allowed values.
+    */
+  @throws[IllegalArgumentException]
+  def fromConfigValue(configValue: String)(timeout: FiniteDuration): WriteConsistency = {
+    configValue match {
+      case "all"      => WriteAll(timeout)
+      case "majority" => WriteMajority(timeout)
+      case wrongConfigValue =>
+        throw new IllegalArgumentException(s"$wrongConfigValue is not a valid value for write-consistency")
+    }
+  }
+}

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -46,6 +46,7 @@ object MetadataSpec extends MultiNodeConfig {
     |    port = 7817
     |  }
     |
+    |  global.timeout = 30 seconds
     |  read-coordinator.timeout = 10 seconds
     |  namespace-schema.timeout = 10 seconds
     |  namespace-data.timeout = 10 seconds
@@ -54,6 +55,8 @@ object MetadataSpec extends MultiNodeConfig {
     |  publisher.scheduler.interval = 5 seconds
     |  write.scheduler.interval = 15 seconds
     |  retention.check.interval = 1 seconds
+    |
+    |  cluster.metadata-write-consistency = "all"
     |
     |  sharding {
     |    interval = 1d

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -21,7 +21,7 @@ object ReplicatedMetadataCacheSpec extends MultiNodeConfig {
 
   commonConfig(ConfigFactory.parseString("""
     |akka.loglevel = ERROR
-    |akka.actor{
+    |akka.actor {
     | provider = "cluster"
     |
     | serialization-bindings {
@@ -33,14 +33,17 @@ object ReplicatedMetadataCacheSpec extends MultiNodeConfig {
     |   }
     |}
     |akka.log-dead-letters-during-shutdown = off
-    |nsdb{
+    |nsdb {
     |
+    |  global.timeout = 30 seconds
     |  read-coordinator.timeout = 10 seconds
     |  namespace-schema.timeout = 10 seconds
     |  namespace-data.timeout = 10 seconds
     |  publisher.timeout = 10 seconds
     |  publisher.scheduler.interval = 5 seconds
     |  write.scheduler.interval = 15 seconds
+    |
+    |  cluster.metadata-write-consistency = "all"
     |
     |  write-coordinator.timeout = 5 seconds
     |  metadata-coordinator.timeout = 5 seconds

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCacheSpec.scala
@@ -26,7 +26,7 @@ object ReplicatedSchemaCacheSpec extends MultiNodeConfig {
 
   commonConfig(ConfigFactory.parseString("""
     |akka.loglevel = INFO
-    |akka.actor{
+    |akka.actor {
     |
     | serialization-bindings {
     |   "io.radicalbit.nsdb.common.protocol.NSDbSerializable" = jackson-json
@@ -38,14 +38,17 @@ object ReplicatedSchemaCacheSpec extends MultiNodeConfig {
     |   }
     |}
     |akka.log-dead-letters-during-shutdown = off
-    |nsdb{
+    |nsdb {
     |
+    |  global.timeout = 30 seconds
     |  read-coordinator.timeout = 10 seconds
     |  namespace-schema.timeout = 10 seconds
     |  namespace-data.timeout = 10 seconds
     |  publisher.timeout = 10 seconds
     |  publisher.scheduler.interval = 5 seconds
     |  write.scheduler.interval = 15 seconds
+    |
+    |  cluster.metadata-write-consistency = "all"
     |
     |  write-coordinator.timeout = 5 seconds
     |  metadata-coordinator.timeout = 5 seconds

--- a/nsdb-it/src/main/resources/nsdb-minicluster.conf
+++ b/nsdb-it/src/main/resources/nsdb-minicluster.conf
@@ -52,11 +52,12 @@ nsdb {
     passivate-after = 1h
   }
 
-  cluster{
+  cluster {
     replication-factor = 2
     consistency-level = 1
     mode = native
     required-contact-point-nr = 3
+    metadata-write-consistency = "all"
     endpoints = [
       {
         host = "127.0.0.1"


### PR DESCRIPTION
In this PR we give the possibility to choose the write consistency of nsdb cluster: all or majority.

In few words, write all consistency means that when you request to write a Bit, the data will be replicated among all nodes, while majority write the data will be reploicated among n(nodes) / 2 +1