### PR TITLE
Improve Parser Error Messages

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -236,7 +236,7 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
                 }.map(limitAndOrder(_, statement, schema))
 
               case Right(ParsedAggregatedQuery(_, _, _, agg @ InternalCountSimpleAggregation(_, _), _, _)) =>
-                gatherAndGroupNodeResults(statement, statement.groupBy.get.dimension, schema, uniqueLocationsByNode) {
+                gatherAndGroupNodeResults(statement, statement.groupBy.get.field, schema, uniqueLocationsByNode) {
                   values =>
                     Bit(0,
                         NSDbNumericType(values.map(_.value.rawValue.asInstanceOf[Long]).sum),
@@ -245,9 +245,9 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
                 }.map(limitAndOrder(_, statement, schema, Some(agg)))
 
               case Right(ParsedAggregatedQuery(_, _, _, aggregationType, _, _)) =>
-                gatherAndGroupNodeResults(statement, statement.groupBy.get.dimension, schema, uniqueLocationsByNode) {
+                gatherAndGroupNodeResults(statement, statement.groupBy.get.field, schema, uniqueLocationsByNode) {
                   values =>
-                    val v                = schema.fieldsMap("value").indexType.asInstanceOf[NumericType[_]]
+                    val v                = schema.value.indexType.asInstanceOf[NumericType[_]]
                     implicit val numeric = v.numeric
                     aggregationType match {
                       case InternalMaxSimpleAggregation(_, _) =>
@@ -325,7 +325,7 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
                                                                         condition)
 
                 gatherNodeResults(statement, schema, uniqueLocationsByNode, globalRanges) { res =>
-                  val v                              = schema.fieldsMap("value").indexType.asInstanceOf[NumericType[_]]
+                  val v                              = schema.value.indexType.asInstanceOf[NumericType[_]]
                   implicit val numeric: Numeric[Any] = v.numeric
                   applyOrderingWithLimit(
                     res
@@ -361,7 +361,7 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
                                                                         condition)
 
                 gatherNodeResults(statement, schema, uniqueLocationsByNode, globalRanges) { res =>
-                  val v                              = schema.fieldsMap("value").indexType.asInstanceOf[NumericType[_]]
+                  val v                              = schema.value.indexType.asInstanceOf[NumericType[_]]
                   implicit val numeric: Numeric[Any] = v.numeric
                   applyOrderingWithLimit(
                     res

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -229,14 +229,14 @@ final case class RelativeComparisonValue[T](override val value: T, operator: Str
     new JsonSubTypes.Type(value = classOf[TemporalGroupByAggregation], name = "TemporalGroupByAggregation")
   ))
 sealed trait GroupByAggregation {
-  def dimension: String
+  def field: String
 }
 
 /**
   * Class that represent a simple Group By clause.
-  * @param dimension the dimension to apply the aggregation to
+  * @param field (tag) the field to apply the aggregation to
   */
-final case class SimpleGroupByAggregation(dimension: String) extends GroupByAggregation
+final case class SimpleGroupByAggregation(field: String) extends GroupByAggregation
 
 /**
   * Temporal aggregation.
@@ -246,7 +246,7 @@ final case class SimpleGroupByAggregation(dimension: String) extends GroupByAggr
   */
 final case class TemporalGroupByAggregation(interval: Long, quantity: Long, unitMeasure: String)
     extends GroupByAggregation {
-  override val dimension: String = "timestamp"
+  override val field: String = "timestamp"
 }
 
 /**

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
@@ -214,13 +214,13 @@ class MetricAccumulatorActor(val basePath: String,
       sender ! RecordDeleted(db, ns, key.metric, bit)
     case ExecuteDeleteStatementInShards(statement, schema, keys) =>
       StatementParser.parseStatement(statement, schema) match {
-        case Success(ParsedDeleteQuery(ns, metric, q)) =>
+        case Right(ParsedDeleteQuery(ns, metric, q)) =>
           keys.foreach { key =>
             opBufferMap += (UUID.randomUUID().toString -> DeleteShardQueryOperation(ns, key, statement, schema))
           }
           sender() ! DeleteStatementExecuted(db, namespace, metric)
-        case Failure(ex) =>
-          sender() ! DeleteStatementFailed(db = db, namespace = namespace, metric = statement.metric, ex.getMessage)
+        case Left(errorMessage) =>
+          sender() ! DeleteStatementFailed(db = db, namespace = namespace, metric = statement.metric, errorMessage)
       }
     case msg @ Refresh(writeIds, keys) =>
       garbageCollectIndexes()

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
@@ -296,7 +296,7 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
             actorsForLocations(locations)
 
           val shardResults =
-            gatherAndGroupShardResults(statement, filteredIndexes, statement.groupBy.get.dimension, msg) { values =>
+            gatherAndGroupShardResults(statement, filteredIndexes, statement.groupBy.get.field, msg) { values =>
               Bit(0,
                   NSDbNumericType(values.map(_.value.rawValue.asInstanceOf[Long]).sum),
                   values.head.dimensions,
@@ -309,8 +309,8 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
             actorsForLocations(locations)
 
           val rawResult =
-            gatherAndGroupShardResults(statement, filteredIndexes, statement.groupBy.get.dimension, msg) { values =>
-              val v                              = schema.fieldsMap("value").indexType.asInstanceOf[NumericType[_]]
+            gatherAndGroupShardResults(statement, filteredIndexes, statement.groupBy.get.field, msg) { values =>
+              val v                              = schema.value.indexType.asInstanceOf[NumericType[_]]
               implicit val numeric: Numeric[Any] = v.numeric
               aggregationType match {
                 case InternalMaxSimpleAggregation(_, _) =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -86,15 +86,8 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
               facetIndexes.facetCountIndex
                 .result(q, groupField, sort, limit, schema.fieldsMap(groupField).indexType)))
         case Right(ParsedAggregatedQuery(_, _, q, InternalSumSimpleAggregation(groupField, _), sort, limit)) =>
-          handleNoIndexResults(
-            Try(
-              facetIndexes.facetSumIndex
-                .result(q,
-                        groupField,
-                        sort,
-                        limit,
-                        schema.fieldsMap(groupField).indexType,
-                        Some(schema.fieldsMap("value").indexType))))
+          handleNoIndexResults(Try(facetIndexes.facetSumIndex
+            .result(q, groupField, sort, limit, schema.fieldsMap(groupField).indexType, Some(schema.value.indexType))))
         case Right(ParsedAggregatedQuery(_, _, q, InternalFirstSimpleAggregation(groupField, _), _, _)) =>
           handleNoIndexResults(Try(index.getFirstGroupBy(q, schema, groupField)))
         case Right(ParsedAggregatedQuery(_, _, q, InternalLastSimpleAggregation(groupField, _), _, _)) =>
@@ -124,7 +117,7 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
                     }
                 }))
         case Right(ParsedTemporalAggregatedQuery(_, _, q, _, InternalSumTemporalAggregation, _, _, _)) =>
-          val valueFieldType: IndexType[_] = schema.fieldsMap("value").indexType
+          val valueFieldType: IndexType[_] = schema.value.indexType
           handleNoIndexResults(
             Try(
               facetIndexes.facetRangeIndex
@@ -151,7 +144,7 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
                     }
                 }))
         case Right(ParsedTemporalAggregatedQuery(_, _, q, _, aggregationType, _, _, _)) =>
-          val valueFieldType: IndexType[_] = schema.fieldsMap("value").indexType
+          val valueFieldType: IndexType[_] = schema.value.indexType
           handleNoIndexResults(
             Try(
               facetIndexes.facetRangeIndex

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
@@ -16,9 +16,8 @@
 
 package io.radicalbit.nsdb.model
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import io.radicalbit.nsdb.common.NSDbType
-import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType, FieldClassType, NSDbSerializable, TagFieldType}
+import io.radicalbit.nsdb.common.protocol._
 import io.radicalbit.nsdb.index.{IndexType, TypeSupport}
 
 import scala.util.{Failure, Success, Try}
@@ -58,13 +57,11 @@ case class Schema private (metric: String, fieldsMap: Map[String, SchemaField]) 
   /**
     * filters tags from fieldsMap
     */
-  @JsonIgnore
   lazy val tags: Map[String, SchemaField] = fieldsMap.filter { case (_, field) => field.fieldClassType == TagFieldType }
 
   /**
     * filters tags from fieldsMap
     */
-  @JsonIgnore
   lazy val dimensions: Map[String, SchemaField] = fieldsMap.filter {
     case (_, field) => field.fieldClassType == DimensionFieldType
   }
@@ -72,8 +69,8 @@ case class Schema private (metric: String, fieldsMap: Map[String, SchemaField]) 
   /**
     * extract value from fieldsMap
     */
-  @JsonIgnore
-  lazy val value: SchemaField = fieldsMap("value")
+  lazy val value: SchemaField =
+    fieldsMap("value")
 
   override def equals(obj: scala.Any): Boolean = {
     if (obj != null && obj.isInstanceOf[Schema]) {

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
@@ -16,8 +16,9 @@
 
 package io.radicalbit.nsdb.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.radicalbit.nsdb.common.NSDbType
-import io.radicalbit.nsdb.common.protocol.{Bit, FieldClassType, NSDbSerializable}
+import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType, FieldClassType, NSDbSerializable, TagFieldType}
 import io.radicalbit.nsdb.index.{IndexType, TypeSupport}
 
 import scala.util.{Failure, Success, Try}
@@ -53,6 +54,27 @@ case class SchemaField(name: String, fieldClassType: FieldClassType, indexType: 
   * @param fieldsMap a map of [[SchemaField]] keyed by field name
   */
 case class Schema private (metric: String, fieldsMap: Map[String, SchemaField]) extends NSDbSerializable {
+
+  /**
+    * filters tags from fieldsMap
+    */
+  @JsonIgnore
+  lazy val tags: Map[String, SchemaField] = fieldsMap.filter { case (_, field) => field.fieldClassType == TagFieldType }
+
+  /**
+    * filters tags from fieldsMap
+    */
+  @JsonIgnore
+  lazy val dimensions: Map[String, SchemaField] = fieldsMap.filter {
+    case (_, field) => field.fieldClassType == DimensionFieldType
+  }
+
+  /**
+    * extract value from fieldsMap
+    */
+  @JsonIgnore
+  lazy val value: SchemaField = fieldsMap("value")
+
   override def equals(obj: scala.Any): Boolean = {
     if (obj != null && obj.isInstanceOf[Schema]) {
       val otherSchema = obj.asInstanceOf[Schema]

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
@@ -17,7 +17,6 @@
 package io.radicalbit.nsdb.model
 
 import io.radicalbit.nsdb.common.NSDbType
-import io.radicalbit.nsdb.common.protocol.{Bit, FieldClassType}
 import io.radicalbit.nsdb.common.protocol.{Bit, FieldClassType, NSDbSerializable}
 import io.radicalbit.nsdb.index.{IndexType, TypeSupport}
 
@@ -53,7 +52,7 @@ case class SchemaField(name: String, fieldClassType: FieldClassType, indexType: 
   * @param metric the metric.
   * @param fieldsMap a map of [[SchemaField]] keyed by field name
   */
-case class Schema(metric: String, fieldsMap: Map[String, SchemaField]) extends NSDbSerializable {
+case class Schema private (metric: String, fieldsMap: Map[String, SchemaField]) extends NSDbSerializable {
   override def equals(obj: scala.Any): Boolean = {
     if (obj != null && obj.isInstanceOf[Schema]) {
       val otherSchema = obj.asInstanceOf[Schema]

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
@@ -16,13 +16,10 @@
 
 package io.radicalbit.nsdb.statement
 
-import io.radicalbit.nsdb.common.exception.InvalidStatementException
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.index._
 import io.radicalbit.nsdb.model.{Schema, SchemaField}
 import org.apache.lucene.search._
-
-import scala.util.{Failure, Success, Try}
 
 /**
   * This class exposes method for parsing from a [[io.radicalbit.nsdb.common.statement.SQLStatement]] into a [[io.radicalbit.nsdb.statement.StatementParser.ParsedQuery]].
@@ -36,7 +33,7 @@ object StatementParser {
     * @param schema    metric'groupFieldType schema.
     * @return a Try of [[ParsedQuery]] to handle errors.
     */
-  def parseStatement(statement: DeleteSQLStatement, schema: Schema): Try[ParsedQuery] = {
+  def parseStatement(statement: DeleteSQLStatement, schema: Schema): Either[String, ParsedQuery] = {
     val expParsed = ExpressionParser.parseExpression(Some(statement.condition.expression), schema.fieldsMap)
     expParsed.map(exp => ParsedDeleteQuery(statement.namespace, statement.metric, exp.q))
   }
@@ -85,16 +82,16 @@ object StatementParser {
     })
 
     val expParsed = ExpressionParser.parseExpression(statement.condition.map(_.expression), schema.fieldsMap)
-    val fieldList = statement.fields match {
-      case AllFields() => Success(List.empty)
+    val fieldList: Either[String, List[Field]] = statement.fields match {
+      case AllFields() => Right(List.empty)
       case ListFields(list) =>
         val metricDimensions     = schema.fieldsMap.values.map(_.name).toSeq
         val projectionDimensions = list.map(_.name).filterNot(_ == "*")
         val diff                 = projectionDimensions.filterNot(metricDimensions.contains)
         if (diff.isEmpty)
-          Success(list)
+          Right(list)
         else
-          Failure(new InvalidStatementException(StatementParserErrors.notExistingDimensions(diff)))
+          Left(StatementParserErrors.notExistingDimensions(diff))
     }
 
     val distinctValue = statement.distinct
@@ -102,16 +99,16 @@ object StatementParser {
     val limitOpt = statement.limit.map(_.value)
 
     expParsed match {
-      case Success(exp) =>
+      case Right(exp) =>
         (distinctValue, fieldList, statement.groupBy) match {
-          case (_, Failure(exception), _) => Left(exception.getMessage)
+          case (_, Left(errorMessage), _) => Left(errorMessage)
           // Trying to order by a dimension not in group by clause
-          case (false, Success(Seq(Field(_, Some(_)))), Some(group))
+          case (false, Right(Seq(Field(_, Some(_)))), Some(group))
               if sortOpt.isDefined && !Seq("value", group.field).contains(sortOpt.get.getSort.head.getField) =>
             Left(StatementParserErrors.SORT_DIMENSION_NOT_IN_GROUP)
           // Match temporal count aggregation
           case (false,
-                Success(Seq(Field(fieldName, Some(aggregation)))),
+                Right(Seq(Field(fieldName, Some(aggregation)))),
                 Some(TemporalGroupByAggregation(interval, _, _))) if fieldName == "value" || fieldName == "*" =>
             Right(
               ParsedTemporalAggregatedQuery(
@@ -125,7 +122,7 @@ object StatementParser {
                 limitOpt
               )
             )
-          case (false, Success(Seq(Field(fieldName, Some(agg)))), Some(group: SimpleGroupByAggregation))
+          case (false, Right(Seq(Field(fieldName, Some(agg)))), Some(group: SimpleGroupByAggregation))
               if schema.tags.get(group.field).isDefined && (fieldName == "value" || fieldName == "*") =>
             Right(
               ParsedAggregatedQuery(
@@ -136,25 +133,25 @@ object StatementParser {
                 sortOpt,
                 limitOpt
               ))
-          case (false, Success(Seq(Field(fieldName, Some(_)))), Some(_: SimpleGroupByAggregation))
+          case (false, Right(Seq(Field(fieldName, Some(_)))), Some(_: SimpleGroupByAggregation))
               if fieldName == "value" || fieldName == "*" =>
             Left(StatementParserErrors.SIMPLE_AGGREGATION_NOT_ON_TAG)
-          case (false, Success(Seq(Field(_, Some(_)))), Some(group)) if schema.tags.get(group.field).isDefined =>
+          case (false, Right(Seq(Field(_, Some(_)))), Some(group)) if schema.tags.get(group.field).isDefined =>
             Left(StatementParserErrors.AGGREGATION_NOT_ON_VALUE)
-          case (false, Success(Seq(Field(_, Some(_)))), Some(group)) =>
+          case (false, Right(Seq(Field(_, Some(_)))), Some(group)) =>
             Left(StatementParserErrors.notExistingDimension(group.field))
-          case (_, Success(List(Field(_, None))), Some(_)) =>
+          case (_, Right(List(Field(_, None))), Some(_)) =>
             Left(StatementParserErrors.NO_AGGREGATION_GROUP_BY)
-          case (_, Success(Nil), Some(_)) =>
+          case (_, Right(Nil), Some(_)) =>
             Left(StatementParserErrors.NO_AGGREGATION_GROUP_BY)
-          case (_, Success(List(_)), Some(_)) =>
+          case (_, Right(List(_)), Some(_)) =>
             Left(StatementParserErrors.MORE_FIELDS_GROUP_BY)
-          case (true, Success(List()), None) =>
+          case (true, Right(List()), None) =>
             Left(StatementParserErrors.MORE_FIELDS_DISTINCT)
           //TODO: Not supported yet
-          case (true, Success(fieldsSeq), None) if fieldsSeq.lengthCompare(1) > 0 =>
+          case (true, Right(fieldsSeq), None) if fieldsSeq.lengthCompare(1) > 0 =>
             Left(StatementParserErrors.MORE_FIELDS_DISTINCT)
-          case (false, Success(Seq(Field(name, Some(CountAggregation)))), None) =>
+          case (false, Right(Seq(Field(name, Some(CountAggregation)))), None) =>
             Right(
               ParsedSimpleQuery(
                 statement.namespace,
@@ -166,7 +163,7 @@ object StatementParser {
                 sortOpt
               )
             )
-          case (distinct, Success(fieldsSeq), None)
+          case (distinct, Right(fieldsSeq), None)
               if !fieldsSeq.exists(f => f.aggregation.isDefined && f.aggregation.get != CountAggregation) =>
             Right(
               ParsedSimpleQuery(
@@ -178,7 +175,7 @@ object StatementParser {
                 fieldsSeq.map(f => SimpleField(f.name, f.aggregation.isDefined)),
                 sortOpt
               ))
-          case (false, Success(List()), None) =>
+          case (false, Right(List()), None) =>
             Right(
               ParsedSimpleQuery(statement.namespace,
                                 statement.metric,
@@ -188,11 +185,11 @@ object StatementParser {
                                 List(),
                                 sortOpt))
 
-          case (_, Success(fieldsSeq), None)
+          case (_, Right(fieldsSeq), None)
               if fieldsSeq.exists(f => f.aggregation.isDefined && !(f.aggregation.get == CountAggregation)) =>
             Left(StatementParserErrors.NO_GROUP_BY_AGGREGATION)
         }
-      case Failure(ex) => Left(ex.getMessage)
+      case Left(errorMessage) => Left(errorMessage)
     }
   }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParserErrors.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParserErrors.scala
@@ -23,8 +23,10 @@ object StatementParserErrors {
   lazy val MORE_FIELDS_DISTINCT    = "cannot execute a select distinct projecting more than one dimension"
   lazy val NO_GROUP_BY_AGGREGATION =
     "cannot execute a query with aggregation different than count without a groupField by"
+  lazy val SIMPLE_AGGREGATION_NOT_ON_TAG =
+    "cannot execute a groupBy query grouping by a field that is not a tag"
   lazy val AGGREGATION_NOT_ON_VALUE =
-    "cannot execute a groupField by query performing an aggregation on dimension different from value"
+    "cannot execute a groupBy query performing an aggregation on dimension different from value"
   lazy val SORT_DIMENSION_NOT_IN_GROUP =
     "cannot sort groupField by query result by a dimension not in groupField"
   def notExistingDimension(dim: String)       = s"dimension $dim does not exist"

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParserErrors.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParserErrors.scala
@@ -20,9 +20,9 @@ object StatementParserErrors {
 
   lazy val NO_AGGREGATION_GROUP_BY = "cannot execute a groupField by query without an aggregation"
   lazy val MORE_FIELDS_GROUP_BY    = "cannot execute a groupField by query with more than a aggregateField"
-  lazy val MORE_FIELDS_DISTINCT    = "cannot execute a select distinct projecting more than one dimension"
+  lazy val MORE_FIELDS_DISTINCT    = "cannot execute a select distinct projecting more than one field"
   lazy val NO_GROUP_BY_AGGREGATION =
-    "cannot execute a query with aggregation different than count without a groupField by"
+    "cannot execute a query with aggregation different than count without a groupBy field"
   lazy val SIMPLE_AGGREGATION_NOT_ON_TAG =
     "cannot execute a groupBy query grouping by a field that is not a tag"
   lazy val AGGREGATION_NOT_ON_VALUE =
@@ -30,7 +30,7 @@ object StatementParserErrors {
   lazy val SORT_DIMENSION_NOT_IN_GROUP =
     "cannot sort groupField by query result by a dimension not in groupField"
   def notExistingDimension(dim: String)       = s"dimension $dim does not exist"
-  def notExistingDimensions(dim: Seq[String]) = s"dimensions [$dim] does not exist"
+  def notExistingDimensions(dim: Seq[String]) = s"dimensions [${dim.mkString(",")}] does not exist"
   def uncompatibleOperator(operator: String, dimTypeAllowed: String) =
     s"cannot use $operator operator on dimension different from $dimTypeAllowed"
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -20,7 +20,7 @@ import akka.actor.{Actor, ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import io.radicalbit.nsdb.actors.PublisherActor.Command.{SubscribeBySqlStatement, Unsubscribe}
 import io.radicalbit.nsdb.actors.PublisherActor.Events._
-import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType}
+import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType, ValueFieldType}
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.index.{BIGINT, VARCHAR}
 import io.radicalbit.nsdb.model.{Schema, SchemaField}
@@ -69,9 +69,14 @@ class PublisherActorSpec
   val testRecordNotSatisfy = Bit(0, 23, Map("name"   -> "john"), Map.empty)
   val testRecordSatisfy    = Bit(100, 25, Map("name" -> "john"), Map.empty)
 
-  val schema = Schema("people",
-                      Map("timestamp" -> SchemaField("timestamp", DimensionFieldType, BIGINT()),
-                          "name"      -> SchemaField("name", DimensionFieldType, VARCHAR())))
+  val schema = Schema(
+    "people",
+    Map(
+      "timestamp" -> SchemaField("timestamp", DimensionFieldType, BIGINT()),
+      "name"      -> SchemaField("name", DimensionFieldType, VARCHAR()),
+      "value"     -> SchemaField("value", ValueFieldType, BIGINT())
+    )
+  )
 
   "PublisherActor" should "make other actors subscribe and unsubscribe" in {
     probe.send(publisherActor, SubscribeBySqlStatement(probeActor, "queryString", testSqlStatement))

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
@@ -177,7 +177,7 @@ trait QueryApi {
                       logger.error("unknown response received {}", r)
                       complete(HttpResponse(InternalServerError, entity = "unknown response"))
                     case Failure(ex) =>
-                      logger.error(ex,s"error while trying to execute $statement")
+                      logger.error(ex, s"error while trying to execute $statement")
                       complete(HttpResponse(InternalServerError, entity = ex.getMessage))
                   }
                 case None => complete(HttpResponse(BadRequest, entity = s"statement ${qb.queryString} is invalid"))

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
@@ -177,7 +177,7 @@ trait QueryApi {
                       logger.error("unknown response received {}", r)
                       complete(HttpResponse(InternalServerError, entity = "unknown response"))
                     case Failure(ex) =>
-                      logger.error("", ex)
+                      logger.error(ex,s"error while trying to execute $statement")
                       complete(HttpResponse(InternalServerError, entity = ex.getMessage))
                   }
                 case None => complete(HttpResponse(BadRequest, entity = s"statement ${qb.queryString} is invalid"))

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/actor/FakeReadCoordinator.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/actor/FakeReadCoordinator.scala
@@ -58,7 +58,7 @@ class FakeReadCoordinator extends Actor {
         case Right(_) =>
           val e = statement.condition.get.expression.asInstanceOf[RangeExpression[Long]]
           sender ! SelectStatementExecuted(statement, bitsParametrized(e.value1.value, e.value2.value))
-        case Left(_) => sender ! SelectStatementFailed(statement, "statement not valid")
+        case Left(errorMessage) => sender ! SelectStatementFailed(statement, errorMessage)
       }
     case ExecuteStatement(statement) =>
       StatementParser.parseStatement(
@@ -66,7 +66,7 @@ class FakeReadCoordinator extends Actor {
         Schema("metric", bits.head).getOrElse(Schema("metric", Map.empty[String, SchemaField]))) match {
         case Right(_) =>
           sender ! SelectStatementExecuted(statement, bits)
-        case Left(_) => sender ! SelectStatementFailed(statement, "statement not valid")
+        case Left(errorMessage) => sender ! SelectStatementFailed(statement, errorMessage)
       }
   }
 }

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiTest.scala
@@ -528,7 +528,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
       QueryBody("db",
                 "namespace",
                 "metric",
-                "select sum(value) from metric group by name limit 2 ",
+                "select sum(value) from metric group by country limit 2 ",
                 None,
                 None,
                 None,
@@ -574,7 +574,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
           |      } ]
           |    },
           |    "groupBy" : {
-          |      "dimension" : "name"
+          |      "field" : "country"
           |    },
           |    "limit" : {
           |      "value" : 2
@@ -591,7 +591,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
       QueryBody("db",
                 "namespace",
                 "metric",
-                "select min(value) from metric group by name limit 3 ",
+                "select min(value) from metric group by country limit 3 ",
                 None,
                 None,
                 None,
@@ -637,7 +637,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
           |      } ]
           |    },
           |    "groupBy" : {
-          |      "dimension" : "name"
+          |      "field" : "country"
           |    },
           |    "limit" : {
           |      "value" : 3
@@ -654,7 +654,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
       QueryBody("db",
                 "namespace",
                 "metric",
-                "select max(value) from metric group by name limit 4",
+                "select max(value) from metric group by country limit 4",
                 None,
                 None,
                 None,
@@ -700,7 +700,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
           |      } ]
           |    },
           |    "groupBy" : {
-          |      "dimension" : "name"
+          |      "field" : "country"
           |    },
           |    "limit" : {
           |      "value" : 4
@@ -1236,7 +1236,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
         "db",
         "namespace",
         "metric",
-        "select count(*) from metric where timestamp > now - 2d or name = 'a' and timestamp < 3 group by timestamp",
+        "select count(*) from metric where timestamp > now - 2d or name = 'a' and timestamp < 3 group by country",
         None,
         None,
         None,
@@ -1313,7 +1313,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
           |      }
           |    },
           |    "groupBy" : {
-          |      "dimension" : "timestamp"
+          |      "field" : "country"
           |    }
           |  }
           |}""".stripMargin
@@ -1328,7 +1328,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
         "db",
         "namespace",
         "metric",
-        "select count(*) from metric where name like $m$ or timestamp in (now - 2h, 7) and timestamp > now - 2d or name = 'a' and timestamp < 3 group by timestamp",
+        "select count(*) from metric where name like $m$ or timestamp in (now - 2h, 7) and timestamp > now - 2d or name = 'a' and timestamp < 3 group by country",
         None,
         None,
         None,
@@ -1428,7 +1428,7 @@ class QueryApiTest extends FlatSpec with Matchers with ScalatestRouteTest {
           |      }
           |    },
           |    "groupBy" : {
-          |      "dimension" : "timestamp"
+          |      "field" : "country"
           |    }
           |  }
           |}""".stripMargin


### PR DESCRIPTION
This PR has the purpose to improve the error messages returned in case of an invalid statement provided.

Basically:
- Either has been used in favour of Try to handle errors
- Accessors methods are added in Schema object to access tags dimensions and value independently 