### PR TITLE
Silently Refuse Records Beyond Retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ NSDb is distributed under the [Apache 2](http://www.apache.org/licenses/LICENSE-
 
 * Optimized time series management
 * Focus on read performance [(doc)](docs/Architecture.md)
-* High availability and clustering [(doc)](docs/Architecture.md)
+* High availability and clustering [(doc)](docs/Clustering.md)
 * Ad-hoc publish-subscribe streaming feature (using WebSockets) [(doc)](docs/Websocket.md)
 * SQL like query language [(doc)](docs/SQL_doc.md)
 * Fluent Java / Scala Api [(doc)](docs/JVM_API_doc.md)

--- a/docs/JVM_API_doc.md
+++ b/docs/JVM_API_doc.md
@@ -6,6 +6,50 @@ Despite actual APIs implementation is limited to Java and Scala languages, the s
 
 The main difference between Java and Scala APIs is the way asynchronous calls are handled. In Java, `CompletableFuture` is used, while async results in Scala are wrapped into Scala native `Future`.
 
+## Adding the library to your project
+
+The library artifact is publicly available in a dedicated maven repository, available at https://tools.radicalbit.io/artifactory/public-release/io/radicalbit/nsdb/.
+
+### Release versions
+
+####Maven dependencies:
+
+```
+<project>
+...
+    <repositories>
+        <repository>
+        <id>NSDb</id>
+        <name>NSDb Repo</name>
+        <url>https://tools.radicalbit.io/artifactory/public-release/</url>
+        </repository>
+    </repositories>
+...
+    <dependency>
+        groupId>io.radicalbit.nsdb</groupId>
+        <artifactId>nsdb-java-api</artifactId>
+        <version>1.0.0</version>
+    </dependency>
+...
+    <dependency>
+        groupId>io.radicalbit.nsdb</groupId>
+        <artifactId>nsdb-scala-api_2.12</artifactId>
+        <version>1.0.0</version>
+    </dependency>
+...
+</<project>
+```
+
+####SBT dependencies:
+
+```
+resolvers += "NSDb Public Releases" at "https://tools.radicalbit.io/artifactory/public-release/"
+
+libraryDependencies += "io.radicalbit.nsdb" %% "nsdb-scala-api" % "1.0.0"
+
+libraryDependencies += "io.radicalbit.nsdb" % "nsdb-java-api" % "1.0.0"
+```
+
 # Java API
 
 NSDb implements utility classes to perform writes and to execute queries using **Java language**.

--- a/nsdb-cluster/src/main/resources/nsdb.conf
+++ b/nsdb-cluster/src/main/resources/nsdb.conf
@@ -75,6 +75,8 @@ nsdb {
     # local = metadata is written to the local node then disseminated to the remainings.
     metadata-write-consistency = all
     metadata-write-consistency = ${?METADATA_WRITE_CONSISTENCY}
+    # parallel write-processing guarantees higher throughput while serial write-processing preserves the order of the operations
+    write-processing = parallel
     endpoints = [
       {
         host = ${nsdb.node.hostname}

--- a/nsdb-cluster/src/main/resources/nsdb.conf
+++ b/nsdb-cluster/src/main/resources/nsdb.conf
@@ -86,7 +86,7 @@ nsdb {
   }
 
   sharding {
-    interval = 1d
+    interval = 30d
     interval = ${?SHARD_INTERVAL}
     passivate-after = 1h
     passivate-after = ${?PASSIVATION_PERIOD}

--- a/nsdb-cluster/src/main/resources/nsdb.conf
+++ b/nsdb-cluster/src/main/resources/nsdb.conf
@@ -69,7 +69,11 @@ nsdb {
     mode = ${?CLUSTER_MODE}
     required-contact-point-nr = 1
     required-contact-point-nr = ${?CONTACT_POINT_NR}
-    metadata-write-consistency = "all"
+    # Metadata consistency level
+    # all = metadata is writtem immediatly to all the nodes.
+    # majority = metadata is written immediatly to the majority of the nodes, then disseminated to the remainings.
+    # local = metadata is written to the local node then disseminated to the remainings.
+    metadata-write-consistency = all
     metadata-write-consistency = ${?METADATA_WRITE_CONSISTENCY}
     endpoints = [
       {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbCluster.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbCluster.scala
@@ -19,7 +19,7 @@ package io.radicalbit.nsdb.cluster
 import akka.actor.ActorSystem
 
 /**
-  * Run a concrete Nsdb cluster node according to the configuration provided in `confDir` folder or into the classpath
+  * Run a concrete NSDb cluster node according to the configuration provided in `confDir` folder or into the classpath
   */
 object NsdbCluster extends App with ProductionCluster {
   initMonitoring()

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
@@ -35,7 +35,7 @@ import io.radicalbit.nsdb.cluster.actor.ClusterListener.{DiskOccupationChanged, 
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{AddLocations, RemoveNodeMetadata}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.metrics.NSDbMetrics
-import io.radicalbit.nsdb.cluster.util.{ErrorManagementUtils, FileUtils}
+import io.radicalbit.nsdb.cluster.util.ErrorManagementUtils
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel._
 import io.radicalbit.nsdb.common.protocol.NSDbSerializable
 import io.radicalbit.nsdb.model.LocationWithCoordinates
@@ -45,7 +45,7 @@ import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{
   MetricsDataActorUnSubscribed,
   PublisherUnSubscribed
 }
-import io.radicalbit.nsdb.util.FutureRetryUtility
+import io.radicalbit.nsdb.util.{FileUtils, FutureRetryUtility}
 
 import scala.collection.mutable
 import scala.concurrent.Future

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
@@ -26,7 +26,7 @@ import akka.util.Timeout
 import com.typesafe.config.Config
 import io.radicalbit.nsdb.actors.{MetricAccumulatorActor, MetricReaderActor}
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor._
-import io.radicalbit.nsdb.cluster.util.{FileUtils => NSDbFileUtils}
+import io.radicalbit.nsdb.util.{FileUtils => NSDbFileUtils}
 import io.radicalbit.nsdb.common.protocol.{Bit, NSDbSerializable}
 import io.radicalbit.nsdb.common.statement.DeleteSQLStatement
 import io.radicalbit.nsdb.model.{Location, Schema}

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
@@ -16,7 +16,6 @@
 
 package io.radicalbit.nsdb.cluster.actor
 
-import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorRef, Props}
@@ -26,14 +25,12 @@ import akka.util.Timeout
 import com.typesafe.config.Config
 import io.radicalbit.nsdb.actors.{MetricAccumulatorActor, MetricReaderActor}
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor._
-import io.radicalbit.nsdb.util.{FileUtils => NSDbFileUtils}
 import io.radicalbit.nsdb.common.protocol.{Bit, NSDbSerializable}
 import io.radicalbit.nsdb.common.statement.DeleteSQLStatement
 import io.radicalbit.nsdb.model.{Location, Schema}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.util.ActorPathLogging
-import org.apache.commons.io.FileUtils
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
@@ -42,7 +42,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class MetricsDataActor(val basePath: String, val nodeName: String, commitLogCoordinator: ActorRef)
     extends ActorPathLogging {
 
-  lazy val readParallelism = ReadParallelism(context.system.settings.config.getConfig("nsdb.read.parallelism"))
+  lazy val readParallelism: ReadParallelism = ReadParallelism(
+    context.system.settings.config.getConfig("nsdb.read.parallelism"))
 
   /**
     * Gets or creates reader child actor of class [[MetricReaderActor]] to handle read requests
@@ -113,6 +114,8 @@ class MetricsDataActor(val basePath: String, val nodeName: String, commitLogCoor
         .map(_ => NamespaceDeleted(db, namespace))
         .pipeTo(sender())
     case msg @ DropMetricWithLocations(db, namespace, _, _) =>
+      getOrCreateAccumulator(db, namespace) forward msg
+    case msg @ DisseminateRetention(db, namespace, _, _) =>
       getOrCreateAccumulator(db, namespace) forward msg
     case msg @ EvictShard(db, namespace, _) =>
       getOrCreateAccumulator(db, namespace) forward msg

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
@@ -119,24 +119,6 @@ class MetricsDataActor(val basePath: String, val nodeName: String, commitLogCoor
       getOrCreateAccumulator(db, namespace) forward msg
     case msg @ EvictShard(db, namespace, _) =>
       getOrCreateAccumulator(db, namespace) forward msg
-    case CheckForOutDatedShards(db, namespace, locations) =>
-      val locationGrouped = locations.groupBy(_.metric)
-
-      val shardPath = Option(Paths.get(basePath, db, namespace, "shards"))
-
-      locationGrouped.foreach {
-        case (metric, locations) =>
-          val locationShardsName = locations.map(_.shardName)
-
-          val outdatedSeq = NSDbFileUtils
-            .getMetricshards(shardPath, metric)
-            .toSeq
-            .filterNot(f => locationShardsName.contains(f.getName))
-          outdatedSeq.foreach { outdated =>
-            FileUtils.deleteDirectory(outdated)
-          }
-      }
-
     case msg @ GetCountWithLocations(db, namespace, _, _) =>
       getOrCreateReader(db, namespace) forward msg
     case msg @ ExecuteSelectStatement(statement, _, _, _) =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
@@ -184,7 +184,7 @@ class ReplicatedMetadataCache extends Actor with ActorLogging with WriteConsiste
 
   def receive: Receive = {
     case PutCoordinateInCache(db, namespace, metric) =>
-      (replicator ? Update(coordinatesKey, ORSet(), writeConsistency)(_ :+ Coordinates(db, namespace, metric)))
+      (replicator ? Update(coordinatesKey, ORSet(), metadataWriteConsistency)(_ :+ Coordinates(db, namespace, metric)))
         .map {
           case UpdateSuccess(_, _) =>
             CoordinateCached(db, namespace, metric)
@@ -195,7 +195,7 @@ class ReplicatedMetadataCache extends Actor with ActorLogging with WriteConsiste
     case PutLocationInCache(db, namespace, metric, location) =>
       val metricKey = MetricLocationsCacheKey(db, namespace, metric)
       (for {
-        loc <- (replicator ? Update(metricLocationsKey(metricKey), ORSet(), writeConsistency)(_ :+ location))
+        loc <- (replicator ? Update(metricLocationsKey(metricKey), ORSet(), metadataWriteConsistency)(_ :+ location))
           .map {
             case UpdateSuccess(_, _) =>
               LocationCached(db, namespace, metric, location)
@@ -203,9 +203,9 @@ class ReplicatedMetadataCache extends Actor with ActorLogging with WriteConsiste
               log.error(s"error in put location in cache $e")
               PutLocationInCacheFailed(db, namespace, metric, location)
           }
-        _ <- replicator ? Update(nodeLocationsKey(location.node), ORSet(), writeConsistency)(
+        _ <- replicator ? Update(nodeLocationsKey(location.node), ORSet(), metadataWriteConsistency)(
           _ :+ LocationWithCoordinates(db, namespace, location))
-        _ <- replicator ? Update(coordinatesKey, ORSet(), writeConsistency)(_ :+ Coordinates(db, namespace, metric))
+        _ <- replicator ? Update(coordinatesKey, ORSet(), metadataWriteConsistency)(_ :+ Coordinates(db, namespace, metric))
       } yield loc).pipeTo(sender())
     case PutMetricInfoInCache(metricInfo @ MetricInfo(db, namespace, metric, _, _)) =>
       val key = MetricInfoCacheKey(db, namespace, metric)
@@ -219,8 +219,8 @@ class ReplicatedMetadataCache extends Actor with ActorLogging with WriteConsiste
                 Future(MetricInfoAlreadyExisting(key, metricInfo))
               case None =>
                 (for {
-                  _   <- replicator ? Update(allMetricInfoKey, ORSet(), writeConsistency)(_ :+ metricInfo)
-                  res <- replicator ? Update(metricInfoKey(key), LWWMap(), writeConsistency)(_ :+ (key -> metricInfo))
+                  _   <- replicator ? Update(allMetricInfoKey, ORSet(), metadataWriteConsistency)(_ :+ metricInfo)
+                  res <- replicator ? Update(metricInfoKey(key), LWWMap(), metadataWriteConsistency)(_ :+ (key -> metricInfo))
                 } yield res)
                   .map {
                     case UpdateSuccess(_, _) =>
@@ -230,8 +230,8 @@ class ReplicatedMetadataCache extends Actor with ActorLogging with WriteConsiste
             }
           case NotFound(_, _) =>
             (for {
-              _   <- replicator ? Update(allMetricInfoKey, ORSet(), writeConsistency)(_ :+ metricInfo)
-              res <- replicator ? Update(metricInfoKey(key), LWWMap(), writeConsistency)(_ :+ (key -> metricInfo))
+              _   <- replicator ? Update(allMetricInfoKey, ORSet(), metadataWriteConsistency)(_ :+ metricInfo)
+              res <- replicator ? Update(metricInfoKey(key), LWWMap(), metadataWriteConsistency)(_ :+ (key -> metricInfo))
             } yield res)
               .map {
                 case UpdateSuccess(_, _) =>
@@ -244,8 +244,8 @@ class ReplicatedMetadataCache extends Actor with ActorLogging with WriteConsiste
     case EvictLocation(db, namespace, loc @ Location(metric, node, from, to)) =>
       val metricKey = MetricLocationsCacheKey(db, namespace, metric)
       val f = for {
-        remove <- replicator ? Update(metricLocationsKey(metricKey), ORSet(), writeConsistency)(_ remove loc)
-        _ <- replicator ? Update(nodeLocationsKey(node), ORSet(), writeConsistency)(
+        remove <- replicator ? Update(metricLocationsKey(metricKey), ORSet(), metadataWriteConsistency)(_ remove loc)
+        _ <- replicator ? Update(nodeLocationsKey(node), ORSet(), metadataWriteConsistency)(
           _ remove LocationWithCoordinates(db, namespace, loc))
       } yield remove
       f.map {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCache.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCache.scala
@@ -78,7 +78,7 @@ class ReplicatedSchemaCache extends ActorPathLogging with WriteConsistencyLogic 
   def receive: Receive = {
     case PutSchemaInCache(db, namespace, metric, value) =>
       val key = SchemaKey(db, namespace, metric)
-      (replicator ? Update(namespaceKey(db, namespace), LWWMap(), writeConsistency)(_ :+ (key -> value)))
+      (replicator ? Update(namespaceKey(db, namespace), LWWMap(), metadataWriteConsistency)(_ :+ (key -> value)))
         .map {
           case UpdateSuccess(_, _) =>
             SchemaCached(db, namespace, metric, Some(value))
@@ -87,7 +87,7 @@ class ReplicatedSchemaCache extends ActorPathLogging with WriteConsistencyLogic 
         .pipeTo(sender())
     case EvictSchema(db, namespace, metric) =>
       val key = SchemaKey(db, namespace, metric)
-      (replicator ? Update(namespaceKey(db, namespace), LWWMap(), writeConsistency)(_ remove (address, key)))
+      (replicator ? Update(namespaceKey(db, namespace), LWWMap(), metadataWriteConsistency)(_ remove (address, key)))
         .map(_ => SchemaCached(db, namespace, metric, None))
         .pipeTo(sender)
     case DeleteNamespaceSchema(db, namespace) =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCache.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCache.scala
@@ -25,7 +25,7 @@ import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.actor.ReplicatedSchemaCache._
 import io.radicalbit.nsdb.cluster.coordinator.SchemaCoordinator.commands.DeleteNamespaceSchema
 import io.radicalbit.nsdb.cluster.coordinator.SchemaCoordinator.events.NamespaceSchemaDeleted
-import io.radicalbit.nsdb.cluster.logic.WriteConsistencyLogic
+import io.radicalbit.nsdb.cluster.logic.WriteConfig
 import io.radicalbit.nsdb.common.protocol.NSDbSerializable
 import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
@@ -53,7 +53,7 @@ object ReplicatedSchemaCache {
 /**
   * cluster aware cache to store metric's locations based on [[akka.cluster.ddata.Replicator]]
   */
-class ReplicatedSchemaCache extends ActorPathLogging with WriteConsistencyLogic {
+class ReplicatedSchemaCache extends ActorPathLogging with WriteConfig {
 
   import akka.cluster.ddata.Replicator._
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/SequentialFutureProcessing.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/SequentialFutureProcessing.scala
@@ -33,7 +33,7 @@ import scala.util.{Failure, Success}
   * }}}
   *
   */
-trait SequentialFutureProcessing extends Stash { this: Actor =>
+trait SequentialFutureProcessing { this: Actor with Stash =>
 
   private val waitingBehaviour: Receive = {
     case Continue =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -433,8 +433,8 @@ class MetadataCoordinator(clusterListener: ActorRef,
           else {
             (metadataCache ? GetLocationsFromCache(db, namespace, metric))
               .flatMap {
-                case LocationsCached(_, _, _, values) =>
-                  values.filter(v => v.from <= timestamp && v.to >= timestamp) match {
+                case LocationsCached(_, _, _, locations) =>
+                  locations.filter(location => location.contains(timestamp)) match {
                     case Nil =>
                       for {
                         nodeMetrics <- (clusterListener ? GetNodeMetrics).mapTo[NodeMetricsGot]

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -295,7 +295,7 @@ class MetadataCoordinator(clusterListener: ActorRef,
             .mapTo[LocationsCached]
             .map {
               case LocationsCached(_, _, _, locations) =>
-                log.error(s"checking locations $locations at time $currentTime and retention $retention")
+                log.debug(s"checking locations $locations at time $currentTime and retention $retention")
                 val (locationsToFullyEvict, locationsToPartiallyEvict) =
                   TimeRangeManager.getLocationsToEvict(locations, retention, currentTime)
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
@@ -159,6 +159,10 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
       case WriteLocationsGot(_, _, _, locations) =>
         log.debug(s"received locations for metric $metric, $locations")
         op(locations)
+      case GetWriteLocationsBeyondRetention(_, _, _, _, retention) =>
+        log.warning(
+          s"bit $bit will not be written because its timestamp is beyond retention of $retention. Sending positive response.")
+        Future(InputMapped(db, namespace, metric, bit))
       case GetWriteLocationsFailed(db, namespace, metric, timestamp, reason) =>
         val errorMessage = s"no location found for bit $bit:\n $reason"
         log.error(errorMessage)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
@@ -152,7 +152,8 @@ class GrpcEndpoint(readCoordinator: ActorRef, writeCoordinator: ActorRef, metada
     override def initMetric(request: InitMetricRequest): Future[InitMetricResponse] = {
 
       Try {
-        (Duration(request.shardInterval).toMillis, Duration(request.retention).toMillis)
+        (if (request.shardInterval.nonEmpty) Duration(request.shardInterval).toMillis else 0L,
+         if (request.retention.nonEmpty) Duration(request.retention).toMillis else 0L)
       } match {
         case Success((interval, retention)) =>
           (metadataCoordinator ? PutMetricInfo(

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/WriteConsistencyLogic.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/WriteConsistencyLogic.scala
@@ -19,7 +19,7 @@ package io.radicalbit.nsdb.cluster.logic
 import java.util.concurrent.TimeUnit
 
 import akka.actor.Actor
-import akka.cluster.ddata.Replicator.{WriteAll, WriteConsistency, WriteMajority}
+import akka.cluster.ddata.Replicator.{WriteAll, WriteConsistency, WriteLocal, WriteMajority}
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -32,12 +32,13 @@ trait WriteConsistencyLogic { this: Actor =>
   /**
     * Provides a Write Consistency policy from a config value.
     */
-  protected lazy val writeConsistency: WriteConsistency = {
+  protected lazy val metadataWriteConsistency: WriteConsistency = {
     val configValue = config.getString("nsdb.cluster.metadata-write-consistency")
 
     configValue match {
       case "all"      => WriteAll(timeout)
       case "majority" => WriteMajority(timeout)
+      case "local" => WriteLocal
       case wrongConfigValue =>
         throw new IllegalArgumentException(s"$wrongConfigValue is not a valid value for metadata-write-consistency")
     }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -331,6 +331,14 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
       metadataCoordinator ! GetWriteLocations("db", "namespace", "metric", 0)
 
       awaitAssert{
+        expectMsgType[GetWriteLocationsBeyondRetention]
+      }
+
+      val currentTime = System.currentTimeMillis()
+
+      metadataCoordinator ! GetWriteLocations("db", "namespace", "metric", currentTime)
+
+      awaitAssert{
         val reply = expectMsgType[WriteLocationsGot]
         reply.db shouldBe "db"
         reply.namespace shouldBe "namespace"
@@ -347,7 +355,7 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
 
       enterBarrier("one-node-up")
 
-      metadataCoordinator ! GetWriteLocations("db", "namespace", "metric", 0)
+      metadataCoordinator ! GetWriteLocations("db", "namespace", "metric", currentTime)
 
       awaitAssert{
         val reply = expectMsgType[GetWriteLocationsFailed]

--- a/nsdb-cluster/src/test/resources/application.conf
+++ b/nsdb-cluster/src/test/resources/application.conf
@@ -53,8 +53,8 @@ nsdb {
 
   cluster{
     replication-factor = 1
-
     metrics-selector = disk
+    write-processing = parallel
   }
 
   sharding {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
@@ -16,7 +16,6 @@
 
 package io.radicalbit.nsdb.cluster.actor
 
-import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorRef, ActorSystem, Props}
@@ -29,7 +28,6 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
-import io.radicalbit.nsdb.util.FileUtils
 import org.scalatest.{BeforeAndAfter, FlatSpecLike, Matchers}
 
 import scala.concurrent.Await
@@ -163,42 +161,6 @@ class MetricsDataActorSpec()
     }
 
     expectNoMessage(interval)
-
-  }
-
-  "metricsDataActor" should "delete outdated locations" in within(5.seconds) {
-    val namespaceToCheck = "namespaceToCheck"
-
-    val record = Bit(System.currentTimeMillis, 23, Map("dimension" -> s"dimension"), Map("tag" -> s"tag"))
-
-    val locationToEvict    = Location("metricToCheck", "testNode", 0, 100)
-    val locationNotToEvict = Location("metricToCheck", "testNode", 100, 200)
-
-    probe.send(metricsDataActor, AddRecordToLocation(db, namespaceToCheck, record, locationToEvict))
-    awaitAssert {
-      probe.expectMsgType[RecordAdded]
-    }
-    probe.send(metricsDataActor, AddRecordToLocation(db, namespaceToCheck, record, locationNotToEvict))
-    awaitAssert {
-      probe.expectMsgType[RecordAdded]
-    }
-
-    expectNoMessage(interval)
-
-    awaitAssert {
-      FileUtils
-        .getSubDirs(Paths.get(basePath, db, namespaceToCheck, "shards"))
-        .map(_.getName)
-        .sortBy(identity) shouldBe Seq(locationToEvict.shardName, locationNotToEvict.shardName)
-    }
-
-    probe.send(metricsDataActor, CheckForOutDatedShards(db, namespaceToCheck, Seq(locationNotToEvict)))
-    awaitAssert {
-      FileUtils
-        .getSubDirs(Paths.get(basePath, db, namespaceToCheck, "shards"))
-        .map(_.getName)
-        .sortBy(identity) shouldBe Seq(locationNotToEvict.shardName)
-    }
 
   }
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
@@ -25,11 +25,11 @@ import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.{AddRecordToLocation, DeleteRecordFromLocation}
 import io.radicalbit.nsdb.cluster.coordinator.mockedActors.{LocalMetadataCache, LocalMetadataCoordinator}
-import io.radicalbit.nsdb.cluster.util.FileUtils
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
+import io.radicalbit.nsdb.util.FileUtils
 import org.scalatest.{BeforeAndAfter, FlatSpecLike, Matchers}
 
 import scala.concurrent.Await

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -356,7 +356,9 @@ class MetadataCoordinatorSpec
         probe.send(metadataCoordinator, GetLocations(db, namespace, metric))
         val locationsGot = probe.expectMsgType[LocationsGot]
         locationsGot.locations.sortBy(_.from) shouldBe locations.takeRight(2)
+      }
 
+      awaitAssert {
         val deleteCommand = metricsDataActorProbe.expectMsgType[ExecuteDeleteStatementInternalInLocations]
         deleteCommand.locations shouldBe Seq(locations.takeRight(2).head)
       }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
@@ -22,7 +22,10 @@ import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
-import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache.{AllMetricInfoWithRetentionGot, GetAllMetricInfoWithRetention}
+import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache.{
+  AllMetricInfoWithRetentionGot,
+  GetAllMetricInfoWithRetention
+}
 import io.radicalbit.nsdb.cluster.actor.{ClusterListener, MetricsDataActor}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.PutMetricInfo
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.MetricInfoPut
@@ -180,9 +183,7 @@ class RetentionSpec
           Bit(currentTime + retention - 500, 4L, Map("surname"  -> "Doe"), Map("name" -> "Bill")),
           Bit(currentTime + retention - 300, 5L, Map("surname"  -> "Doe"), Map("name" -> "Frank")),
           Bit(currentTime + retention - 200, 6L, Map("surname"  -> "Doe"), Map("name" -> "Frankie")),
-          Bit(currentTime + retention - 100, 7L, Map("surname"  -> "Doe"), Map("name" -> "Bill")),
-          Bit(currentTime + retention - 20, 8L, Map("surname"   -> "Doe"), Map("name" -> "Frank")),
-          Bit(currentTime + retention - 10, 9L, Map("surname"   -> "Doe"), Map("name" -> "Frankie"))
+          Bit(currentTime + retention - 100, 7L, Map("surname"  -> "Doe"), Map("name" -> "Bill"))
         )
 
         val retention = 2000
@@ -207,26 +208,6 @@ class RetentionSpec
         recordsToTest.foreach { r =>
           probe.send(writeCoordinator, MapInput(r.timestamp, db, namespace, metricWithRetention, r))
           probe.expectMsgType[InputMapped]
-        }
-
-        awaitAssert {
-          probe.send(
-            readCoordinatorActor,
-            selectAllOrderByTimestamp(metricWithRetention)
-          )
-          val result = probe.expectMsgType[SelectStatementExecuted]
-          result.values.size shouldBe 9
-          result.values should be(recordsToTest)
-        }
-
-        awaitAssert {
-          probe.send(
-            readCoordinatorActor,
-            selectAllOrderByTimestamp(metricWithRetention)
-          )
-          val result = probe.expectMsgType[SelectStatementExecuted]
-          result.values.size shouldBe 8
-          result.values should be(recordsToTest.takeRight(8))
         }
 
         awaitAssert {
@@ -285,7 +266,6 @@ class RetentionSpec
             selectAllOrderByTimestamp(metricWithRetention)
           )
           val result = probe.expectMsgType[SelectStatementExecuted].values
-          println(result.size)
           result.size shouldBe 2
           result shouldBe recordsToTest.takeRight(2)
         }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
@@ -52,7 +52,7 @@ class RetentionSpec
           .withValue("akka.actor.provider", ConfigValueFactory.fromAnyRef("cluster"))
           .withValue("nsdb.sharding.interval", ConfigValueFactory.fromAnyRef("5s"))
           .withValue("nsdb.write.scheduler.interval", ConfigValueFactory.fromAnyRef("20ms"))
-          .withValue("nsdb.retention.check.interval", ConfigValueFactory.fromAnyRef("1ms"))
+          .withValue("nsdb.retention.check.interval", ConfigValueFactory.fromAnyRef("50ms"))
       ))
     with ImplicitSender
     with WordSpecLike
@@ -178,7 +178,7 @@ class RetentionSpec
 
         def currentRecords(currentTime: Long, retention: Long): Seq[Bit] = Seq(
           Bit(currentTime + retention - 3000, 1L, Map("surname" -> "Doe"), Map("name" -> "John")),
-          Bit(currentTime + retention - 1500, 2L, Map("surname" -> "Doe"), Map("name" -> "John")),
+          Bit(currentTime + retention - 1000, 2L, Map("surname" -> "Doe"), Map("name" -> "John")),
           Bit(currentTime + retention - 700, 3L, Map("surname"  -> "D"), Map("name"   -> "J")),
           Bit(currentTime + retention - 500, 4L, Map("surname"  -> "Doe"), Map("name" -> "Bill")),
           Bit(currentTime + retention - 300, 5L, Map("surname"  -> "Doe"), Map("name" -> "Frank")),
@@ -268,16 +268,6 @@ class RetentionSpec
           val result = probe.expectMsgType[SelectStatementExecuted].values
           result.size shouldBe 2
           result shouldBe recordsToTest.takeRight(2)
-        }
-
-        awaitAssert {
-          probe.send(
-            readCoordinatorActor,
-            selectAllOrderByTimestamp(metricWithRetention)
-          )
-          val result = probe.expectMsgType[SelectStatementExecuted].values
-          result.size shouldBe 1
-          result shouldBe recordsToTest.takeRight(1)
         }
 
         awaitAssert {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
@@ -52,7 +52,7 @@ class RetentionSpec
           .withValue("akka.actor.provider", ConfigValueFactory.fromAnyRef("cluster"))
           .withValue("nsdb.sharding.interval", ConfigValueFactory.fromAnyRef("5s"))
           .withValue("nsdb.write.scheduler.interval", ConfigValueFactory.fromAnyRef("20ms"))
-          .withValue("nsdb.retention.check.interval", ConfigValueFactory.fromAnyRef("30ms"))
+          .withValue("nsdb.retention.check.interval", ConfigValueFactory.fromAnyRef("1ms"))
       ))
     with ImplicitSender
     with WordSpecLike

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
@@ -173,14 +173,7 @@ class MetricAccumulatorActor(val basePath: String,
       metricsRetention += (metric -> retention)
     case msg @ EvictShard(_, _, location) =>
       Try {
-//        shards.get(location).foreach(_.close())
-//        facetIndexShards.get(location).foreach(_.close())
-//
-//        shards -= location
-//        facetIndexShards -= location
-
         releaseLocation(location)
-
         deleteLocation(location)
       } match {
         case Success(_) =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
@@ -141,7 +141,7 @@ class MetricAccumulatorActor(val basePath: String,
       }
       facetIndexShards.foreach {
         case (k, indexes) =>
-          implicit val writer: IndexWriter = indexes.newIndexWriter
+          implicit val writer: IndexWriter = indexes.getIndexWriter
           indexes.deleteAll()
           writer.close()
           facetIndexShards -= k
@@ -163,7 +163,7 @@ class MetricAccumulatorActor(val basePath: String,
       }
       facetsShardsFromLocations(locations).foreach {
         case (key, Some(indexes)) =>
-          implicit val writer: IndexWriter = indexes.newIndexWriter
+          implicit val writer: IndexWriter = indexes.getIndexWriter
           indexes.deleteAll()
           writer.close()
           indexes.refresh()

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
@@ -99,12 +99,6 @@ class MetricAccumulatorActor(val basePath: String,
     )
   }
 
-  private def deleteLocation(location: Location): Unit = {
-    val path = Paths.get(basePath, db, namespace, "shards", s"${location.shardName}")
-    if (path.toFile.exists())
-      FileUtils.deleteDirectory(path.toFile)
-  }
-
   /**
     * Any existing shard is retrieved, the [[MetricPerformerActor]] is initialized and actual writes are scheduled.
     */
@@ -175,10 +169,17 @@ class MetricAccumulatorActor(val basePath: String,
 
       readerActor ! Broadcast(msg)
       sender() ! MetricDropped(db, namespace, metric)
+    case DisseminateRetention(_, _, metric, retention) =>
+      metricsRetention += (metric -> retention)
     case msg @ EvictShard(_, _, location) =>
       Try {
-        shards -= location
-        facetIndexShards -= location
+//        shards.get(location).foreach(_.close())
+//        facetIndexShards.get(location).foreach(_.close())
+//
+//        shards -= location
+//        facetIndexShards -= location
+
+        releaseLocation(location)
 
         deleteLocation(location)
       } match {

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
@@ -16,6 +16,8 @@
 
 package io.radicalbit.nsdb.actors
 
+import java.nio.file.{Files, Paths}
+import java.util.Comparator
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorRef, Props}
@@ -61,6 +63,15 @@ class MetricPerformerActor(val basePath: String,
     StorageStrategy.withValue(context.system.settings.config.getString(NSDbConfig.HighLevel.StorageStrategy))
 
   private val maxAttempts = context.system.settings.config.getInt("nsdb.write.retry-attempts")
+
+//  private def deleteLocation(location: Location): Unit = {
+//    val path = Paths.get(basePath, db, namespace, "shards", s"${location.shardName}")
+//    log.info("Trying to delete path {}", path)
+//    Files.walk(path).sorted(Comparator.reverseOrder()).iterator().asScala.foreach {
+//      case path if path.toFile.exists() => path.toFile.delete()
+//      case _                            => //do nothing
+//    }
+//  }
 
   def receive: Receive = {
     case PerformShardWrites(opBufferMap) =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
@@ -62,15 +62,6 @@ class MetricPerformerActor(val basePath: String,
 
   private val maxAttempts = context.system.settings.config.getInt("nsdb.write.retry-attempts")
 
-//  private def deleteLocation(location: Location): Unit = {
-//    val path = Paths.get(basePath, db, namespace, "shards", s"${location.shardName}")
-//    log.info("Trying to delete path {}", path)
-//    Files.walk(path).sorted(Comparator.reverseOrder()).iterator().asScala.foreach {
-//      case path if path.toFile.exists() => path.toFile.delete()
-//      case _                            => //do nothing
-//    }
-//  }
-
   def receive: Receive = {
     case PerformShardWrites(opBufferMap) =>
       val groupedByKey = opBufferMap.values.groupBy(_.location)
@@ -142,8 +133,6 @@ class MetricPerformerActor(val basePath: String,
           facetsTaxoWriter.close()
           facetsIndexWriter.close()
       }
-
-      garbageCollectIndexes()
 
       val persistedBits = performedBitOperations
       context.parent ! Refresh(opBufferMap.keys.toSeq, groupedByKey.keys.toSeq)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
@@ -74,8 +74,8 @@ class MetricPerformerActor(val basePath: String,
           val facetIndexes        = getOrCreatefacetIndexesFor(loc)
           val writer: IndexWriter = index.getWriter
 
-          val facetsIndexWriter = facetIndexes.newIndexWriter
-          val facetsTaxoWriter  = facetIndexes.newDirectoryTaxonomyWriter
+          val facetsIndexWriter = facetIndexes.getIndexWriter
+          val facetsTaxoWriter  = facetIndexes.getTaxonomyWriter
 
           ops.foreach {
             case op @ WriteShardOperation(_, _, bit) =>
@@ -167,8 +167,8 @@ class MetricPerformerActor(val basePath: String,
                                            namespace = namespace,
                                            location = loc,
                                            indexStorageStrategy = indexStorageStrategy)
-          val facetsIndexWriter = facets.newIndexWriter
-          val facetsTaxoWriter  = facets.newDirectoryTaxonomyWriter
+          val facetsIndexWriter = facets.getIndexWriter
+          val facetsTaxoWriter  = facets.getTaxonomyWriter
 
           /**
             * compensate the failed action

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
@@ -16,8 +16,6 @@
 
 package io.radicalbit.nsdb.actors
 
-import java.nio.file.{Files, Paths}
-import java.util.Comparator
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorRef, Props}
@@ -189,8 +187,8 @@ class MetricPerformerActor(val basePath: String,
               Try((Seq(index.delete(bit)) ++ facetIndexes.delete(bit)).map(_.get))
             case WriteShardOperation(_, _, bit) =>
               Try(Seq(index.write(bit), facets.write(bit)(facetsIndexWriter, facetsTaxoWriter)).map(_.get))
-            case _ => Success(Seq(0l)) //do nothing for now. Return Success
-          }).getOrElse(Success(Seq(0l)))
+            case _ => Success(Seq(0L)) //do nothing for now. Return Success
+          }).getOrElse(Success(Seq(0L)))
 
           compensation match {
             case Success(_) =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
@@ -378,9 +378,10 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
         actor ! PoisonPill
         actors -= location
       }
-    case Refresh(_, keys) =>
-      keys.foreach { key =>
-        getShardReaderActor(key).foreach(_ ! RefreshShard)
+    case Refresh(_, locations) =>
+      log.info(s"refreshing locations $locations")
+      locations.foreach { location =>
+        getShardReaderActor(location).foreach(_ ! RefreshShard)
       }
   }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
@@ -108,15 +108,15 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
     Option(Paths.get(basePath, db, namespace, "shards").toFile.list())
       .map(_.toSet)
       .getOrElse(Set.empty)
-      .filter(_.split("_").length == 3)
-      .map(_.split("_"))
       .foreach {
-        case Array(metric, from, to) =>
-          val location = Location(metric, nodeName, from.toLong, to.toLong)
+        case shardName if shardName.split("_").length == 3 =>
+          val Array(metric, from, to) = shardName.split("_")
+          val location                = Location(metric, nodeName, from.toLong, to.toLong)
           val shardActor =
             context.actorOf(ShardReaderActor.props(basePath, db, namespace, location), actorName(location))
           context.watch(shardActor)
           actors += (location -> shardActor)
+        case _ => //do nothing
       }
   }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
@@ -379,7 +379,7 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
         actors -= location
       }
     case Refresh(_, locations) =>
-      log.info(s"refreshing locations $locations")
+      log.debug(s"refreshing locations $locations")
       locations.foreach { location =>
         getShardReaderActor(location).foreach(_ ! RefreshShard)
       }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AllFacetIndexes.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AllFacetIndexes.scala
@@ -54,9 +54,9 @@ class AllFacetIndexes(basePath: String,
   private val facetIndexes: Set[FacetIndex] = Set(facetCountIndex, facetSumIndex)
 
   /**
-    * @return the [[org.apache.lucene.facet.taxonomy.TaxonomyWriter]]
+    * @return the [[org.apache.lucene.index.IndexWriter]]
     */
-  def newIndexWriter: IndexWriter =
+  def getIndexWriter: IndexWriter =
     new IndexWriter(
       directory,
       new IndexWriterConfig(new StandardAnalyzer)
@@ -64,7 +64,10 @@ class AllFacetIndexes(basePath: String,
         .setMergedSegmentWarmer(new SimpleMergedSegmentWarmer(InfoStream.NO_OUTPUT))
     )
 
-  def newDirectoryTaxonomyWriter: DirectoryTaxonomyWriter = new DirectoryTaxonomyWriter(taxoDirectory)
+  /**
+    * @return the [[org.apache.lucene.facet.taxonomy.TaxonomyWriter]]
+    */
+  def getTaxonomyWriter: DirectoryTaxonomyWriter = new DirectoryTaxonomyWriter(taxoDirectory)
 
   def write(bit: Bit)(implicit writer: IndexWriter, taxonomyWriter: DirectoryTaxonomyWriter): Try[Long] = {
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Location.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Location.scala
@@ -35,6 +35,12 @@ case class Location(metric: String, node: String, from: Long, to: Long) extends 
   def interval: Interval[Long] = Interval.fromBounds(Closed(from), Closed(to))
 
   /**
+    * Checks if this Location contains the given timestamp.
+    * @param timestamp the timestamp to check.
+    */
+  def contains(timestamp: Long): Boolean = this.from <= timestamp && this.to >= timestamp
+
+  /**
     * Checks if the location is beyond retention upper and lower bounds.
     */
   def isBeyond(retention: Long, currentTime: Long = System.currentTimeMillis()): Boolean =

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Location.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Location.scala
@@ -19,7 +19,7 @@ package io.radicalbit.nsdb.model
 import io.radicalbit.nsdb.common.protocol.NSDbSerializable
 import spire.implicits._
 import spire.math.Interval
-import spire.math.interval.Closed
+import spire.math.interval.{Closed, Open}
 
 /**
   * Metric shard location.
@@ -33,6 +33,12 @@ case class Location(metric: String, node: String, from: Long, to: Long) extends 
   def shardName = s"${metric}_${from}_$to"
 
   def interval: Interval[Long] = Interval.fromBounds(Closed(from), Closed(to))
+
+  /**
+    * Checks if the location is beyond retention upper and lower bounds.
+    */
+  def isBeyond(retention: Long, currentTime: Long = System.currentTimeMillis()): Boolean =
+    !interval.intersects(Interval.fromBounds(Open(currentTime - retention), Open(currentTime + retention)))
 }
 
 object Location {

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -210,7 +210,6 @@ object MessageProtocol {
     case class ShardEvicted(db: String, namespace: String, location: Location)           extends NSDbSerializable
     case class EvictedShardFailed(db: String, namespace: String, location: Location, reason: String)
         extends NSDbSerializable
-    case class CheckForOutDatedShards(db: String, namespace: String, location: Seq[Location]) extends NSDbSerializable
 
     case class CommitLogCoordinatorSubscribed(actor: ActorRef, nodeName: String) extends NSDbSerializable
     case class MetricsDataActorSubscribed(actor: ActorRef, nodeName: String)     extends NSDbSerializable

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -67,6 +67,9 @@ object MessageProtocol {
         extends NSDbSerializable
     case class DeleteNamespace(db: String, namespace: String) extends NSDbSerializable
 
+    case class DisseminateRetention(db: String, namespace: String, metric: String, retention: Long)
+        extends NSDbSerializable
+
     case class UpdateSchemaFromRecord(db: String, namespace: String, metric: String, record: Bit)
         extends NSDbSerializable
     case class UpdateSchema(db: String, namespace: String, metric: String, newSchema: Schema) extends NSDbSerializable

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/TimeRangeManager.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/TimeRangeManager.scala
@@ -119,14 +119,13 @@ object TimeRangeManager {
     * Filters a sequence of [[Location]] given a threshold.
     * Locations that are older that the threshold are returned.
     * @param locations the location with coordinates to evict.
-    * @param threshold the lowest timestamp to keep.
+    * @param currentTime the current timestamp in milliseconds.
+    * @param retention the retention in milliseconds.
     * @return the location that must be completely evicted, and the locations that must be partially evicted.
     */
-  def getLocationsToEvict(locations: Seq[Location], threshold: Long): (Seq[Location], Seq[Location]) = {
-    (locations.filter { l =>
-      l.to < threshold
-    }, locations.filter { l =>
-      l.from <= threshold && l.to >= threshold
-    })
-  }
+  def getLocationsToEvict(locations: Seq[Location],
+                          retention: Long,
+                          currentTime: Long = System.currentTimeMillis()): (Seq[Location], Seq[Location]) =
+    locations.partition(_.isBeyond(retention, currentTime))
+
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/FileUtils.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/FileUtils.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.radicalbit.nsdb.cluster.util
+package io.radicalbit.nsdb.util
 
 import java.io._
 import java.nio.file.{Path, Paths}

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/FacetIndexTest.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/FacetIndexTest.scala
@@ -41,8 +41,8 @@ class FacetIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
         indexStorageStrategy = indexStorageStrategy
       )
 
-    implicit val writer     = facetIndexes.newIndexWriter
-    implicit val taxoWriter = facetIndexes.newDirectoryTaxonomyWriter
+    implicit val writer     = facetIndexes.getIndexWriter
+    implicit val taxoWriter = facetIndexes.getTaxonomyWriter
 
     (1 to 100).foreach { i =>
       val testData =
@@ -89,8 +89,8 @@ class FacetIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
         indexStorageStrategy = indexStorageStrategy
       )
 
-    implicit val writer     = facetIndexes.newIndexWriter
-    implicit val taxoWriter = facetIndexes.newDirectoryTaxonomyWriter
+    implicit val writer     = facetIndexes.getIndexWriter
+    implicit val taxoWriter = facetIndexes.getTaxonomyWriter
 
     (1 to 100).foreach { i =>
       val testData =
@@ -133,8 +133,8 @@ class FacetIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
         indexStorageStrategy = indexStorageStrategy
       )
 
-    implicit val writer     = facetIndexes.newIndexWriter
-    implicit val taxoWriter = facetIndexes.newDirectoryTaxonomyWriter
+    implicit val writer     = facetIndexes.getIndexWriter
+    implicit val taxoWriter = facetIndexes.getTaxonomyWriter
 
     (1 to 100).foreach { i =>
       val testData =
@@ -176,8 +176,8 @@ class FacetIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
         indexStorageStrategy = indexStorageStrategy
       )
 
-    implicit val writer     = facetIndexes.newIndexWriter
-    implicit val taxoWriter = facetIndexes.newDirectoryTaxonomyWriter
+    implicit val writer     = facetIndexes.getIndexWriter
+    implicit val taxoWriter = facetIndexes.getTaxonomyWriter
 
     (1 to 100).foreach { i =>
       val testData =
@@ -196,7 +196,7 @@ class FacetIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
       .result(new MatchAllDocsQuery(), "surname", None, Some(100), VARCHAR())
       .size shouldBe 100
 
-    val deleteWriter = facetIndexes.newIndexWriter
+    val deleteWriter = facetIndexes.getIndexWriter
 
     facetIndexes.delete(
       Bit(timestamp = 100,
@@ -222,8 +222,8 @@ class FacetIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
         indexStorageStrategy = indexStorageStrategy
       )
 
-    implicit val writer     = facetIndexes.newIndexWriter
-    implicit val taxoWriter = facetIndexes.newDirectoryTaxonomyWriter
+    implicit val writer     = facetIndexes.getIndexWriter
+    implicit val taxoWriter = facetIndexes.getTaxonomyWriter
 
     (1 to 100).foreach { i =>
       val factor = i / 4
@@ -286,8 +286,8 @@ class FacetIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
         indexStorageStrategy = indexStorageStrategy
       )
 
-    implicit val writer     = facetIndexes.newIndexWriter
-    implicit val taxoWriter = facetIndexes.newDirectoryTaxonomyWriter
+    implicit val writer     = facetIndexes.getIndexWriter
+    implicit val taxoWriter = facetIndexes.getTaxonomyWriter
 
     (1 to 100).foreach { i =>
       val testData =
@@ -327,8 +327,8 @@ class FacetIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
         indexStorageStrategy = indexStorageStrategy
       )
 
-    implicit val writer     = facetIndexes.newIndexWriter
-    implicit val taxoWriter = facetIndexes.newDirectoryTaxonomyWriter
+    implicit val writer     = facetIndexes.getIndexWriter
+    implicit val taxoWriter = facetIndexes.getTaxonomyWriter
 
     (1 to 100).foreach { i =>
       val factor: Double = 1.2d

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
@@ -343,7 +343,7 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
 
     "executing getLocationsToEvict" should {
 
-      "filter locations given a threshold" in {
+      "filter locations given a retention" in {
         val locationSequence = Seq(
           Location("metric", "node", 0, 5),
           Location("metric", "node", 6, 10),
@@ -352,9 +352,9 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
           Location("metric", "node", 21, 25)
         )
 
-        TimeRangeManager.getLocationsToEvict(locationSequence, 15) shouldBe (
-          Seq(Location("metric", "node", 0, 5), Location("metric", "node", 6, 10)),
-          Seq(Location("metric", "node", 11, 15))
+        TimeRangeManager.getLocationsToEvict(locationSequence, 6, 10) shouldBe (
+          Seq(Location("metric", "node", 16, 20), Location("metric", "node", 21, 25)),
+          Seq(Location("metric", "node", 0, 5), Location("metric", "node", 6, 10), Location("metric", "node", 11, 15))
         )
 
       }

--- a/nsdb-it/src/main/resources/nsdb-minicluster.conf
+++ b/nsdb-it/src/main/resources/nsdb-minicluster.conf
@@ -57,7 +57,8 @@ nsdb {
     metrics-selector = disk
     mode = native
     required-contact-point-nr = 3
-    metadata-write-consistency = "all"
+    metadata-write-consistency = all
+    write-processing = parallel
     endpoints = [
       {
         host = "127.0.0.1"


### PR DESCRIPTION
This PR improves the Retention Capability by silently refusing a record if its timestamp is beyond the metric retention (if it has been set previously).

Previously `if  timestamp > currentTime + retention OR timestamp < currentTime - retention` the record would have been written and deleted afterwards.
With this PR the record will be discarded although a positive response is sent to the caller anyway. A warning log is emitted to track this discarding.
