### PR TITLE
[HOTFIX] Allow schema creation only from bit

### DIFF
--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCacheSpec.scala
@@ -83,15 +83,15 @@ class ReplicatedSchemaCacheSpec
 
   val metric1 = "metric1"
   val key1    = SchemaKey(db, namespace, metric1)
-  val schema1 = Schema(metric1, Bit(0, 1L, Map("dimension" -> "dimension"), Map("tag" -> "tag"))).get
+  val schema1 = Schema(metric1, Bit(0, 1L, Map("dimension" -> "dimension"), Map("tag" -> "tag")))
 
   val metric2 = "metric2"
   val key2    = SchemaKey(db, namespace, metric2)
-  val schema2 = Schema(metric2, Bit(0, 1.5, Map("dimension" -> "dimension"), Map("tag" -> "tag"))).get
+  val schema2 = Schema(metric2, Bit(0, 1.5, Map("dimension" -> "dimension"), Map("tag" -> "tag")))
 
   val metric3 = "metric3"
   val key3    = SchemaKey(db, namespace, metric3)
-  val schema3 = Schema(metric3, Bit(0, 1L, Map("dimension" -> "dimension"), Map("tag" -> "tag"))).get
+  val schema3 = Schema(metric3, Bit(0, 1L, Map("dimension" -> "dimension"), Map("tag" -> "tag")))
 
   "ReplicatedSchemaCacheSpec" must {
 
@@ -135,7 +135,7 @@ class ReplicatedSchemaCacheSpec
 
       def key(i: Int) = SchemaKey(db, namespace, s"multimetric_$i")
       def schema(i: Int) =
-        Schema(s"multimetric_$i", Bit(0, 1L, Map("dimension" -> "dimension"), Map("tag" -> "tag"))).get
+        Schema(s"multimetric_$i", Bit(0, 1L, Map("dimension" -> "dimension"), Map("tag" -> "tag")))
 
       runOn(node1) {
         for (i ← 10 to 20) {
@@ -196,9 +196,9 @@ class ReplicatedSchemaCacheSpec
 
       val metric = "metric4"
 
-      val schema = Schema(metric, Bit(0, 1L, Map("dimension" -> "dimension"), Map("tag" -> "tag"))).get
+      val schema = Schema(metric, Bit(0, 1L, Map("dimension" -> "dimension"), Map("tag" -> "tag")))
       val updatedSchema =
-        Schema("updatedMetric", Bit(0, 1L, Map("dimension" -> "dimension1"), Map("tag" -> "tag1"))).get
+        Schema("updatedMetric", Bit(0, 1L, Map("dimension" -> "dimension1"), Map("tag" -> "tag1")))
 
       runOn(node1) {
         replicatedCache ! PutSchemaInCache(db, namespace, metric, schema)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/SchemaCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/SchemaCoordinatorSpec.scala
@@ -21,8 +21,7 @@ import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
 import io.radicalbit.nsdb.common.protocol._
-import io.radicalbit.nsdb.index._
-import io.radicalbit.nsdb.model.{Schema, SchemaField}
+import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import org.scalatest._
@@ -186,7 +185,7 @@ class SchemaCoordinatorSpec
     val schema = probe.expectMsgType[SchemaGot]
     schema.metric shouldBe "offices"
     schema.schema shouldBe Some(
-      unionSchema.copy(metric = "offices")
+      Schema(metric = "offices", mergedRecord)
     )
 
     probe.send(
@@ -228,7 +227,7 @@ class SchemaCoordinatorSpec
     existingGot.schema shouldBe Some(
       Schema(
         "people",
-        dummyBit
+        nameRecord
       ))
 
     probe.send(schemaCoordinator, GetSchema(db, namespace1, "people"))
@@ -238,7 +237,7 @@ class SchemaCoordinatorSpec
     existingGot1.schema shouldBe Some(
       Schema(
         "people",
-        dummyBit
+        surnameRecord
       ))
   }
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/SchemaCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/SchemaCoordinatorSpec.scala
@@ -51,27 +51,15 @@ class SchemaCoordinatorSpec
   val nameRecord    = Bit(0, 1, Map("name"    -> "name"), Map("city"       -> "milano"))
   val surnameRecord = Bit(0, 1, Map("surname" -> "surname"), Map("country" -> "italy"))
 
-  val baseSchema = Schema(
-    "people",
-    Map(
-      "name"      -> SchemaField("name", DimensionFieldType, VARCHAR()),
-      "timestamp" -> SchemaField("timestamp", TimestampFieldType, BIGINT()),
-      "value"     -> SchemaField("value", ValueFieldType, INT()),
-      "city"      -> SchemaField("city", TagFieldType, VARCHAR())
-    )
-  )
+  val mergedRecord =
+    Bit(0, 1, Map("name" -> "name", "surname" -> "surname"), Map("city" -> "milano", "country" -> "italy"))
 
-  val unionSchema = Schema(
-    "people",
-    Map(
-      "timestamp" -> SchemaField("timestamp", TimestampFieldType, BIGINT()),
-      "value"     -> SchemaField("value", ValueFieldType, INT()),
-      "name"      -> SchemaField("name", DimensionFieldType, VARCHAR()),
-      "surname"   -> SchemaField("surname", DimensionFieldType, VARCHAR()),
-      "city"      -> SchemaField("city", TagFieldType, VARCHAR()),
-      "country"   -> SchemaField("country", TagFieldType, VARCHAR())
-    )
-  )
+  val baseSchema = Schema("people", nameRecord)
+
+  val unionSchema = Schema("people", mergedRecord)
+
+  private val dummyBit: Bit =
+    Bit(0, 23, Map("name" -> "john", "surname" -> "doe"), Map("city" -> "milano", "country" -> "italy"))
 
   before {
     implicit val timeout = Timeout(10 seconds)
@@ -114,15 +102,10 @@ class SchemaCoordinatorSpec
     probe.expectNoMessage(1 second)
 
   }
-
   "schemaCoordinator" should "update schemas coming from a record" in {
     probe.send(
       schemaCoordinator,
-      UpdateSchemaFromRecord(
-        "db",
-        "namespace",
-        "people",
-        Bit(0, 23, Map("name" -> "john", "surname" -> "doe"), Map("city" -> "milano", "country" -> "italy")))
+      UpdateSchemaFromRecord("db", "namespace", "people", dummyBit)
     )
 
     val schema = probe.expectMsgType[SchemaUpdateResponse].asInstanceOf[SchemaUpdated].schema
@@ -146,11 +129,7 @@ class SchemaCoordinatorSpec
   "schemaCoordinator" should "return the same schema for a new schema included in the old one" in {
     probe.send(
       schemaCoordinator,
-      UpdateSchemaFromRecord(
-        "db",
-        "namespace",
-        "people",
-        Bit(0, 23, Map("name" -> "john", "surname" -> "doe"), Map("city" -> "milano", "country" -> "italy")))
+      UpdateSchemaFromRecord("db", "namespace", "people", dummyBit)
     )
 
     probe.expectMsgType[SchemaUpdateResponse].isInstanceOf[SchemaUpdated] shouldBe true
@@ -182,11 +161,7 @@ class SchemaCoordinatorSpec
 
     probe.send(
       schemaCoordinator,
-      UpdateSchemaFromRecord(
-        "db",
-        "namespace",
-        "people",
-        Bit(0, 23, Map("name" -> "john", "surname" -> "doe"), Map("city" -> "milano", "country" -> "italy")))
+      UpdateSchemaFromRecord("db", "namespace", "people", dummyBit)
     )
 
     probe.expectMsgType[SchemaUpdateResponse].isInstanceOf[SchemaUpdated] shouldBe true
@@ -201,11 +176,7 @@ class SchemaCoordinatorSpec
 
     probe.send(
       schemaCoordinator,
-      UpdateSchemaFromRecord(
-        "db",
-        "namespace",
-        "offices",
-        Bit(0, 23, Map("name" -> "john", "surname" -> "doe"), Map("city" -> "milano", "country" -> "italy")))
+      UpdateSchemaFromRecord("db", "namespace", "offices", dummyBit)
     )
 
     probe.expectMsgType[SchemaUpdateResponse].isInstanceOf[SchemaUpdated] shouldBe true
@@ -257,12 +228,7 @@ class SchemaCoordinatorSpec
     existingGot.schema shouldBe Some(
       Schema(
         "people",
-        Map(
-          "timestamp" -> SchemaField("timestamp", TimestampFieldType, BIGINT()),
-          "value"     -> SchemaField("value", ValueFieldType, INT()),
-          "name"      -> SchemaField("name", DimensionFieldType, VARCHAR()),
-          "city"      -> SchemaField("city", TagFieldType, VARCHAR())
-        )
+        dummyBit
       ))
 
     probe.send(schemaCoordinator, GetSchema(db, namespace1, "people"))
@@ -272,12 +238,7 @@ class SchemaCoordinatorSpec
     existingGot1.schema shouldBe Some(
       Schema(
         "people",
-        Map(
-          "timestamp" -> SchemaField("timestamp", TimestampFieldType, BIGINT()),
-          "value"     -> SchemaField("value", ValueFieldType, INT()),
-          "surname"   -> SchemaField("surname", DimensionFieldType, VARCHAR()),
-          "country"   -> SchemaField("country", TagFieldType, VARCHAR())
-        )
+        dummyBit
       ))
   }
 

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/Bit.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/Bit.scala
@@ -18,6 +18,9 @@ package io.radicalbit.nsdb.common.protocol
 
 import io.radicalbit.nsdb.common.{NSDbNumericType, NSDbType}
 
+/**
+  * Placeholder traits used for serialization purposes
+  */
 trait NSDbSerializable
 
 /**

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/TypeSupport.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/TypeSupport.scala
@@ -134,6 +134,7 @@ sealed abstract class NumericType[T] extends IndexType[T] {
     * Returns a [[Numeric]] to be used for arithmetic operations
     */
   def numeric: Numeric[Any]
+  def zero: NSDbNumericType
 }
 
 object IndexType {
@@ -177,6 +178,8 @@ case class INT() extends NumericType[Int] {
 
   override def numeric: Numeric[Any] = implicitly[Numeric[Int]].asInstanceOf[Numeric[Any]]
 
+  override def zero: NSDbNumericType = NSDbNumericType(0)
+
   override def cast(value: Any): Int = value.toString.toInt
 
   val sortType: SortField.Type = SortField.Type.INT
@@ -200,6 +203,8 @@ case class BIGINT() extends NumericType[Long] {
 
   override def numeric: Numeric[Any] = implicitly[Numeric[Long]].asInstanceOf[Numeric[Any]]
 
+  override def zero: NSDbNumericType = NSDbNumericType(0L)
+
   override def cast(value: Any): Long = value.toString.toLong
 
   val sortType: SortField.Type = SortField.Type.LONG
@@ -222,6 +227,8 @@ case class DECIMAL() extends NumericType[Double] {
   def deserialize(value: Array[Byte]): NSDbDoubleType = NSDbDoubleType(new String(value).toDouble)
 
   override def numeric: Numeric[Any] = implicitly[Numeric[Double]].asInstanceOf[Numeric[Any]]
+
+  override def zero: NSDbNumericType = NSDbNumericType(0.0)
 
   override def cast(value: Any): Double = value.toString.toDouble
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
@@ -69,8 +69,7 @@ case class Schema private (metric: String, fieldsMap: Map[String, SchemaField]) 
   /**
     * extract value from fieldsMap
     */
-  lazy val value: SchemaField =
-    fieldsMap("value")
+  lazy val value: SchemaField = fieldsMap("value")
 
   override def equals(obj: scala.Any): Boolean = {
     if (obj != null && obj.isInstanceOf[Schema]) {
@@ -82,19 +81,22 @@ case class Schema private (metric: String, fieldsMap: Map[String, SchemaField]) 
 
 object Schema extends TypeSupport {
 
+  private def apply(metric: String, fieldsMap: Map[String, SchemaField]) = new Schema(metric, fieldsMap)
+
   /**
     * Creates a schema by analyzing a [[Bit]] structure.
     * @param metric the metric.
     * @param bit the bit to be used to create the schema.
     * @return the resulting [[Schema]]. If bit contains invalid fields the result will be a [[scala.util.Failure]]
     */
-  def apply(metric: String, bit: Bit): Try[Schema] = {
-    validateSchemaTypeSupport(bit).map(
-      fieldsMap =>
-        Schema(
-          metric,
-          fieldsMap.mapValues(field => SchemaField(field.name, field.fieldClassType, field.indexType)).map(identity)))
-  }
+  def apply(metric: String, bit: Bit): Schema =
+    validateSchemaTypeSupport(bit)
+      .map(
+        fieldsMap =>
+          new Schema(
+            metric,
+            fieldsMap.mapValues(field => SchemaField(field.name, field.fieldClassType, field.indexType)).map(identity)))
+      .get
 
   /**
     * Assemblies, if possible, the union schema from 2 given schemas.
@@ -116,7 +118,7 @@ object Schema extends TypeSupport {
     if (notCompatibleFields.nonEmpty)
       Failure(new RuntimeException(notCompatibleFields.mkString(",")))
     else {
-      val schema = Schema(secondSchema.metric, firstSchema.fieldsMap ++ secondSchema.fieldsMap)
+      val schema = new Schema(secondSchema.metric, firstSchema.fieldsMap ++ secondSchema.fieldsMap)
       Success(schema)
     }
   }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
@@ -52,7 +52,7 @@ case class SchemaField(name: String, fieldClassType: FieldClassType, indexType: 
   * @param metric the metric.
   * @param fieldsMap a map of [[SchemaField]] keyed by field name
   */
-case class Schema private (metric: String, fieldsMap: Map[String, SchemaField]) extends NSDbSerializable {
+class Schema private (val metric: String, val fieldsMap: Map[String, SchemaField]) extends NSDbSerializable {
 
   /**
     * filters tags from fieldsMap
@@ -80,8 +80,6 @@ case class Schema private (metric: String, fieldsMap: Map[String, SchemaField]) 
 }
 
 object Schema extends TypeSupport {
-
-  private def apply(metric: String, fieldsMap: Map[String, SchemaField]) = new Schema(metric, fieldsMap)
 
   /**
     * Creates a schema by analyzing a [[Bit]] structure.

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
@@ -61,10 +61,9 @@ class MetricAccumulatorActorSpec()
       MetricAccumulatorActor.props(basePath, db, namespace, metricsReaderActor, system.actorOf(Props.empty)),
       probeActor)
 
-  val schema =
-    Schema("",
-           Map("dimension" -> SchemaField("dimension", DimensionFieldType, VARCHAR()),
-               "tag"       -> SchemaField("tag", TagFieldType, VARCHAR())))
+  val dummyBit = Bit(0, 0, Map("dimension" -> "d"), Map("tag" -> "t"))
+
+  val schema = Schema("", dummyBit)
 
   private val location = Location("testMetric", nodeName, 0, 0)
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
@@ -24,9 +24,8 @@ import akka.pattern.ask
 import akka.routing.RoundRobinPool
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import akka.util.Timeout
-import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType, TagFieldType}
-import io.radicalbit.nsdb.index.VARCHAR
-import io.radicalbit.nsdb.model.{Location, Schema, SchemaField}
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.model.{Location, Schema}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import org.scalatest.{BeforeAndAfter, FlatSpecLike, Matchers}

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -69,14 +69,7 @@ class PublisherActorSpec
   val testRecordNotSatisfy = Bit(0, 23, Map("name"   -> "john"), Map.empty)
   val testRecordSatisfy    = Bit(100, 25, Map("name" -> "john"), Map.empty)
 
-  val schema = Schema(
-    "people",
-    Map(
-      "timestamp" -> SchemaField("timestamp", DimensionFieldType, BIGINT()),
-      "name"      -> SchemaField("name", DimensionFieldType, VARCHAR()),
-      "value"     -> SchemaField("value", ValueFieldType, BIGINT())
-    )
-  )
+  val schema = Schema("people", testRecordSatisfy)
 
   "PublisherActor" should "make other actors subscribe and unsubscribe" in {
     probe.send(publisherActor, SubscribeBySqlStatement(probeActor, "queryString", testSqlStatement))

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -20,10 +20,9 @@ import akka.actor.{Actor, ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import io.radicalbit.nsdb.actors.PublisherActor.Command.{SubscribeBySqlStatement, Unsubscribe}
 import io.radicalbit.nsdb.actors.PublisherActor.Events._
-import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType, ValueFieldType}
+import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement._
-import io.radicalbit.nsdb.index.{BIGINT, VARCHAR}
-import io.radicalbit.nsdb.model.{Schema, SchemaField}
+import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import org.scalatest._

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeSeriesIndexTest.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeSeriesIndexTest.scala
@@ -19,8 +19,8 @@ package io.radicalbit.nsdb.index
 import java.nio.file.Paths
 import java.util.UUID
 
-import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType, TagFieldType}
-import io.radicalbit.nsdb.model.{Schema, SchemaField}
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.model.Schema
 import org.apache.lucene.document.LongPoint
 import org.apache.lucene.index.Term
 import org.apache.lucene.search._
@@ -29,9 +29,7 @@ import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
 
 class TimeSeriesIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
 
-  private val schema = Schema("",
-                              Map("dimension" -> SchemaField("dimension", DimensionFieldType, VARCHAR()),
-                                  "tag"       -> SchemaField("tag", TagFieldType, VARCHAR())))
+  private val schema = Schema("", Bit(0, 0, Map("dimension" -> "d"), Map("tag" -> "t")))
 
   "TimeSeriesIndex" should "write and read properly on disk" in {
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/FirstLastIndexSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/FirstLastIndexSpec.scala
@@ -31,30 +31,26 @@ import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
 
 class FirstLastIndexSpec extends FlatSpec with Matchers with OneInstancePerTest {
 
-  private val BigIntValueSchema = Schema(
-    "testMetric",
-    Map(
-      "dimension" -> SchemaField("dimension", DimensionFieldType, VARCHAR()),
-      "tag1"      -> SchemaField("tag1", TagFieldType, VARCHAR()),
-      "tag2"      -> SchemaField("tag2", TagFieldType, BIGINT()),
-      "tag3"      -> SchemaField("tag3", TagFieldType, DECIMAL()),
-      "value"     -> SchemaField("value", TagFieldType, BIGINT()),
-      "timestamp" -> SchemaField("timestamp", TimestampFieldType, BIGINT())
-    )
-  )
+  private val BigIntValueSchema = Schema("testMetric",
+                                         Bit(0,
+                                             0,
+                                             Map("dimension" -> "dimension"),
+                                             Map(
+                                               "tag1" -> "tag1",
+                                               "tag2" -> "tag2",
+                                               "tag3" -> "tag3"
+                                             )))
 
-  private val DecimalValueSchema = Schema(
-    "testMetric",
-    Map(
-      "dimension" -> SchemaField("dimension", DimensionFieldType, VARCHAR()),
-      "tag1"      -> SchemaField("tag1", TagFieldType, VARCHAR()),
-      "tag2"      -> SchemaField("tag2", TagFieldType, BIGINT()),
-      "tag3"      -> SchemaField("tag3", TagFieldType, DECIMAL()),
-      "value"     -> SchemaField("value", TagFieldType, DECIMAL()),
-      "timestamp" -> SchemaField("timestamp", TimestampFieldType, BIGINT())
-    )
-  )
-
+  private val DecimalValueSchema = Schema("testMetric",
+                                          Bit(0,
+                                              1.1,
+                                              Map("dimension" -> "dimension"),
+                                              Map(
+                                                "tag1" -> "tag1",
+                                                "tag2" -> "tag2",
+                                                "tag3" -> "tag3"
+                                              )))
+  
   "TimeSeriesIndex" should "return last values properly for a bigint value" in {
 
     val timeSeriesIndex =

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/FirstLastIndexSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/FirstLastIndexSpec.scala
@@ -20,9 +20,9 @@ import java.nio.file.Paths
 import java.util.UUID
 
 import io.radicalbit.nsdb.common.NSDbType
-import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType, TagFieldType, TimestampFieldType}
-import io.radicalbit.nsdb.index.{BIGINT, DECIMAL, TimeSeriesIndex, VARCHAR}
-import io.radicalbit.nsdb.model.{Schema, SchemaField}
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.index.TimeSeriesIndex
+import io.radicalbit.nsdb.model.Schema
 import org.apache.lucene.document.LongPoint
 import org.apache.lucene.index.Term
 import org.apache.lucene.search.{MatchAllDocsQuery, TermQuery}
@@ -37,8 +37,8 @@ class FirstLastIndexSpec extends FlatSpec with Matchers with OneInstancePerTest 
                                              Map("dimension" -> "dimension"),
                                              Map(
                                                "tag1" -> "tag1",
-                                               "tag2" -> "tag2",
-                                               "tag3" -> "tag3"
+                                               "tag2" -> 0L,
+                                               "tag3" -> 0
                                              )))
 
   private val DecimalValueSchema = Schema("testMetric",
@@ -47,10 +47,10 @@ class FirstLastIndexSpec extends FlatSpec with Matchers with OneInstancePerTest 
                                               Map("dimension" -> "dimension"),
                                               Map(
                                                 "tag1" -> "tag1",
-                                                "tag2" -> "tag2",
-                                                "tag3" -> "tag3"
+                                                "tag2" -> 0L,
+                                                "tag3" -> 0
                                               )))
-  
+
   "TimeSeriesIndex" should "return last values properly for a bigint value" in {
 
     val timeSeriesIndex =

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/MinMaxIndexSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/MinMaxIndexSpec.scala
@@ -20,9 +20,9 @@ import java.nio.file.Paths
 import java.util.UUID
 
 import io.radicalbit.nsdb.common.NSDbType
-import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType, TagFieldType, TimestampFieldType}
-import io.radicalbit.nsdb.index.{BIGINT, DECIMAL, TimeSeriesIndex, VARCHAR}
-import io.radicalbit.nsdb.model.{Schema, SchemaField}
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.index.TimeSeriesIndex
+import io.radicalbit.nsdb.model.Schema
 import org.apache.lucene.document.LongPoint
 import org.apache.lucene.index.Term
 import org.apache.lucene.search.{MatchAllDocsQuery, TermQuery}
@@ -30,28 +30,26 @@ import org.apache.lucene.store.MMapDirectory
 import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
 
 class MinMaxIndexSpec extends FlatSpec with Matchers with OneInstancePerTest {
-  private val BigIntValueSchema = Schema(
-    "testMetric",
-    Map(
-      "dimension" -> SchemaField("dimension", DimensionFieldType, VARCHAR()),
-      "tag1"      -> SchemaField("tag1", TagFieldType, VARCHAR()),
-      "tag2"      -> SchemaField("tag2", TagFieldType, BIGINT()),
-      "tag3"      -> SchemaField("tag3", TagFieldType, DECIMAL()),
-      "value"     -> SchemaField("value", TagFieldType, BIGINT()),
-      "timestamp" -> SchemaField("timestamp", TimestampFieldType, BIGINT())
-    )
-  )
+  private val BigIntValueSchema = Schema("testMetric",
+                                         Bit(0,
+                                             0,
+                                             Map(
+                                               "tag1" -> "tag1",
+                                               "tag2" -> 0L,
+                                               "tag3" -> 0.0,
+                                             ),
+                                             Map("dimension" -> "dimension")))
 
   private val DecimalValueSchema = Schema(
     "testMetric",
-    Map(
-      "dimension" -> SchemaField("dimension", DimensionFieldType, VARCHAR()),
-      "tag1"      -> SchemaField("tag1", TagFieldType, VARCHAR()),
-      "tag2"      -> SchemaField("tag2", TagFieldType, BIGINT()),
-      "tag3"      -> SchemaField("tag3", TagFieldType, DECIMAL()),
-      "value"     -> SchemaField("value", TagFieldType, DECIMAL()),
-      "timestamp" -> SchemaField("timestamp", TimestampFieldType, BIGINT())
-    )
+    Bit(0,
+        0.0,
+        Map(
+          "tag1" -> "tag1",
+          "tag2" -> 0L,
+          "tag3" -> 0.0,
+        ),
+        Map("dimension" -> "dimension"))
   )
 
   "TimeSeriesIndex" should "return max values properly for a bigint value" in {

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
@@ -16,10 +16,9 @@
 
 package io.radicalbit.nsdb.statement
 
-import io.radicalbit.nsdb.common.protocol.{DimensionFieldType, TagFieldType, TimestampFieldType, ValueFieldType}
+import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement.{SumAggregation => SqlSumAggregation, _}
-import io.radicalbit.nsdb.index._
-import io.radicalbit.nsdb.model.{Schema, SchemaField}
+import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.statement.StatementParser._
 import org.apache.lucene.document.{DoublePoint, LongPoint}
 import org.apache.lucene.index.Term
@@ -30,17 +29,10 @@ class StatementParserSpec extends WordSpec with Matchers {
 
   val schema = Schema(
     "people",
-    Map(
-      "timestamp"    -> SchemaField("timestamp", TimestampFieldType, BIGINT()),
-      "value"        -> SchemaField("value", ValueFieldType, DECIMAL()),
-      "name"         -> SchemaField("name", DimensionFieldType, VARCHAR()),
-      "surname"      -> SchemaField("surname", DimensionFieldType, VARCHAR()),
-      "amount"       -> SchemaField("amount", TagFieldType, DECIMAL()),
-      "creationDate" -> SchemaField("creationDate", DimensionFieldType, BIGINT()),
-      "city"         -> SchemaField("city", TagFieldType, VARCHAR()),
-      "country"      -> SchemaField("country", TagFieldType, VARCHAR()),
-      "age"          -> SchemaField("age", TagFieldType, INT())
-    )
+    Bit(0,
+        1.1,
+        Map("name"   -> "name", "surname" -> "surname", "creationDate" -> 0L),
+        Map("amount" -> 1.1, "city"       -> "city", "country"         -> "country", "age" -> 0))
   )
 
   "A statement parser instance" when {

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/WebSocketSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/WebSocketSpec.scala
@@ -97,8 +97,8 @@ class WebSocketSpec() extends FlatSpec with ScalatestRouteTest with Matchers wit
         parse(firstSubscribed).extractOpt[SubscribedByQueryString].isDefined shouldBe true
 
         val bit = Bit(System.currentTimeMillis(), 1, Map.empty, Map.empty)
-        publisherActor ! PublishRecord("db", "registry", "people", bit, Schema("people", bit).get)
-        publisherActor ! PublishRecord("db", "registry", "animals", bit, Schema("people", bit).get)
+        publisherActor ! PublishRecord("db", "registry", "people", bit, Schema("people", bit))
+        publisherActor ! PublishRecord("db", "registry", "animals", bit, Schema("people", bit))
 
         val firstRecordsPublished = wsClient.expectMessage().asTextMessage.getStrictText
 


### PR DESCRIPTION
This PR aims at improving and making safer the Schema API.

In particular, the Schema primary constructor is going to become private so that Schema must be inferred from a Bit and not arbitrarily  created