### PR TITLE
Privilege local shards to minimize network traffic

### DIFF
--- a/nsdb-cluster/src/main/resources/application-common.conf
+++ b/nsdb-cluster/src/main/resources/application-common.conf
@@ -23,12 +23,18 @@ akka {
   log-dead-letters = 10
   log-dead-letters-during-shutdown = off
 
+  serialization.jackson.jackson-json.compression {
+    algorithm = gzip
+    compress-larger-than = 1024 KiB
+  }
+
+
   actor {
     provider = cluster
 
     # FIXME: temporary serialization until a different method will be implemented
     allow-java-serialization = on
-
+    
     serialization-bindings {
       "io.radicalbit.nsdb.common.protocol.NSDbSerializable" = jackson-json
       "com.swissborg.lithium.internals.LithiumSeenChanged" = java

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -36,7 +36,7 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands._
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.deleteStatementFromThreshold
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.createNodeName
-import io.radicalbit.nsdb.cluster.logic.{CapacityWriteNodesSelectionLogic, WriteNodesSelectionLogic}
+import io.radicalbit.nsdb.cluster.logic.WriteNodesSelectionLogic
 import io.radicalbit.nsdb.cluster.util.ErrorManagementUtils._
 import io.radicalbit.nsdb.commit_log.CommitLogWriterActor._
 import io.radicalbit.nsdb.common.configuration.NSDbConfig

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -190,7 +190,7 @@ class ReadCoordinator(metadataCoordinator: ActorRef,
               ReadNodesSelection.filterLocationsThroughTime(statement.condition.map(_.expression), locations)
 
             val uniqueLocationsByNode: Map[String, Seq[Location]] =
-              readNodesSelection.getUniqueLocationsByNode(filteredLocations)
+              readNodesSelection.getDistinctLocationsByNode(filteredLocations)
 
             StatementParser.parseStatement(statement, schema) match {
               //pure count(*) query

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -26,9 +26,10 @@ import io.radicalbit.nsdb.cluster.NsdbPerfLogger
 import io.radicalbit.nsdb.cluster.PubSubTopics._
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.GetLocations
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.LocationsGot
+import io.radicalbit.nsdb.cluster.logic.ReadNodesSelection
 import io.radicalbit.nsdb.common.NSDbNumericType
 import io.radicalbit.nsdb.common.protocol.Bit
-import io.radicalbit.nsdb.common.statement.{Expression, SelectSQLStatement}
+import io.radicalbit.nsdb.common.statement.SelectSQLStatement
 import io.radicalbit.nsdb.index.NumericType
 import io.radicalbit.nsdb.model.{Location, Schema, TimeRange}
 import io.radicalbit.nsdb.post_proc.{applyOrderingWithLimit, _}
@@ -38,8 +39,6 @@ import io.radicalbit.nsdb.statement.StatementParser._
 import io.radicalbit.nsdb.statement._
 import io.radicalbit.nsdb.util.ActorPathLogging
 import io.radicalbit.nsdb.util.PipeableFutureWithSideEffect._
-import spire.implicits._
-import spire.math.Interval
 
 import scala.collection.mutable
 import scala.concurrent.Future
@@ -50,7 +49,10 @@ import scala.concurrent.duration.FiniteDuration
   * @param metadataCoordinator  [[MetadataCoordinator]] the metadata coordinator.
   * @param schemaCoordinator [[SchemaCoordinator]] the metrics schema actor.
   */
-class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef, mediator: ActorRef)
+class ReadCoordinator(metadataCoordinator: ActorRef,
+                      schemaCoordinator: ActorRef,
+                      mediator: ActorRef,
+                      readNodesSelection: ReadNodesSelection)
     extends ActorPathLogging
     with NsdbPerfLogger {
 
@@ -76,17 +78,6 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
     context.system.scheduler.schedule(FiniteDuration(0, "ms"), interval) {
       mediator ! Publish(NODE_GUARDIANS_TOPIC, GetMetricsDataActors)
       log.debug("readcoordinator data actor : {}", metricsDataActors.size)
-    }
-  }
-
-  private def filterLocationsThroughTime(expression: Option[Expression], locations: Seq[Location]): Seq[Location] = {
-    val intervals = TimeRangeManager.extractTimeRange(expression)
-    locations.filter {
-      case key if intervals.nonEmpty =>
-        intervals
-          .map(i => Interval.closed(key.from, key.to).intersect(i) != Interval.empty[Long])
-          .foldLeft(false)((x, y) => x || y)
-      case _ => true
     }
   }
 
@@ -195,10 +186,11 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
         .flatMap {
           case SchemaGot(_, _, _, Some(schema)) :: LocationsGot(_, _, _, locations) :: Nil =>
             log.debug("found schema {} and locations", schema, locations)
-            val filteredLocations = filterLocationsThroughTime(statement.condition.map(_.expression), locations)
+            val filteredLocations: Seq[Location] =
+              ReadNodesSelection.filterLocationsThroughTime(statement.condition.map(_.expression), locations)
 
-            val uniqueLocationsByNode =
-              filteredLocations.groupBy(l => (l.from, l.to)).map(_._2.head).toSeq.groupBy(_.node)
+            val uniqueLocationsByNode: Map[String, Seq[Location]] =
+              readNodesSelection.getUniqueLocationsByNode(filteredLocations)
 
             StatementParser.parseStatement(statement, schema) match {
               //pure count(*) query
@@ -414,7 +406,10 @@ class ReadCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRef
 
 object ReadCoordinator {
 
-  def props(metadataCoordinator: ActorRef, schemaActor: ActorRef, mediator: ActorRef): Props =
-    Props(new ReadCoordinator(metadataCoordinator, schemaActor, mediator: ActorRef))
+  def props(metadataCoordinator: ActorRef,
+            schemaActor: ActorRef,
+            mediator: ActorRef,
+            readNodesSelection: ReadNodesSelection): Props =
+    Props(new ReadCoordinator(metadataCoordinator, schemaActor, mediator: ActorRef, readNodesSelection))
 
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelection.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelection.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.logic
+
+import io.radicalbit.nsdb.model.Location
+
+/**
+  * ReadNodesSelection strategy that privileges local locations.
+  * @param localNode the local node.
+  */
+class LocalityReadNodesSelection(localNode: String) extends ReadNodesSelection {
+
+  override def getUniqueLocationsByNode(locations: Seq[Location]): Map[String, Seq[Location]] = {
+    locations
+      .groupBy(l => (l.from, l.to))
+      .collect {
+        case ((_, _), locs) if locs.size > 1 => locs.find(_.node == localNode).getOrElse(locs.head)
+        case ((_, _), locs)                  => locs.head
+      }
+      .toSeq
+      .groupBy(_.node)
+  }
+}

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelection.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelection.scala
@@ -24,7 +24,7 @@ import io.radicalbit.nsdb.model.Location
   */
 class LocalityReadNodesSelection(localNode: String) extends ReadNodesSelection {
 
-  override def getUniqueLocationsByNode(locationsWithReplicas: Seq[Location]): Map[String, Seq[Location]] = {
+  override def getDistinctLocationsByNode(locationsWithReplicas: Seq[Location]): Map[String, Seq[Location]] = {
     locationsWithReplicas
       .groupBy(l => (l.from, l.to))
       .collect {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelection.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelection.scala
@@ -24,12 +24,13 @@ import io.radicalbit.nsdb.model.Location
   */
 class LocalityReadNodesSelection(localNode: String) extends ReadNodesSelection {
 
-  override def getUniqueLocationsByNode(locations: Seq[Location]): Map[String, Seq[Location]] = {
-    locations
+  override def getUniqueLocationsByNode(locationsWithReplicas: Seq[Location]): Map[String, Seq[Location]] = {
+    locationsWithReplicas
       .groupBy(l => (l.from, l.to))
       .collect {
-        case ((_, _), locs) if locs.size > 1 => locs.find(_.node == localNode).getOrElse(locs.head)
-        case ((_, _), locs)                  => locs.head
+        case ((_, _), locations) if locations.size > 1 =>
+          locations.find(_.node == localNode).getOrElse(locations.minBy(_.node))
+        case ((_, _), locations) => locations.minBy(_.node)
       }
       .toSeq
       .groupBy(_.node)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/ReadNodesSelection.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/ReadNodesSelection.scala
@@ -29,9 +29,9 @@ trait ReadNodesSelection {
 
   /**
     * Returns all the unique locations grouped by node.
-    * @param locations all the locations for a metric (replicas included).
+    * @param locationsWithReplicas all the locations for a metric (replicas included).
     */
-  def getUniqueLocationsByNode(locations: Seq[Location]): Map[String, Seq[Location]]
+  def getUniqueLocationsByNode(locationsWithReplicas: Seq[Location]): Map[String, Seq[Location]]
 
 }
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/ReadNodesSelection.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/ReadNodesSelection.scala
@@ -23,15 +23,15 @@ import spire.math.Interval
 import spire.implicits._
 
 /**
-  * contains the method to select unique locations
+  * contains the method to select distinct locations
   */
 trait ReadNodesSelection {
 
   /**
-    * Returns all the unique locations grouped by node.
+    * Returns all the distinct locations grouped by node.
     * @param locationsWithReplicas all the locations for a metric (replicas included).
     */
-  def getUniqueLocationsByNode(locationsWithReplicas: Seq[Location]): Map[String, Seq[Location]]
+  def getDistinctLocationsByNode(locationsWithReplicas: Seq[Location]): Map[String, Seq[Location]]
 
 }
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/ReadNodesSelection.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/ReadNodesSelection.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.logic
+
+import io.radicalbit.nsdb.common.statement.Expression
+import io.radicalbit.nsdb.model.Location
+import io.radicalbit.nsdb.statement.TimeRangeManager
+import spire.math.Interval
+import spire.implicits._
+
+/**
+  * contains the method to select unique locations
+  */
+trait ReadNodesSelection {
+
+  /**
+    * Returns all the unique locations grouped by node.
+    * @param locations all the locations for a metric (replicas included).
+    */
+  def getUniqueLocationsByNode(locations: Seq[Location]): Map[String, Seq[Location]]
+
+}
+
+object ReadNodesSelection {
+
+  def filterLocationsThroughTime(expression: Option[Expression], locations: Seq[Location]): Seq[Location] = {
+    val intervals = TimeRangeManager.extractTimeRange(expression)
+    locations.filter {
+      case key if intervals.nonEmpty =>
+        intervals
+          .map(i => Interval.closed(key.from, key.to).intersect(i) != Interval.empty[Long])
+          .foldLeft(false)((x, y) => x || y)
+      case _ => true
+    }
+  }
+}

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -56,6 +56,7 @@ object MetadataSpec extends MultiNodeConfig {
     |  retention.check.interval = 1 seconds
     |
     |  cluster {
+    |    metrics-selector = disk
     |    metadata-write-consistency = "all"
     |    replication-factor = 2
     |    consistency-level = 2

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -353,7 +353,7 @@ class ReplicatedMetadataCacheSpec
       awaitAssert {
         replicatedCache ! GetLocationsFromCache("db", "namespace", metric)
         val cached = expectMsgType[LocationsCached]
-        cached.value.size shouldBe 11
+        cached.locations.size shouldBe 11
       }
 
       enterBarrier("after-bulk-add")
@@ -463,16 +463,16 @@ class ReplicatedMetadataCacheSpec
 
       awaitAssert {
         replicatedCache ! GetLocationsFromCache(db, namespace, metric)
-        expectMsgType[LocationsCached].value.size shouldBe 22
+        expectMsgType[LocationsCached].locations.size shouldBe 22
       }
 
       awaitAssert {
         replicatedCache ! GetLocationsInNodeFromCache(db, namespace, metric, "node10")
-        expectMsgType[LocationsCached].value.size shouldBe 11
+        expectMsgType[LocationsCached].locations.size shouldBe 11
       }
       awaitAssert {
         replicatedCache ! GetLocationsInNodeFromCache(db, namespace, metric, "node20")
-        expectMsgType[LocationsCached].value.size shouldBe 11
+        expectMsgType[LocationsCached].locations.size shouldBe 11
       }
 
       runOn(node2) {
@@ -482,7 +482,7 @@ class ReplicatedMetadataCacheSpec
 
       awaitAssert {
         replicatedCache ! GetLocationsFromCache(db, namespace, metric)
-        expectMsgType[LocationsCached].value.size shouldBe 11
+        expectMsgType[LocationsCached].locations.size shouldBe 11
       }
 
       runOn(node1) {
@@ -492,7 +492,7 @@ class ReplicatedMetadataCacheSpec
 
       awaitAssert {
         replicatedCache ! GetLocationsFromCache(db, namespace, metric)
-        expectMsgType[LocationsCached].value.size shouldBe 0
+        expectMsgType[LocationsCached].locations.size shouldBe 0
       }
 
       enterBarrier("after-node-evict")

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/split_brain/ClusterSingletonWithSplitBrainResolutionSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/split_brain/ClusterSingletonWithSplitBrainResolutionSpec.scala
@@ -1,6 +1,6 @@
 package io.radicalbit.nsdb.split_brain
 
-import akka.actor.{ActorPath, PoisonPill, Props}
+import akka.actor.{PoisonPill, Props}
 import akka.cluster.Cluster
 import akka.cluster.singleton.{ClusterSingletonManager, ClusterSingletonManagerSettings, ClusterSingletonProxy, ClusterSingletonProxySettings}
 import io.radicalbit.nsdb.split_brain.DatabaseActorsGuardianForTest.WhoAreYou
@@ -38,7 +38,7 @@ abstract class ClusterSingletonWithSplitBrainResolutionSpec extends MultiNodeBas
           settings = ClusterSingletonProxySettings(system)), name = "databaseActorGuardianProxy"
       )
     dbActorGuardian ! WhoAreYou
-    expectMsgType[ActorPath] === ActorPath.fromString("akka://MultiNodeBaseSpec/user/databaseActorGuardian/singleton")
+    expectMsgType[String] === "akka://MultiNodeBaseSpec/user/databaseActorGuardian/singleton"
   }
 
   "MultiJvmTestSpec" must {

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/split_brain/ClusterSingletonWithSplitBrainSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/split_brain/ClusterSingletonWithSplitBrainSpec.scala
@@ -1,6 +1,6 @@
 package io.radicalbit.nsdb.split_brain
 
-import akka.actor.{ActorPath, PoisonPill, Props}
+import akka.actor.{PoisonPill, Props}
 import akka.cluster.Cluster
 import akka.cluster.singleton.{ClusterSingletonManager, ClusterSingletonManagerSettings, ClusterSingletonProxy, ClusterSingletonProxySettings}
 import akka.remote.testconductor.RoleName
@@ -43,7 +43,7 @@ abstract class ClusterSingletonWithSplitBrainSpec
         )
 
       dbActorGuardian ! WhoAreYou
-      expectMsgType[ActorPath] === ActorPath.fromString("akka://MultiNodeBaseSpec/user/databaseActorGuardian/singleton")
+      expectMsgType[String] === "akka://MultiNodeBaseSpec/user/databaseActorGuardian/singleton"
     }
   }
 

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/split_brain/DatabaseActorsGuardianForTest.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/split_brain/DatabaseActorsGuardianForTest.scala
@@ -17,6 +17,6 @@ class DatabaseActorsGuardianForTest extends DatabaseActorsGuardian {
   override def receive: Receive = {
     case WhoAreYou =>
       log.info("Received msg WhoAreYou")
-      sender() ! self.path
+      sender() ! self.path.toString
   }
 }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/split_brain/configs/SplitBrainSpecConfig.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/split_brain/configs/SplitBrainSpecConfig.scala
@@ -88,7 +88,6 @@ trait NSDbBaseSpecWithSerializationConfig {
   protected val serializationConfig =
     ConfigFactory.parseString("""
         |akka.actor {
-        |  allow-java-serialization = on
         |  serialization-bindings {
         |    "io.radicalbit.nsdb.common.protocol.NSDbSerializable" = jackson-json
         |  }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
@@ -25,6 +25,7 @@ import io.radicalbit.nsdb.cluster.actor.MetricsDataActor
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.AddRecordToLocation
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.AddLocations
 import io.radicalbit.nsdb.cluster.coordinator.mockedActors.{LocalMetadataCache, LocalMetadataCoordinator}
+import io.radicalbit.nsdb.cluster.logic.LocalityReadNodesSelection
 import io.radicalbit.nsdb.common.protocol._
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
@@ -106,6 +107,9 @@ abstract class AbstractReadCoordinatorSpec
   val basePath  = "target/test_index/ReadCoordinatorShardSpec"
   val db        = "db"
   val namespace = "registry"
+
+  val readNodesSelection = new LocalityReadNodesSelection("notImportant")
+
   val schemaCoordinator =
     system.actorOf(SchemaCoordinator.props(system.actorOf(Props[FakeSchemaCache])), "schema-coordinator")
   val metadataCoordinator =
@@ -114,7 +118,8 @@ abstract class AbstractReadCoordinatorSpec
     system.actorOf(MetricsDataActor.props(basePath, "node1", Actor.noSender))
   val readCoordinatorActor = system actorOf ReadCoordinator.props(metadataCoordinator,
                                                                   schemaCoordinator,
-                                                                  system.actorOf(Props.empty))
+                                                                  system.actorOf(Props.empty),
+                                                                  readNodesSelection)
 
   override def beforeAll = {
     import scala.concurrent.duration._

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -27,6 +27,7 @@ import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.ExecuteDeleteStatementI
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands._
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.coordinator.mockedActors.{FakeCommitLogCoordinator, LocalMetadataCache}
+import io.radicalbit.nsdb.cluster.logic.CapacityWriteNodesSelectionLogic
 import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Location
@@ -60,6 +61,9 @@ class MetadataCoordinatorSpec
 
   import io.radicalbit.nsdb.cluster.coordinator.mockedActors.LocalMetadataCache._
 
+  val writeNodesSelection = new CapacityWriteNodesSelectionLogic(
+    CapacityWriteNodesSelectionLogic.fromConfigValue(system.settings.config.getString("nsdb.cluster.metrics-selector")))
+
   val probe                = TestProbe()
   val commitLogCoordinator = system.actorOf(Props[FakeCommitLogCoordinator])
   val schemaCache          = system.actorOf(Props[FakeSchemaCache])
@@ -70,7 +74,8 @@ class MetadataCoordinatorSpec
   val clusterListener       = system.actorOf(ClusterListener.props(true))
 
   val metadataCoordinator =
-    system.actorOf(MetadataCoordinator.props(clusterListener, metadataCache, schemaCache, probe.ref))
+    system.actorOf(
+      MetadataCoordinator.props(clusterListener, metadataCache, schemaCache, probe.ref, writeNodesSelection))
 
   val db        = "testDb"
   val namespace = "testNamespace"

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -31,14 +31,9 @@ import io.radicalbit.nsdb.cluster.logic.CapacityWriteNodesSelectionLogic
 import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Location
-import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.{
-  GetMetricInfo,
-  SubscribeCommitLogCoordinator,
-  SubscribeMetricsDataActor,
-  UpdateSchemaFromRecord
-}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.MetricInfoGot
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
+import org.scalatest._
 
 import scala.concurrent.Await
 import scala.concurrent.duration._

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
@@ -74,7 +74,7 @@ class LocalMetadataCoordinator(cache: ActorRef) extends Actor {
     case GetLocations(db, namespace, metric) =>
       (cache ? GetLocationsFromCache(db, namespace, metric))
         .mapTo[LocationsCached]
-        .map(l => LocationsGot(db, namespace, metric, l.value))
+        .map(l => LocationsGot(db, namespace, metric, l.locations))
         .pipeTo(sender())
     case GetWriteLocations(db, namespace, metric, timestamp) =>
       val start = getShardStartIstant(timestamp, defaultShardingInterval)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelectionSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelectionSpec.scala
@@ -35,7 +35,7 @@ class LocalityReadNodesSelectionSpec extends WordSpec with Matchers {
         testLocations("this", 10, 19) ++
         testLocations("that2", 10, 19)
 
-      val uniqueLocations = localityReadNodesSelection.getUniqueLocationsByNode(completelyLocalLocations)
+      val uniqueLocations = localityReadNodesSelection.getDistinctLocationsByNode(completelyLocalLocations)
       uniqueLocations.keySet shouldBe Set("this")
       uniqueLocations("this").sortBy(_.from) shouldBe testLocations("this", 0, 9) ++ testLocations("this", 10, 19)
     }
@@ -50,7 +50,7 @@ class LocalityReadNodesSelectionSpec extends WordSpec with Matchers {
         testLocations("that2", 20, 29) ++
         testLocations("that2", 30, 39)
 
-      val uniqueLocations = localityReadNodesSelection.getUniqueLocationsByNode(scatteredLocations)
+      val uniqueLocations = localityReadNodesSelection.getDistinctLocationsByNode(scatteredLocations)
       uniqueLocations.keySet shouldBe Set("this", "that", "that2")
       uniqueLocations("this").sortBy(_.from) shouldBe testLocations("this", 0, 9)
       uniqueLocations("that").sortBy(_.from) shouldBe testLocations("that", 10, 19) ++ testLocations("that", 20, 29)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelectionSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelectionSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.logic
+
+import io.radicalbit.nsdb.model.Location
+import org.scalatest.{Matchers, WordSpec}
+
+class LocalityReadNodesSelectionSpec extends WordSpec with Matchers {
+
+  val localityReadNodesSelection = new LocalityReadNodesSelection("this")
+
+  private def testLocations(node: String, start: Long, end: Long) = (start to end).map { i =>
+    Location("metric", node, i, i + 1)
+  }
+
+  "LocalityReadNodesSelection" should {
+    "privilege local nodes" in {
+
+      val completelyLocalLocations = testLocations("this", 0, 9) ++
+        testLocations("that", 0, 9) ++
+        testLocations("this", 10, 19) ++
+        testLocations("that2", 10, 19)
+
+      val uniqueLocations = localityReadNodesSelection.getUniqueLocationsByNode(completelyLocalLocations)
+      uniqueLocations.keySet shouldBe Set("this")
+      uniqueLocations("this").sortBy(_.from) shouldBe testLocations("this", 0, 9) ++ testLocations("this", 10, 19)
+    }
+
+    "use the minimum amount of other locations when some shards is not locally available" in {
+
+      val scatteredLocations = testLocations("this", 0, 9) ++
+        testLocations("that", 0, 9) ++
+        testLocations("that", 10, 19) ++
+        testLocations("that2", 10, 19) ++
+        testLocations("that", 20, 29) ++
+        testLocations("that2", 20, 29) ++
+        testLocations("that2", 30, 39)
+
+      val uniqueLocations = localityReadNodesSelection.getUniqueLocationsByNode(scatteredLocations)
+      uniqueLocations.keySet shouldBe Set("this", "that", "that2")
+      uniqueLocations("this").sortBy(_.from) shouldBe testLocations("this", 0, 9)
+      uniqueLocations("that").sortBy(_.from) shouldBe testLocations("that", 10, 19) ++ testLocations("that", 20, 29)
+      uniqueLocations("that2").sortBy(_.from) shouldBe testLocations("that2", 30, 39)
+    }
+  }
+
+}

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -116,10 +116,20 @@ object MessageProtocol {
     case class MetricNotFound(metric: String) extends ErrorCode with NSDbSerializable
     case class Generic()                      extends ErrorCode with NSDbSerializable
 
-    case class DbsGot(dbs: Set[String])                                                         extends NSDbSerializable
-    case class NamespacesGot(db: String, namespaces: Set[String])                               extends NSDbSerializable
-    case class SchemaGot(db: String, namespace: String, metric: String, schema: Option[Schema]) extends NSDbSerializable
-    case class GetSchemaFailed(db: String, namespace: String, metric: String, reason: String)   extends NSDbSerializable
+    case class DbsGot(dbs: Set[String])                           extends NSDbSerializable
+    case class NamespacesGot(db: String, namespaces: Set[String]) extends NSDbSerializable
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes(
+      Array(
+        new JsonSubTypes.Type(value = classOf[GetSchemaResponse], name = "GetSchemaResponse"),
+        new JsonSubTypes.Type(value = classOf[GetSchemaFailed], name = "GetSchemaFailed")
+      ))
+    trait GetSchemaResponse extends NSDbSerializable
+    case class SchemaGot(db: String, namespace: String, metric: String, schema: Option[Schema])
+        extends GetSchemaResponse
+    case class GetSchemaFailed(db: String, namespace: String, metric: String, reason: String) extends GetSchemaResponse
+
     case class MetricInfoGot(db: String, namespace: String, metric: String, metricInfo: Option[MetricInfo])
         extends NSDbSerializable
     case class SchemaCached(db: String, namespace: String, metric: String, schema: Option[Schema])

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
@@ -65,18 +65,15 @@ trait WebResources extends WsResources with SSLSupport { this: NsdbSecurity =>
 
         val http: Future[Http.ServerBinding] =
           if (isSSLEnabled) {
-            val port = config.getInt("nsdb.http.https-port")
-            logger.info(s"Cluster Apis started with https protocol on port $port")
-            httpExt.bindAndHandle(
-              withCors(withNSDbVersion(api)),
-              config.getString(HttpInterface),
-              config.getInt(HttpsPort),
-              connectionContext = serverContext
-            )
+            val interface = config.getString(HttpInterface)
+            val port      = config.getInt(HttpsPort)
+            logger.info(s"Cluster Apis started with https protocol at interface $interface on port $port")
+            httpExt.bindAndHandle(withCors(withNSDbVersion(api)), interface, port, connectionContext = serverContext)
           } else {
-            val port = config.getInt(HttpPort)
-            logger.info(s"Cluster Apis started with http protocol on port $port")
-            httpExt.bindAndHandle(withCors(withNSDbVersion(api)), config.getString(HttpInterface), port)
+            val interface = config.getString(HttpInterface)
+            val port      = config.getInt(HttpPort)
+            logger.info(s"Cluster Apis started with http protocol at interface $interface and port $port")
+            httpExt.bindAndHandle(withCors(withNSDbVersion(api)), interface, port)
           }
 
         scala.sys.addShutdownHook {

--- a/nsdb-it/src/it/resources/logback.xml
+++ b/nsdb-it/src/it/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.out</target>
+        <encoder>
+            <pattern>%date{yyyy-MM-dd} %X{akkaTimestamp} %-5level[%thread] %X{actorName} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+
+    <logger name="com.ning.http.client" level="WARN"/>
+    <logger name="io.grpc.netty" level="WARN"/>
+    <logger name="io.netty" level="WARN"/>
+    <logger name="akka" level="ERROR" />
+    <logger name="com.typesafe" level="ERROR"/>
+
+    <root level="ERROR">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/test/MiniClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/test/MiniClusterSpec.scala
@@ -17,6 +17,7 @@
 package io.radicalbit.nsdb.test
 
 import java.time.Duration
+import java.util.logging.{Level, Logger}
 
 import io.radicalbit.nsdb.minicluster.NsdbMiniCluster
 import org.json4s.DefaultFormats
@@ -25,6 +26,8 @@ import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 trait MiniClusterSpec extends FunSuite with BeforeAndAfterAll with Eventually with NsdbMiniCluster {
+
+  Logger.getLogger("io.grpc.internal").setLevel(Level.OFF)
 
   val nodesNumber: Int
 

--- a/nsdb-it/src/main/resources/nsdb-minicluster.conf
+++ b/nsdb-it/src/main/resources/nsdb-minicluster.conf
@@ -55,6 +55,7 @@ nsdb {
   cluster {
     replication-factor = 2
     consistency-level = 1
+    metrics-selector = disk
     mode = native
     required-contact-point-nr = 3
     metadata-write-consistency = "all"

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/client/rpc/GRPCClient.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/client/rpc/GRPCClient.scala
@@ -16,6 +16,8 @@
 
 package io.radicalbit.nsdb.client.rpc
 
+import java.util.concurrent.TimeUnit
+
 import io.grpc.{ManagedChannel, ManagedChannelBuilder}
 import io.radicalbit.nsdb.rpc.health.{HealthCheckRequest, HealthCheckResponse, HealthGrpc}
 import io.radicalbit.nsdb.rpc.init._
@@ -86,5 +88,7 @@ class GRPCClient(host: String, port: Int) {
     log.debug("Preparing of command describe metric for namespace: {} ", request.namespace)
     stubCommand.describeMetric(request)
   }
+
+  def close(): Unit = channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS)
 
 }

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/client/rpc/GRPCServer.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/client/rpc/GRPCServer.scala
@@ -59,9 +59,11 @@ trait GRPCServer {
   protected[this] def parserSQL: SQLStatementParser
 
   sys.addShutdownHook {
-    System.err.println(s"Shutting down gRPC server at interface $interface and port $port since JVM is shutting down")
-    stop()
-    System.err.println(s"Server at interface $interface and port $port shut down")
+    if (!server.isTerminated) {
+      System.err.println(s"Shutting down gRPC server at interface $interface and port $port since JVM is shutting down")
+      stop()
+      System.err.println(s"Server at interface $interface and port $port shut down")
+    }
   }
 
   lazy val server: Server = NettyServerBuilder

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDB.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDB.scala
@@ -138,7 +138,7 @@ case class NSDB(host: String, port: Int)(implicit executionContextExecutor: Exec
   /**
     * Closes the connection. Here any allocated resources must be released.
     */
-  def close(): Unit = {}
+  def close(): Unit = client.close()
 }
 
 /**
@@ -175,7 +175,7 @@ case class Namespace(db: String, name: String) {
     * @param queryString raw query.
     * @return auxiliary [[SQLStatement]] case class.
     */
-  def query(queryString: String) = SQLStatement(db = db, namespace = name, sQLStatement = queryString)
+  def query(queryString: String): SQLStatement = SQLStatement(db = db, namespace = name, sQLStatement = queryString)
 
 }
 


### PR DESCRIPTION
This PR aims at introducing a pluggable `ReadNodesSelection` strategy which has the responsibility to select the distinct locations by node.

The first implementation is `LocalityReadNodesSelection` which privilege local nodes in order to minimize network traffic.

Moreover, minor fixes on serialization and naming have been developed. 