### PR TITLE
Improve Query Enrichment and Parser Result 

### DIFF
--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/QueryEnriched.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/QueryEnriched.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.web
+
+import io.radicalbit.nsdb.common.statement.SelectSQLStatement
+import io.radicalbit.nsdb.sql.parser.SQLStatementParser
+import io.radicalbit.nsdb.web.routes.Filter
+
+import scala.util.Success
+
+object QueryEnriched {
+
+  def apply(db: String,
+            namespace: String,
+            queryString: String,
+            from: Option[Long],
+            to: Option[Long],
+            filters: Seq[Filter]) =
+    (new SQLStatementParser().parse(db, namespace, queryString), from, to, filters) match {
+      case (Success(statement: SelectSQLStatement), Some(from), Some(to), filters) if filters.nonEmpty =>
+        Some(
+          statement
+            .enrichWithTimeRange("timestamp", from, to)
+            .addConditions(filters.map(f => Filter.unapply(f).get)))
+      case (Success(statement: SelectSQLStatement), None, None, filters) if filters.nonEmpty =>
+        Some(
+          statement
+            .addConditions(filters.map(f => Filter.unapply(f).get)))
+      case (Success(statement: SelectSQLStatement), Some(from), Some(to), _) =>
+        Some(
+          statement
+            .enrichWithTimeRange("timestamp", from, to))
+      case (Success(statement: SelectSQLStatement), _, _, _) =>
+        Some(statement)
+      case _ => None
+    }
+
+}

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/WebSocketSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/WebSocketSpec.scala
@@ -77,7 +77,7 @@ class WebSocketSpec() extends FlatSpec with ScalatestRouteTest with Matchers wit
         val obj: Option[QuerystringRegistrationFailed] = parse(text).extractOpt[QuerystringRegistrationFailed]
 
         obj.isDefined shouldBe true
-        obj.get.reason shouldEqual "not a select query"
+        obj.get.reason shouldEqual "not a select statement"
       }
   }
 
@@ -173,7 +173,7 @@ class WebSocketSpec() extends FlatSpec with ScalatestRouteTest with Matchers wit
           parse(wsClient.expectMessage().asTextMessage.getStrictText).extractOpt[QuerystringRegistrationFailed]
 
         notSelect.isDefined shouldBe true
-        notSelect.get.reason shouldEqual "not a select query"
+        notSelect.get.reason shouldEqual "not a select statement"
 
         wsClient.sendMessage(
           """{"db":"db","namespace":"a","metric":"notAuthorizedMetric","queryString":"INSERT INTO people DIM(name=john) val=23"}""")

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/StatementParserResult.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/StatementParserResult.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.sql.parser
+
+import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
+import io.radicalbit.nsdb.common.protocol.NSDbSerializable
+import io.radicalbit.nsdb.common.statement.{CommandStatement, SQLStatement}
+
+object StatementParserResult {
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+  @JsonSubTypes(
+    Array(
+      new JsonSubTypes.Type(value = classOf[SqlStatementParserSuccess], name = "SqlStatementParserSuccess"),
+      new JsonSubTypes.Type(value = classOf[SqlStatementParserFailure], name = "SqlStatementParserFailure")
+    ))
+  trait SqlStatementParserResult
+
+  case class SqlStatementParserSuccess(queryString: String, statement: SQLStatement)
+      extends SqlStatementParserResult
+      with NSDbSerializable
+  case class SqlStatementParserFailure(queryString: String, error: String)
+      extends SqlStatementParserResult
+      with NSDbSerializable
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+  @JsonSubTypes(
+    Array(
+      new JsonSubTypes.Type(value = classOf[CommandStatementParserSuccess], name = "CommandStatementParserSuccess"),
+      new JsonSubTypes.Type(value = classOf[CommandStatementParserFailure], name = "CommandStatementParserFailure")
+    ))
+  trait CommandStatementParserResult
+
+  case class CommandStatementParserSuccess(inputString: String, statement: CommandStatement)
+      extends CommandStatementParserResult
+      with NSDbSerializable
+  case class CommandStatementParserFailure(inputString: String, error: String)
+      extends CommandStatementParserResult
+      with NSDbSerializable
+
+}

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
@@ -17,9 +17,8 @@
 package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.sql.parser.StatementParserResult.{SqlStatementParserFailure, SqlStatementParserSuccess}
 import org.scalatest.{Matchers, WordSpec}
-
-import scala.util.Success
 
 class AggregationSQLStatementSpec extends WordSpec with Matchers {
 
@@ -29,8 +28,10 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
 
     "receive a select with a group by and one aggregation" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT sum(value) FROM people group by name") should be(
-          Success(
+        val query = "SELECT sum(value) FROM people group by name"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             SelectSQLStatement(
               db = "db",
               namespace = "registry",
@@ -42,8 +43,10 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
           ))
       }
       "parse it successfully if sum(*) is provided" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT sum(*) FROM people group by name") should be(
-          Success(
+        val query = "SELECT sum(*) FROM people group by name"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             SelectSQLStatement(
               db = "db",
               namespace = "registry",
@@ -55,8 +58,10 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
           ))
       }
       "parse it successfully if count(*) is provided" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT count(*) FROM people group by name") should be(
-          Success(
+        val query = "SELECT count(*) FROM people group by name"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             SelectSQLStatement(
               db = "db",
               namespace = "registry",
@@ -71,176 +76,193 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
 
     "receive a select containing a range selection and a group by" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT count(value) FROM people WHERE timestamp IN (2,4) group by name") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("value", Some(CountAggregation)))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp",
-                                                       value1 = AbsoluteComparisonValue(2L),
-                                                       value2 = AbsoluteComparisonValue(4L)))),
-            groupBy = Some(SimpleGroupByAggregation("name"))
-          )))
+        val query = "SELECT count(value) FROM people WHERE timestamp IN (2,4) group by name"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("value", Some(CountAggregation)))),
+              condition = Some(
+                Condition(RangeExpression(dimension = "timestamp",
+                                          value1 = AbsoluteComparisonValue(2L),
+                                          value2 = AbsoluteComparisonValue(4L)))),
+              groupBy = Some(SimpleGroupByAggregation("name"))
+            )
+          ))
       }
     }
 
     "receive a select containing a GTE selection and a group by" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT min(value) FROM people WHERE timestamp >= 10 group by name") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("value", Some(MinAggregation)))),
-            condition = Some(Condition(ComparisonExpression(dimension = "timestamp",
-                                                            comparison = GreaterOrEqualToOperator,
-                                                            value = AbsoluteComparisonValue(10)))),
-            groupBy = Some(SimpleGroupByAggregation("name"))
-          )))
+        val query = "SELECT min(value) FROM people WHERE timestamp >= 10 group by name"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("value", Some(MinAggregation)))),
+              condition = Some(
+                Condition(ComparisonExpression(dimension = "timestamp",
+                                               comparison = GreaterOrEqualToOperator,
+                                               value = AbsoluteComparisonValue(10)))),
+              groupBy = Some(SimpleGroupByAggregation("name"))
+            )
+          ))
       }
     }
 
     "receive a select containing a GT AND a LTE selection and a group by" should {
       "parse it successfully" in {
-        parser.parse(
-          db = "db",
-          namespace = "registry",
-          input = "SELECT max(value) FROM people WHERE timestamp > 2 AND timestamp <= 4 group by name") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("value", Some(MaxAggregation)))),
-            condition = Some(Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp",
-                                                 comparison = GreaterThanOperator,
-                                                 value = AbsoluteComparisonValue(2L)),
-              operator = AndOperator,
-              expression2 = ComparisonExpression(dimension = "timestamp",
-                                                 comparison = LessOrEqualToOperator,
-                                                 value = AbsoluteComparisonValue(4L))
-            ))),
-            groupBy = Some(SimpleGroupByAggregation("name"))
-          )))
+        val query = "SELECT max(value) FROM people WHERE timestamp > 2 AND timestamp <= 4 group by name"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("value", Some(MaxAggregation)))),
+              condition = Some(Condition(TupledLogicalExpression(
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterThanOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
+                operator = AndOperator,
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(4L))
+              ))),
+              groupBy = Some(SimpleGroupByAggregation("name"))
+            )
+          ))
       }
     }
 
     "receive a select containing a ordering statement" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT count(value) FROM people group by name ORDER BY name") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("value", Some(CountAggregation)))),
-            order = Some(AscOrderOperator("name")),
-            groupBy = Some(SimpleGroupByAggregation("name"))
-          )))
+        val query = "SELECT count(value) FROM people group by name ORDER BY name"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("value", Some(CountAggregation)))),
+              order = Some(AscOrderOperator("name")),
+              groupBy = Some(SimpleGroupByAggregation("name"))
+            )
+          ))
       }
     }
 
     "receive a select containing a ordering statement and a limit clause" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT count(value) FROM people group by name ORDER BY name limit 1") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("value", Some(CountAggregation)))),
-            order = Some(AscOrderOperator("name")),
-            groupBy = Some(SimpleGroupByAggregation("name")),
-            limit = Some(LimitOperator(1))
-          )))
+        val query = "SELECT count(value) FROM people group by name ORDER BY name limit 1"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("value", Some(CountAggregation)))),
+              order = Some(AscOrderOperator("name")),
+              groupBy = Some(SimpleGroupByAggregation("name")),
+              limit = Some(LimitOperator(1))
+            )
+          ))
       }
     }
 
     "receive a select containing uuids" should {
       "parse it successfully" in {
-        parser.parse(
-          db = "db",
-          namespace = "registry",
-          input =
-            "select count(value) from people where name = b483a480-832b-473e-a999-5d1a5950858d and surname = b483a480-832b group by surname"
-        ) should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("value", Some(CountAggregation)))),
-            condition = Some(Condition(TupledLogicalExpression(
-              expression1 = EqualityExpression(dimension = "name",
-                                               value = AbsoluteComparisonValue("b483a480-832b-473e-a999-5d1a5950858d")),
-              expression2 = EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("b483a480-832b")),
-              operator = AndOperator
-            ))),
-            groupBy = Some(SimpleGroupByAggregation("surname"))
-          )))
+        val query =
+          "select count(value) from people where name = b483a480-832b-473e-a999-5d1a5950858d and surname = b483a480-832b group by surname"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("value", Some(CountAggregation)))),
+              condition = Some(Condition(TupledLogicalExpression(
+                expression1 =
+                  EqualityExpression(dimension = "name",
+                                     value = AbsoluteComparisonValue("b483a480-832b-473e-a999-5d1a5950858d")),
+                expression2 =
+                  EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("b483a480-832b")),
+                operator = AndOperator
+              ))),
+              groupBy = Some(SimpleGroupByAggregation("surname"))
+            )
+          ))
 
         parser.parse(
           db = "db",
           namespace = "registry",
           input =
             "select count(value) from people where na-me = b483a480-832b-473e-a999-5d1a5950858d and surname = b483a480-832b group by surname"
-        ) shouldBe 'failure
+        ) shouldBe a[SqlStatementParserFailure]
       }
     }
 
     "receive a select containing uuids and more than 2 where" should {
       "parse it successfully" in {
-        parser.parse(
-          db = "db",
-          namespace = "registry",
-          input =
-            "select count(value) from people where prediction = 1.0 and adoptedModel = b483a480-832b-473e-a999-5d1a5950858d and id = c1234-56789 group by id"
-        ) should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("value", Some(CountAggregation)))),
-            condition = Some(Condition(
-              TupledLogicalExpression(
-                EqualityExpression(dimension = "prediction", value = AbsoluteComparisonValue(1.0)),
-                AndOperator,
-                TupledLogicalExpression(
-                  EqualityExpression(dimension = "adoptedModel",
-                                     value = AbsoluteComparisonValue("b483a480-832b-473e-a999-5d1a5950858d")),
-                  AndOperator,
-                  EqualityExpression(dimension = "id", AbsoluteComparisonValue("c1234-56789"))
-                )
-              )
-            )),
-            groupBy = Some(SimpleGroupByAggregation("id"))
-          )))
+        val query =
+          "select count(value) from people where prediction = 1.0 and adoptedModel = b483a480-832b-473e-a999-5d1a5950858d and id = c1234-56789 group by id"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("value", Some(CountAggregation)))),
+              condition = Some(
+                Condition(
+                  TupledLogicalExpression(
+                    EqualityExpression(dimension = "prediction", value = AbsoluteComparisonValue(1.0)),
+                    AndOperator,
+                    TupledLogicalExpression(
+                      EqualityExpression(dimension = "adoptedModel",
+                                         value = AbsoluteComparisonValue("b483a480-832b-473e-a999-5d1a5950858d")),
+                      AndOperator,
+                      EqualityExpression(dimension = "id", AbsoluteComparisonValue("c1234-56789"))
+                    )
+                  )
+                )),
+              groupBy = Some(SimpleGroupByAggregation("id"))
+            )
+          ))
       }
     }
 
     "receive wrong fields" should {
       "fail" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT count(name,surname) FROM people") shouldBe 'failure
+        parser.parse(db = "db", namespace = "registry", input = "SELECT count(name,surname) FROM people") shouldBe a[
+          SqlStatementParserFailure]
       }
     }
 
     "receive a select with a temporal group by with count aggregation in seconds" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT count(value) FROM people group by interval 3 s") should be(
-          Success(
+        val query = "SELECT count(value) FROM people group by interval 3 s"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             SelectSQLStatement(
               db = "db",
               namespace = "registry",
@@ -255,8 +277,10 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
 
     "receive a select with a temporal group by without measure in minutes" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT count(value) FROM people group by interval m") should be(
-          Success(
+        val query = "SELECT count(value) FROM people group by interval m"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             SelectSQLStatement(
               db = "db",
               namespace = "registry",
@@ -270,27 +294,28 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
     }
 
     "receive a select with a temporal group by with count aggregation with a limit" in {
-      parser.parse(db = "db",
-                   namespace = "registry",
-                   input = "select count(value) from people group by interval 1d limit 1") should be(
-        Success(SelectSQLStatement(
-          db = "db",
-          namespace = "registry",
-          metric = "people",
-          distinct = false,
-          fields = ListFields(List(Field("value", Some(CountAggregation)))),
-          groupBy = Some(TemporalGroupByAggregation(86400000, 1, "d")),
-          limit = Some(LimitOperator(1))
-        )))
+      val query = "select count(value) from people group by interval 1d limit 1"
+      parser.parse(db = "db", namespace = "registry", input = query) should be(
+        SqlStatementParserSuccess(
+          query,
+          SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("value", Some(CountAggregation)))),
+            groupBy = Some(TemporalGroupByAggregation(86400000, 1, "d")),
+            limit = Some(LimitOperator(1))
+          )
+        ))
     }
 
     "receive a select with a temporal group by, filtered by time with measure" should {
       "parse it successfully if the interval contains a space" in {
-        parser.parse(
-          db = "db",
-          namespace = "registry",
-          input = "SELECT count(*) FROM people WHERE timestamp > 1 and timestamp < 100 group by interval 2 d") should be(
-          Success(
+        val query = "SELECT count(*) FROM people WHERE timestamp > 1 and timestamp < 100 group by interval 2 d"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             SelectSQLStatement(
               db = "db",
               namespace = "registry",
@@ -312,11 +337,10 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
       }
 
       "parse it successfully if the interval does not contain any space" in {
-        parser.parse(
-          db = "db",
-          namespace = "registry",
-          input = "SELECT count(*) FROM people WHERE timestamp > 1 and timestamp < 100 group by interval 2d") should be(
-          Success(
+        val query = "SELECT count(*) FROM people WHERE timestamp > 1 and timestamp < 100 group by interval 2d"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             SelectSQLStatement(
               db = "db",
               namespace = "registry",
@@ -338,11 +362,10 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
       }
 
       "parse it successfully if an aggregation different from count is provided " in {
-        parser.parse(
-          db = "db",
-          namespace = "registry",
-          input = "SELECT sum(*) FROM people WHERE timestamp > 1 and timestamp < 100 group by interval 2d") should be(
-          Success(
+        val query = "SELECT sum(*) FROM people WHERE timestamp > 1 and timestamp < 100 group by interval 2d"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             SelectSQLStatement(
               db = "db",
               namespace = "registry",

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/CommandStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/CommandStatementSpec.scala
@@ -16,10 +16,9 @@
 
 package io.radicalbit.nsdb.sql.parser
 
-import io.radicalbit.nsdb.common.statement.{DescribeMetric, ShowMetrics, ShowNamespaces, UseNamespace}
+import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.sql.parser.StatementParserResult._
 import org.scalatest.{Matchers, WordSpec}
-
-import scala.util.Success
 
 class CommandStatementSpec extends WordSpec with Matchers {
 
@@ -29,41 +28,47 @@ class CommandStatementSpec extends WordSpec with Matchers {
 
     "receive the request to show the namespaces" should {
       "parse it successfully" in {
-        parser.parse(None, "show namespaces") should be(Success(ShowNamespaces))
+        val command = "show namespaces"
+        parser.parse(None, command) should be(CommandStatementParserSuccess(command, ShowNamespaces))
       }
     }
 
     "receive the request to use a namespace" should {
       "parse it successfully" in {
-        parser.parse(None, "use registry") should be(Success(UseNamespace("registry")))
+        val command = "use registry"
+        parser.parse(None, command) should be(CommandStatementParserSuccess(command, UseNamespace("registry")))
       }
     }
 
     "receive the request to show the metrics" should {
       "not parsing it without specifying a namespace" in {
-        parser.parse(None, "show metrics") shouldBe 'failure
+        parser.parse(None, "show metrics") shouldBe a[CommandStatementParserFailure]
       }
 
       "parse it successfully specifying a namespace" in {
-        parser.parse(Some("registry"), "show metrics") should be(Success(ShowMetrics("db", "registry")))
+        val command = "show metrics"
+        parser.parse(Some("registry"), command) should be(
+          CommandStatementParserSuccess(command, ShowMetrics("db", "registry")))
       }
     }
 
     "receive the request to describe a metric" should {
       "not parsing it without specifying a namespace" in {
-        parser.parse(None, "describe people") shouldBe 'failure
+        parser.parse(None, "describe people") shouldBe a[CommandStatementParserFailure]
       }
 
       "not parsing it without specifying a metric" in {
-        parser.parse(Some("registry"), "describe") shouldBe 'failure
+        parser.parse(Some("registry"), "describe") shouldBe a[CommandStatementParserFailure]
       }
 
       "not parsing it without specifying a namespace and a metric" in {
-        parser.parse(None, "describe") shouldBe 'failure
+        parser.parse(None, "describe") shouldBe a[CommandStatementParserFailure]
       }
 
       "parse it successfully specifying a namespace and a metric" in {
-        parser.parse(Some("registry"), "describe people") should be(Success(DescribeMetric("db", "registry", "people")))
+        val command = "describe people"
+        parser.parse(Some("registry"), command) should be(
+          CommandStatementParserSuccess(command, DescribeMetric("db", "registry", "people")))
       }
     }
   }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
@@ -17,9 +17,8 @@
 package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.sql.parser.StatementParserResult._
 import org.scalatest.{Matchers, WordSpec}
-
-import scala.util.Success
 
 class DeleteSQLStatementSpec extends WordSpec with Matchers {
 
@@ -29,99 +28,120 @@ class DeleteSQLStatementSpec extends WordSpec with Matchers {
 
     "receive a delete without a where condition" should {
       "fail" in {
-        parser.parse(db = "db", namespace = "registry", input = "DELETE FROM people") shouldBe 'failure
+        parser.parse(db = "db", namespace = "registry", input = "DELETE FROM people") shouldBe a[
+          SqlStatementParserFailure]
       }
     }
 
     "receive a delete containing a range selection" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "delete FROM people WHERE timestamp IN (2,4)") should be(
-          Success(DeleteSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            condition = Condition(RangeExpression(dimension = "timestamp",
-                                                  value1 = AbsoluteComparisonValue(2L),
-                                                  value2 = AbsoluteComparisonValue(4L)))
-          )))
+        val query = "delete FROM people WHERE timestamp IN (2,4)"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            DeleteSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              condition = Condition(
+                RangeExpression(dimension = "timestamp",
+                                value1 = AbsoluteComparisonValue(2L),
+                                value2 = AbsoluteComparisonValue(4L)))
+            )
+          ))
       }
 
       "parse it successfully ignoring case" in {
-        parser.parse(db = "db", namespace = "registry", input = "delete FrOm people where timestamp in (2,4)") should be(
-          Success(DeleteSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            condition = Condition(RangeExpression(dimension = "timestamp",
-                                                  value1 = AbsoluteComparisonValue(2),
-                                                  value2 = AbsoluteComparisonValue(4)))
-          )))
+        val query = "delete FrOm people where timestamp in (2,4)"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            DeleteSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              condition = Condition(
+                RangeExpression(dimension = "timestamp",
+                                value1 = AbsoluteComparisonValue(2),
+                                value2 = AbsoluteComparisonValue(4)))
+            )
+          ))
       }
     }
 
     "receive a delete containing a GTE selection" should {
+      val query = "DELETE FROM people WHERE timestamp >= 10"
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "DELETE FROM people WHERE timestamp >= 10") should be(
-          Success(DeleteSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            condition = Condition(ComparisonExpression(dimension = "timestamp",
-                                                       comparison = GreaterOrEqualToOperator,
-                                                       value = AbsoluteComparisonValue(10L)))
-          )))
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            DeleteSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              condition = Condition(
+                ComparisonExpression(dimension = "timestamp",
+                                     comparison = GreaterOrEqualToOperator,
+                                     value = AbsoluteComparisonValue(10L)))
+            )
+          ))
       }
     }
 
     "receive a delete containing a GT AND a LTE selection" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "Delete FROM people WHERE timestamp > 2 AND timestamp <= 4") should be(
-          Success(DeleteSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            condition = Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp",
-                                                 comparison = GreaterThanOperator,
-                                                 value = AbsoluteComparisonValue(2L)),
-              operator = AndOperator,
-              expression2 = ComparisonExpression(dimension = "timestamp",
-                                                 comparison = LessOrEqualToOperator,
-                                                 value = AbsoluteComparisonValue(4L))
-            ))
-          )))
+        val query = "Delete FROM people WHERE timestamp > 2 AND timestamp <= 4"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            DeleteSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              condition = Condition(TupledLogicalExpression(
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterThanOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
+                operator = AndOperator,
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(4L))
+              ))
+            )
+          ))
       }
     }
 
     "receive a delete containing a GTE OR a LT selection" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "DELETE FROM people WHERE NOT timestamp >= 2 OR timestamp < 4") should be(
-          Success(DeleteSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            condition = Condition(NotExpression(
-              expression = TupledLogicalExpression(
-                expression1 = ComparisonExpression(dimension = "timestamp",
-                                                   comparison = GreaterOrEqualToOperator,
-                                                   value = AbsoluteComparisonValue(2L)),
-                operator = OrOperator,
-                expression2 = ComparisonExpression(dimension = "timestamp",
-                                                   comparison = LessThanOperator,
-                                                   value = AbsoluteComparisonValue(4L))
-              )
-            ))
-          )))
+        val query = "DELETE FROM people WHERE NOT timestamp >= 2 OR timestamp < 4"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            DeleteSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              condition = Condition(
+                NotExpression(
+                  expression = TupledLogicalExpression(
+                    expression1 = ComparisonExpression(dimension = "timestamp",
+                                                       comparison = GreaterOrEqualToOperator,
+                                                       value = AbsoluteComparisonValue(2L)),
+                    operator = OrOperator,
+                    expression2 = ComparisonExpression(dimension = "timestamp",
+                                                       comparison = LessThanOperator,
+                                                       value = AbsoluteComparisonValue(4L))
+                  )
+                ))
+            )
+          ))
       }
     }
 
     "receive random string sequences" should {
       "fail" in {
-        parser.parse(db = "db", namespace = "registry", input = "fkjdskjfdlsf") shouldBe 'failure
+        parser.parse(db = "db", namespace = "registry", input = "fkjdskjfdlsf") shouldBe a[SqlStatementParserFailure]
       }
     }
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/InsertSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/InsertSQLStatementSpec.scala
@@ -17,10 +17,9 @@
 package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.NSDbType
-import io.radicalbit.nsdb.common.statement.{InsertSQLStatement, ListAssignment}
+import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.sql.parser.StatementParserResult.SqlStatementParserSuccess
 import org.scalatest.{Matchers, WordSpec}
-
-import scala.util.Success
 
 class InsertSQLStatementSpec extends WordSpec with Matchers {
 
@@ -30,8 +29,10 @@ class InsertSQLStatementSpec extends WordSpec with Matchers {
 
     "receive an insert with a single dimension without tags" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "INSERT INTO people DIM(name=john) VAL=23 ") should be(
-          Success(
+        val query = "INSERT INTO people DIM(name=john) VAL=23 "
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             InsertSQLStatement(
               db = "db",
               namespace = "registry",
@@ -40,15 +41,18 @@ class InsertSQLStatementSpec extends WordSpec with Matchers {
               dimensions = Some(ListAssignment(Map("name" -> NSDbType("john")))),
               tags = None,
               value = 23L
-            ))
+            )
+          )
         )
       }
     }
 
     "receive an insert with a single tag without dimensions" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "INSERT INTO people TAGS(city='new york') VAL=23 ") should be(
-          Success(
+        val query = "INSERT INTO people TAGS(city='new york') VAL=23 "
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             InsertSQLStatement(
               db = "db",
               namespace = "registry",
@@ -57,17 +61,18 @@ class InsertSQLStatementSpec extends WordSpec with Matchers {
               dimensions = None,
               tags = Some(ListAssignment(Map("city" -> NSDbType("new york")))),
               value = 23L
-            ))
+            )
+          )
         )
       }
     }
 
     "receive an insert with a single dimension and a single tag" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "INSERT INTO people DIM(name=john) TAGS(city='new york') VAL=23 ") should be(
-          Success(
+        val query = "INSERT INTO people DIM(name=john) TAGS(city='new york') VAL=23 "
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             InsertSQLStatement(
               db = "db",
               namespace = "registry",
@@ -76,17 +81,18 @@ class InsertSQLStatementSpec extends WordSpec with Matchers {
               dimensions = Some(ListAssignment(Map("name" -> NSDbType("john")))),
               tags = Some(ListAssignment(Map("city"       -> NSDbType("new york")))),
               value = 23L
-            ))
+            )
+          )
         )
       }
     }
 
     "receive an insert with multiple dimensions and a single tag" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "INSERT INTO people DIM(name=john, surname=doe) TAGS(city='new york') VAL=23 ") should be(
-          Success(
+        val query = "INSERT INTO people DIM(name=john, surname=doe) TAGS(city='new york') VAL=23 "
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             InsertSQLStatement(
               db = "db",
               namespace = "registry",
@@ -95,18 +101,18 @@ class InsertSQLStatementSpec extends WordSpec with Matchers {
               dimensions = Some(ListAssignment(Map("name" -> NSDbType("john"), "surname" -> NSDbType("doe")))),
               tags = Some(ListAssignment(Map("city"       -> NSDbType("new york")))),
               value = 23L
-            ))
+            )
+          )
         )
       }
     }
 
     "receive an insert with multiple dimensions, a single tag and a timestamp" should {
       "parse it successfully" in {
-        parser.parse(
-          db = "db",
-          namespace = "registry",
-          input = "INSERT INTO people TS=123456 DIM(name=john, surname=doe) TAGS(city='new york') VAL=23 ") should be(
-          Success(
+        val query = "INSERT INTO people TS=123456 DIM(name=john, surname=doe) TAGS(city='new york') VAL=23 "
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             InsertSQLStatement(
               db = "db",
               namespace = "registry",
@@ -115,17 +121,18 @@ class InsertSQLStatementSpec extends WordSpec with Matchers {
               dimensions = Some(ListAssignment(Map("name" -> NSDbType("john"), "surname" -> NSDbType("doe")))),
               tags = Some(ListAssignment(Map("city"       -> NSDbType("new york")))),
               value = 23L
-            ))
+            )
+          )
         )
       }
     }
 
     "receive an insert with multiple dimensions and tags in int and float format and a timestamp" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "INSERT INTO people TS=123456 DIM(x=1, y=1.5) TAGS(a=3.2, b=4) VAL=23 ") should be(
-          Success(
+        val query = "INSERT INTO people TS=123456 DIM(x=1, y=1.5) TAGS(a=3.2, b=4) VAL=23 "
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             InsertSQLStatement(
               db = "db",
               namespace = "registry",
@@ -134,17 +141,18 @@ class InsertSQLStatementSpec extends WordSpec with Matchers {
               dimensions = Some(ListAssignment(Map("x" -> NSDbType(1), "y"   -> NSDbType(1.5)))),
               tags = Some(ListAssignment(Map("a"       -> NSDbType(3.2), "b" -> NSDbType(4)))),
               value = 23L
-            ))
+            )
+          )
         )
       }
     }
 
     "receive an insert with multiple dimensions in int and float format, a fixed tag, a a timestamp and a float value" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "INSERT INTO people TS=123456 DIM(x=1, y=1.5) TAGS(city='new york') VAL=23.5 ") should be(
-          Success(
+        val query = "INSERT INTO people TS=123456 DIM(x=1, y=1.5) TAGS(city='new york') VAL=23.5 "
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             InsertSQLStatement(
               db = "db",
               namespace = "registry",
@@ -153,33 +161,34 @@ class InsertSQLStatementSpec extends WordSpec with Matchers {
               dimensions = Some(ListAssignment(Map("x" -> NSDbType(1), "y" -> NSDbType(1.5)))),
               tags = Some(ListAssignment(Map("city"    -> NSDbType("new york")))),
               value = 23.5
-            ))
+            )
+          )
         )
       }
     }
 
     "receive a insert metric without dimensions, tags and timestamp" should {
       "succeed" in {
-        parser.parse(db = "db", namespace = "registry", input = "INSERT INTO people val=23 ") should be(
-          Success(
-            InsertSQLStatement(db = "db",
-                               namespace = "registry",
-                               metric = "people",
-                               timestamp = None,
-                               dimensions = None,
-                               tags = None,
-                               value = 23L)
-          )
+        val query = "INSERT INTO people val=23 "
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(query,
+                                    InsertSQLStatement(db = "db",
+                                                       namespace = "registry",
+                                                       metric = "people",
+                                                       timestamp = None,
+                                                       dimensions = None,
+                                                       tags = None,
+                                                       value = 23L))
         )
       }
     }
 
     "receive a insert metric with dimension string with spaces and tags without spaces" should {
       "succeed" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "INSERT INTO people DIM(name = 'spaced string') TAGS(city = chicago) val=23 ") should be(
-          Success(
+        val query = "INSERT INTO people DIM(name = 'spaced string') TAGS(city = chicago) val=23 "
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             InsertSQLStatement(
               db = "db",
               namespace = "registry",
@@ -196,16 +205,16 @@ class InsertSQLStatementSpec extends WordSpec with Matchers {
 
     "receive a insert metric with dimension string with one char" should {
       "succeed" in {
-        parser.parse(db = "db", namespace = "registry", input = "INSERT INTO people DIM(name = 'a') val=23 ") should be(
-          Success(
-            InsertSQLStatement(db = "db",
-                               "registry",
-                               "people",
-                               None,
-                               Some(ListAssignment(Map("name" -> NSDbType("a")))),
-                               tags = None,
-                               23L)
-          )
+        val query = "INSERT INTO people DIM(name = 'a') val=23 "
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(query,
+                                    InsertSQLStatement(db = "db",
+                                                       "registry",
+                                                       "people",
+                                                       None,
+                                                       Some(ListAssignment(Map("name" -> NSDbType("a")))),
+                                                       tags = None,
+                                                       23L))
         )
       }
     }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
@@ -37,10 +37,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
     "receive a select with a relative timestamp value" should {
 
       "parse it successfully using relative time in simple where equality condition" in {
-        val statement =
+        val result =
           parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp = now - 10s")
-        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
+        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
+        statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
@@ -56,13 +57,14 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
       }
 
       "parse it successfully relative time in simple where comparison condition" in {
-        val statement =
+        val result =
           parser.parse(db = "db",
                        namespace = "registry",
                        input = "SELECT name FROM people WHERE timestamp >= now - 10s")
 
-        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
+        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
+        statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
@@ -78,11 +80,12 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
       }
 
       "parse it successfully relative time in simple where comparison condition (now)" in {
-        val statement =
+        val result =
           parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp < now")
 
-        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
+        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
+        statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
@@ -95,15 +98,15 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
       }
 
       "parse it successfully relative time with double comparison condition (AND)" in {
-        val statement =
+        val result =
           parser.parse(db = "db",
                        namespace = "registry",
                        input = "SELECT name FROM people WHERE timestamp < now AND age >= 18")
 
         val now = System.currentTimeMillis()
-
-        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
+        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
+        statement.isInstanceOf[SelectSQLStatement] shouldBe true
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val condition =
@@ -124,14 +127,14 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
       }
 
       "parse it successfully relative time in complex comparison condition (AND/OR)" in {
-        val statement =
+        val result =
           parser.parse(
             db = "db",
             namespace = "registry",
             input = "SELECT name FROM people WHERE timestamp < now and timestamp > now - 2h OR timestamp = now + 4m")
-
-        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
+        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
+        statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
@@ -166,12 +169,12 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
       "parse it successfully using relative time in complex where condition" in {
 
-        val statement = parser.parse(db = "db",
-                                     namespace = "registry",
-                                     input =
-                                       "SELECT name FROM people WHERE timestamp < now + 5s and timestamp > now - 8d")
-        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
+        val result = parser.parse(db = "db",
+                                  namespace = "registry",
+                                  input = "SELECT name FROM people WHERE timestamp < now + 5s and timestamp > now - 8d")
+        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
+        statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
@@ -195,13 +198,14 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
       "parse it successfully using relative time in very complex where condition" in {
 
-        val statement = parser.parse(
+        val result = parser.parse(
           db = "db",
           namespace = "registry",
           input =
             "SELECT name FROM people WHERE timestamp < now + 30d and timestamp > now - 2h AND timestamp = now + 4m")
-        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
+        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
+        statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
@@ -238,13 +242,14 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
       "parse it successfully using relative time in very complex where condition with brackets" in {
 
-        val statement = parser.parse(
+        val result = parser.parse(
           db = "db",
           namespace = "registry",
           input =
             "SELECT name FROM people WHERE (timestamp < now + 30d and timestamp > now - 2h) or timestamp = now + 4m")
-        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
+        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
+        statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
@@ -282,12 +287,13 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
       }
 
       "parse it successfully with a relative timestamp range condition" in {
-        val statement = parser.parse(db = "db",
-                                     namespace = "registry",
-                                     input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, now + 4 s)")
+        val result = parser.parse(db = "db",
+                                  namespace = "registry",
+                                  input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, now + 4 s)")
 
-        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
+        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
+        statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
@@ -309,12 +315,13 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
       }
 
       "parse it successfully with a relative timestamp range condition with unnecessary brackets" in {
-        val statement = parser.parse(db = "db",
-                                     namespace = "registry",
-                                     input = "SELECT name FROM people WHERE (timestamp IN (now - 2 s, now + 4 s))")
+        val result = parser.parse(db = "db",
+                                  namespace = "registry",
+                                  input = "SELECT name FROM people WHERE (timestamp IN (now - 2 s, now + 4 s))")
 
-        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
+        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
+        statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
@@ -336,12 +343,13 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
       }
 
       "parse it successfully with a mixed relative/absolute timestamp range condition" in {
-        val statement = parser.parse(db = "db",
-                                     namespace = "registry",
-                                     input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, 5)")
+        val result = parser.parse(db = "db",
+                                  namespace = "registry",
+                                  input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, 5)")
 
-        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
+        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
+        statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
@@ -17,9 +17,9 @@
 package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
-import org.scalatest.{Matchers, WordSpec}
-import org.scalatest.TryValues._
+import io.radicalbit.nsdb.sql.parser.StatementParserResult._
 import org.scalatest.OptionValues._
+import org.scalatest.{Matchers, WordSpec}
 
 class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
@@ -39,10 +39,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
       "parse it successfully using relative time in simple where equality condition" in {
         val statement =
           parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp = now - 10s")
-        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
-        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression =
           selectSQLStatement.condition.value.expression.asInstanceOf[EqualityExpression[_]]
 
@@ -60,10 +61,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
                        namespace = "registry",
                        input = "SELECT name FROM people WHERE timestamp >= now - 10s")
 
-        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
-        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression =
           selectSQLStatement.condition.value.expression.asInstanceOf[ComparisonExpression[_]]
 
@@ -79,10 +81,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         val statement =
           parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp < now")
 
-        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
-        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression =
           selectSQLStatement.condition.value.expression.asInstanceOf[ComparisonExpression[_]]
 
@@ -99,9 +102,10 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
         val now = System.currentTimeMillis()
 
-        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
 
-        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val condition =
           selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
 
@@ -126,10 +130,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
             namespace = "registry",
             input = "SELECT name FROM people WHERE timestamp < now and timestamp > now - 2h OR timestamp = now + 4m")
 
-        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
-        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
 
         val firstTimestamp =
@@ -165,10 +170,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
                                      namespace = "registry",
                                      input =
                                        "SELECT name FROM people WHERE timestamp < now + 5s and timestamp > now - 8d")
-        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
-        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
 
         val firstTimestamp =
@@ -194,10 +200,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
           namespace = "registry",
           input =
             "SELECT name FROM people WHERE timestamp < now + 30d and timestamp > now - 2h AND timestamp = now + 4m")
-        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
-        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
 
         val firstTimestamp =
@@ -236,10 +243,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
           namespace = "registry",
           input =
             "SELECT name FROM people WHERE (timestamp < now + 30d and timestamp > now - 2h) or timestamp = now + 4m")
-        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
-        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
 
         val thirdTimestamp =
@@ -278,10 +286,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
                                      namespace = "registry",
                                      input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, now + 4 s)")
 
-        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
-        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression =
           selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[_]]
 
@@ -304,10 +313,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
                                      namespace = "registry",
                                      input = "SELECT name FROM people WHERE (timestamp IN (now - 2 s, now + 4 s))")
 
-        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
-        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression =
           selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[_]]
 
@@ -330,10 +340,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
                                      namespace = "registry",
                                      input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, 5)")
 
-        statement.success.value.isInstanceOf[SelectSQLStatement] shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        statement.asInstanceOf[SqlStatementParserSuccess].statement.isInstanceOf[SelectSQLStatement] shouldBe true
         val now = System.currentTimeMillis()
 
-        val selectSQLStatement = statement.success.value.asInstanceOf[SelectSQLStatement]
+        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression =
           selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[_]]
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
@@ -17,6 +17,7 @@
 package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.sql.parser.StatementParserResult._
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Success
@@ -60,7 +61,7 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
         val statement = parser.parse(db = "db",
                                      namespace = "registry",
                                      input = "SELECT name FROM people WHERE (timestamp IN (now - 2 s, now + 4 s))")
-        statement.isSuccess shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
       }
     }
 
@@ -83,7 +84,7 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
           parser.parse(db = "db",
                        namespace = "registry",
                        input = "SELECT name FROM people WHERE (timestamp = now - 10s)")
-        statement.isSuccess shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
       }
     }
 
@@ -121,7 +122,7 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
           parser.parse(db = "db",
                        namespace = "registry",
                        input = "SELECT name FROM people WHERE (timestamp >= now - 10s)")
-        statement.isSuccess shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
       }
     }
 
@@ -152,7 +153,7 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
           namespace = "registry",
           input =
             "SELECT name FROM people WHERE timestamp < now + 30d and (timestamp > now - 2h) AND (timestamp = now + 4m)")
-        statement.isSuccess shouldBe true
+        statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
       }
     }
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
@@ -20,8 +20,6 @@ import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult._
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.util.Success
-
 class SQLStatementBracketsSpec extends WordSpec with Matchers {
 
   private val parser = new SQLStatementParser
@@ -30,53 +28,66 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
 
     "receive a select containing a range selection inside square brackets" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE (timestamp IN (2,4))") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp",
-                                                       value1 = AbsoluteComparisonValue(2L),
-                                                       value2 = AbsoluteComparisonValue(4L))))
-          )))
+        val query = "SELECT name FROM people WHERE (timestamp IN (2,4))"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(RangeExpression(dimension = "timestamp",
+                                          value1 = AbsoluteComparisonValue(2L),
+                                          value2 = AbsoluteComparisonValue(4L))))
+            )
+          ))
       }
 
       "parse it successfully using decimal values" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE (timestamp IN (2, 3.5))") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp",
-                                                       value1 = AbsoluteComparisonValue(2L),
-                                                       value2 = AbsoluteComparisonValue(3.5))))
-          )))
+        val query = "SELECT name FROM people WHERE (timestamp IN (2, 3.5))"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(RangeExpression(dimension = "timestamp",
+                                          value1 = AbsoluteComparisonValue(2L),
+                                          value2 = AbsoluteComparisonValue(3.5))))
+            )
+          ))
       }
 
       "parse it successfully using relative time" in {
-        val statement = parser.parse(db = "db",
-                                     namespace = "registry",
-                                     input = "SELECT name FROM people WHERE (timestamp IN (now - 2 s, now + 4 s))")
+        val query     = "SELECT name FROM people WHERE (timestamp IN (now - 2 s, now + 4 s))"
+        val statement = parser.parse(db = "db", namespace = "registry", input = query)
         statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
       }
     }
 
     "receive a select containing a = selection" should {
       "parse it successfully using string" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE (timestamp = word_word)") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition =
-              Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue("word_word"))))
-          )))
+        val query = "SELECT name FROM people WHERE (timestamp = word_word)"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue("word_word"))))
+            )
+          ))
       }
 
       "parse it successfully using relative time" in {
@@ -90,31 +101,40 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
 
     "receive a select containing a like selection" should {
       "parse it successfully with predicate containing special characters" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE (name like $a_m-e$)") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_m-e$")))
-          )))
+        val query = "SELECT name FROM people WHERE (name like $a_m-e$)"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_m-e$")))
+            )
+          ))
       }
     }
 
     "receive a select containing a GTE selection" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE (timestamp >= 10)") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(ComparisonExpression(dimension = "timestamp",
-                                                            comparison = GreaterOrEqualToOperator,
-                                                            value = AbsoluteComparisonValue(10L))))
-          )))
+        val query = "SELECT name FROM people WHERE (timestamp >= 10)"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(ComparisonExpression(dimension = "timestamp",
+                                               comparison = GreaterOrEqualToOperator,
+                                               value = AbsoluteComparisonValue(10L))))
+            )
+          ))
       }
 
       "parse it successfully using relative time" in {
@@ -128,23 +148,25 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
 
     "receive a select containing a GT AND a = selection" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT name FROM people WHERE (timestamp > 2) AND (timestamp = 4)") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp",
-                                                 comparison = GreaterThanOperator,
-                                                 value = AbsoluteComparisonValue(2L)),
-              operator = AndOperator,
-              expression2 = EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(4L))
-            )))
-          )))
+        val query = "SELECT name FROM people WHERE (timestamp > 2) AND (timestamp = 4)"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(TupledLogicalExpression(
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterThanOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
+                operator = AndOperator,
+                expression2 = EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(4L))
+              )))
+            )
+          ))
       }
 
       "parse it successfully using relative time" in {
@@ -159,141 +181,156 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
 
     "receive a select containing a NOT and a OR expression" should {
       "parse it successfully if not is applied to the or expression" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT name FROM people WHERE NOT (timestamp >= 2 OR timestamp < 4)") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(NotExpression(
-              expression = TupledLogicalExpression(
-                expression1 = ComparisonExpression(dimension = "timestamp",
-                                                   comparison = GreaterOrEqualToOperator,
-                                                   value = AbsoluteComparisonValue(2L)),
+        val query = "SELECT name FROM people WHERE NOT (timestamp >= 2 OR timestamp < 4)"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(NotExpression(
+                  expression = TupledLogicalExpression(
+                    expression1 = ComparisonExpression(dimension = "timestamp",
+                                                       comparison = GreaterOrEqualToOperator,
+                                                       value = AbsoluteComparisonValue(2L)),
+                    operator = OrOperator,
+                    expression2 = ComparisonExpression(dimension = "timestamp",
+                                                       comparison = LessThanOperator,
+                                                       value = AbsoluteComparisonValue(4L))
+                  )
+                )))
+            )
+          ))
+      }
+      "parse it successfully if not is applied only to the first expression" in {
+        val query = "SELECT name FROM people WHERE (NOT timestamp >= 2) OR (timestamp < 4)"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(TupledLogicalExpression(
+                expression1 = NotExpression(ComparisonExpression(dimension = "timestamp",
+                                                                 comparison = GreaterOrEqualToOperator,
+                                                                 value = AbsoluteComparisonValue(2L))),
                 operator = OrOperator,
                 expression2 = ComparisonExpression(dimension = "timestamp",
                                                    comparison = LessThanOperator,
                                                    value = AbsoluteComparisonValue(4L))
-              )
-            )))
-          )))
-      }
-      "parse it successfully if not is applied only to the first expression" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT name FROM people WHERE (NOT timestamp >= 2) OR (timestamp < 4)") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(TupledLogicalExpression(
-              expression1 = NotExpression(ComparisonExpression(dimension = "timestamp",
-                                                               comparison = GreaterOrEqualToOperator,
-                                                               value = AbsoluteComparisonValue(2L))),
-              operator = OrOperator,
-              expression2 = ComparisonExpression(dimension = "timestamp",
-                                                 comparison = LessThanOperator,
-                                                 value = AbsoluteComparisonValue(4L))
-            )))
-          )))
+              )))
+            )
+          ))
       }
 
       "parse it successfully if not is applied both to the whole chain and to an inner condition" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT name FROM people WHERE NOT (timestamp >= 2 OR NOT timestamp < 4)") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(NotExpression(
-              expression = TupledLogicalExpression(
-                expression1 = ComparisonExpression(dimension = "timestamp",
-                                                   comparison = GreaterOrEqualToOperator,
-                                                   value = AbsoluteComparisonValue(2L)),
-                operator = OrOperator,
-                expression2 = NotExpression(ComparisonExpression(dimension = "timestamp",
-                                                                 comparison = LessThanOperator,
-                                                                 value = AbsoluteComparisonValue(4L)))
-              )
-            )))
-          )))
+        val query = "SELECT name FROM people WHERE NOT (timestamp >= 2 OR NOT timestamp < 4)"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(NotExpression(
+                  expression = TupledLogicalExpression(
+                    expression1 = ComparisonExpression(dimension = "timestamp",
+                                                       comparison = GreaterOrEqualToOperator,
+                                                       value = AbsoluteComparisonValue(2L)),
+                    operator = OrOperator,
+                    expression2 = NotExpression(ComparisonExpression(dimension = "timestamp",
+                                                                     comparison = LessThanOperator,
+                                                                     value = AbsoluteComparisonValue(4L)))
+                  )
+                )))
+            )
+          ))
       }
     }
 
     "receive a complex select containing 3 conditions a desc ordering statement and a limit statement" should {
       "parse it successfully when the first 2 expression are in brackets" in {
+        val query =
+          "SELECT name FROM people WHERE (name like $an$ and surname = pippo) and timestamp IN (2,4)  ORDER BY name DESC LIMIT 5"
         parser.parse(
           db = "db",
           namespace = "registry",
-          input =
-            "SELECT name FROM people WHERE (name like $an$ and surname = pippo) and timestamp IN (2,4)  ORDER BY name DESC LIMIT 5"
+          input = query
         ) should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(TupledLogicalExpression(
-              expression1 = TupledLogicalExpression(
-                expression1 = LikeExpression("name", "$an$"),
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(TupledLogicalExpression(
+                expression1 = TupledLogicalExpression(
+                  expression1 = LikeExpression("name", "$an$"),
+                  operator = AndOperator,
+                  expression2 = EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo"))
+                ),
                 operator = AndOperator,
-                expression2 = EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo"))
-              ),
-              operator = AndOperator,
-              expression2 = RangeExpression(dimension = "timestamp",
-                                            value1 = AbsoluteComparisonValue(2),
-                                            value2 = AbsoluteComparisonValue(4))
-            ))),
-            order = Some(DescOrderOperator(dimension = "name")),
-            limit = Some(LimitOperator(5))
-          )))
+                expression2 = RangeExpression(dimension = "timestamp",
+                                              value1 = AbsoluteComparisonValue(2),
+                                              value2 = AbsoluteComparisonValue(4))
+              ))),
+              order = Some(DescOrderOperator(dimension = "name")),
+              limit = Some(LimitOperator(5))
+            )
+          ))
       }
 
       "parse it successfully when the last 2 expression are in brackets" in {
+        val query =
+          "SELECT name FROM people WHERE name like $an$ and (surname = pippo and timestamp IN (2,4))  ORDER BY name DESC LIMIT 5"
         parser.parse(
           db = "db",
           namespace = "registry",
-          input =
-            "SELECT name FROM people WHERE name like $an$ and (surname = pippo and timestamp IN (2,4))  ORDER BY name DESC LIMIT 5"
+          input = query
         ) should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(TupledLogicalExpression(
-              LikeExpression("name", "$an$"),
-              AndOperator,
-              TupledLogicalExpression(
-                EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo")),
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(TupledLogicalExpression(
+                LikeExpression("name", "$an$"),
                 AndOperator,
-                RangeExpression(dimension = "timestamp",
-                                value1 = AbsoluteComparisonValue(2),
-                                value2 = AbsoluteComparisonValue(4))
-              )
-            ))),
-            order = Some(DescOrderOperator(dimension = "name")),
-            limit = Some(LimitOperator(5))
-          )))
+                TupledLogicalExpression(
+                  EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo")),
+                  AndOperator,
+                  RangeExpression(dimension = "timestamp",
+                                  value1 = AbsoluteComparisonValue(2),
+                                  value2 = AbsoluteComparisonValue(4))
+                )
+              ))),
+              order = Some(DescOrderOperator(dimension = "name")),
+              limit = Some(LimitOperator(5))
+            )
+          ))
       }
 
       "receive a select containing a condition of not nullable" in {
-        parser.parse(
-          db = "db",
-          namespace = "registry",
-          input =
-            "select * from AreaOccupancy where (name=MeetingArea) and (name is not null) order by timestamp desc limit 1") shouldBe
-          Success(
+        val query =
+          "select * from AreaOccupancy where (name=MeetingArea) and (name is not null) order by timestamp desc limit 1"
+        parser.parse(db = "db", namespace = "registry", input = query) shouldBe
+          SqlStatementParserSuccess(
+            query,
             SelectSQLStatement(
               db = "db",
               namespace = "registry",
@@ -309,17 +346,20 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
                   ))),
               order = Some(DescOrderOperator(dimension = "timestamp")),
               limit = Some(LimitOperator(1))
-            ))
+            )
+          )
       }
 
       "receive a select containing two conditions of not nullable" in {
+        val query =
+          "select * from AreaOccupancy where (name=MeetingArea and name is not null) or floor is not null order by timestamp desc limit 1"
         parser.parse(
           db = "db",
           namespace = "registry",
-          input =
-            "select * from AreaOccupancy where (name=MeetingArea and name is not null) or floor is not null order by timestamp desc limit 1"
+          input = query
         ) shouldBe
-          Success(
+          SqlStatementParserSuccess(
+            query,
             SelectSQLStatement(
               db = "db",
               namespace = "registry",
@@ -341,42 +381,47 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
                 )),
               order = Some(DescOrderOperator(dimension = "timestamp")),
               limit = Some(LimitOperator(1))
-            ))
+            )
+          )
       }
     }
 
     "receive a complex select containing inner parenthesis" should {
       "parse it correctly" in {
+        val query =
+          "SELECT name FROM people WHERE ((name like $an$ and surname = pippo) and timestamp IN (2,4)) and code is not null  ORDER BY name DESC LIMIT 5"
         parser.parse(
           db = "db",
           namespace = "registry",
-          input =
-            "SELECT name FROM people WHERE ((name like $an$ and surname = pippo) and timestamp IN (2,4)) and code is not null  ORDER BY name DESC LIMIT 5"
+          input = query
         ) should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(TupledLogicalExpression(
-              expression1 = TupledLogicalExpression(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(TupledLogicalExpression(
                 expression1 = TupledLogicalExpression(
-                  expression1 = LikeExpression("name", "$an$"),
+                  expression1 = TupledLogicalExpression(
+                    expression1 = LikeExpression("name", "$an$"),
+                    operator = AndOperator,
+                    expression2 = EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo"))
+                  ),
                   operator = AndOperator,
-                  expression2 = EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo"))
+                  expression2 = RangeExpression(dimension = "timestamp",
+                                                value1 = AbsoluteComparisonValue(2),
+                                                value2 = AbsoluteComparisonValue(4))
                 ),
-                operator = AndOperator,
-                expression2 = RangeExpression(dimension = "timestamp",
-                                              value1 = AbsoluteComparisonValue(2),
-                                              value2 = AbsoluteComparisonValue(4))
-              ),
-              expression2 = NotExpression(NullableExpression("code")),
-              operator = AndOperator
-            ))),
-            order = Some(DescOrderOperator(dimension = "name")),
-            limit = Some(LimitOperator(5))
-          )))
+                expression2 = NotExpression(NullableExpression("code")),
+                operator = AndOperator
+              ))),
+              order = Some(DescOrderOperator(dimension = "name")),
+              limit = Some(LimitOperator(5))
+            )
+          ))
       }
     }
   }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
@@ -17,9 +17,8 @@
 package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.sql.parser.StatementParserResult.{SqlStatementParserFailure, SqlStatementParserSuccess}
 import org.scalatest.{Matchers, WordSpec}
-
-import scala.util.Success
 
 class SelectSQLStatementSpec extends WordSpec with Matchers {
 
@@ -29,52 +28,58 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
 
     "receive a select projecting a wildcard" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT * FROM people") should be(
-          Success(
-            SelectSQLStatement(db = "db",
-                               namespace = "registry",
-                               metric = "people",
-                               distinct = false,
-                               fields = AllFields())))
+        val query = "SELECT * FROM people"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(query,
+                                    SelectSQLStatement(db = "db",
+                                                       namespace = "registry",
+                                                       metric = "people",
+                                                       distinct = false,
+                                                       fields = AllFields())))
       }
     }
 
     "receive a select projecting a wildcard with distinct" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT DISTINCT * FROM people") should be(
-          Success(
-            SelectSQLStatement(db = "db",
-                               namespace = "registry",
-                               metric = "people",
-                               distinct = true,
-                               fields = AllFields())))
+        val query = "SELECT DISTINCT * FROM people"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(query,
+                                    SelectSQLStatement(db = "db",
+                                                       namespace = "registry",
+                                                       metric = "people",
+                                                       distinct = true,
+                                                       fields = AllFields())))
       }
     }
 
     "receive a select projecting a single field" should {
       "parse it successfully with a simple field" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people") should be(
-          Success(
-            SelectSQLStatement(db = "db",
-                               namespace = "registry",
-                               metric = "people",
-                               distinct = false,
-                               fields = ListFields(List(Field("name", None)))))
+        val query = "SELECT name FROM people"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(query,
+                                    SelectSQLStatement(db = "db",
+                                                       namespace = "registry",
+                                                       metric = "people",
+                                                       distinct = false,
+                                                       fields = ListFields(List(Field("name", None)))))
         )
       }
       "parse it successfully with a simple field with distinct" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT DISTINCT name FROM people") should be(
-          Success(
-            SelectSQLStatement(db = "db",
-                               namespace = "registry",
-                               metric = "people",
-                               distinct = true,
-                               fields = ListFields(List(Field("name", None)))))
+        val query = "SELECT DISTINCT name FROM people"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(query,
+                                    SelectSQLStatement(db = "db",
+                                                       namespace = "registry",
+                                                       metric = "people",
+                                                       distinct = true,
+                                                       fields = ListFields(List(Field("name", None)))))
         )
       }
       "parse it successfully with a count aggregated field" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT count(value) FROM people") should be(
-          Success(
+        val query = "SELECT count(value) FROM people"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             SelectSQLStatement(db = "db",
                                namespace = "registry",
                                metric = "people",
@@ -83,18 +88,21 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
         )
       }
       "parse it successfully with a sum aggregated field" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT sum(value) FROM people") should be(
-          Success(
-            SelectSQLStatement(db = "db",
-                               namespace = "registry",
-                               metric = "people",
-                               distinct = false,
-                               fields = ListFields(List(Field("value", Some(SumAggregation))))))
+        val query = "SELECT sum(value) FROM people"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(query,
+                                    SelectSQLStatement(db = "db",
+                                                       namespace = "registry",
+                                                       metric = "people",
+                                                       distinct = false,
+                                                       fields = ListFields(List(Field("value", Some(SumAggregation))))))
         )
       }
       "parse it successfully with a first aggregated field" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT first(value) FROM people") should be(
-          Success(
+        val query = "SELECT first(value) FROM people"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             SelectSQLStatement(db = "db",
                                namespace = "registry",
                                metric = "people",
@@ -103,8 +111,10 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
         )
       }
       "parse it successfully with a last aggregated field" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT last(value) FROM people") should be(
-          Success(
+        val query = "SELECT last(value) FROM people"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
             SelectSQLStatement(db = "db",
                                namespace = "registry",
                                metric = "people",
@@ -113,382 +123,449 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
         )
       }
       "parse it successfully with an aggregated *" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT count(*) FROM people") should be(
-          Success(
-            SelectSQLStatement(db = "db",
-                               namespace = "registry",
-                               metric = "people",
-                               distinct = false,
-                               fields = ListFields(List(Field("*", Some(CountAggregation))))))
+        val query = "SELECT count(*) FROM people"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(query,
+                                    SelectSQLStatement(db = "db",
+                                                       namespace = "registry",
+                                                       metric = "people",
+                                                       distinct = false,
+                                                       fields = ListFields(List(Field("*", Some(CountAggregation))))))
         )
       }
     }
 
     "receive a select projecting a list of fields" should {
       "parse it successfully only with simple fields" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name,surname,creationDate FROM people") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None), Field("surname", None), Field("creationDate", None)))
-          )))
+        val query = "SELECT name,surname,creationDate FROM people"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None), Field("surname", None), Field("creationDate", None)))
+            )
+          ))
       }
 
       "parse it successfully only with simple fields and distinct" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT DISTINCT name,surname,creationDate FROM people") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = true,
-            fields = ListFields(List(Field("name", None), Field("surname", None), Field("creationDate", None)))
-          )))
+        val query = "SELECT DISTINCT name,surname,creationDate FROM people"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = true,
+              fields = ListFields(List(Field("name", None), Field("surname", None), Field("creationDate", None)))
+            )
+          ))
       }
 
       "parse it successfully with mixed aggregated and simple" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT count(*),surname,sum(creationDate) FROM people") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("*", Some(CountAggregation)),
-                                     Field("surname", None),
-                                     Field("creationDate", Some(SumAggregation))))
-          )))
+        val query = "SELECT count(*),surname,sum(creationDate) FROM people"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(
+                List(Field("*", Some(CountAggregation)),
+                     Field("surname", None),
+                     Field("creationDate", Some(SumAggregation))))
+            )
+          ))
       }
     }
 
     "receive a select containing a range selection" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp IN (2,4)") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp",
-                                                       value1 = AbsoluteComparisonValue(2L),
-                                                       value2 = AbsoluteComparisonValue(4L))))
-          )))
+        val query = "SELECT name FROM people WHERE timestamp IN (2,4)"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(RangeExpression(dimension = "timestamp",
+                                          value1 = AbsoluteComparisonValue(2L),
+                                          value2 = AbsoluteComparisonValue(4L))))
+            )
+          ))
       }
 
       "parse it successfully using decimal values" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp IN (2, 3.5)") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp",
-                                                       value1 = AbsoluteComparisonValue(2L),
-                                                       value2 = AbsoluteComparisonValue(3.5))))
-          )))
+        val query = "SELECT name FROM people WHERE timestamp IN (2, 3.5)"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(RangeExpression(dimension = "timestamp",
+                                          value1 = AbsoluteComparisonValue(2L),
+                                          value2 = AbsoluteComparisonValue(3.5))))
+            )
+          ))
       }
     }
 
     "receive a select containing a = selection" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp = 10") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition =
-              Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(10L))))
-          )))
+        val query = "SELECT name FROM people WHERE timestamp = 10"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition =
+                Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(10L))))
+            )
+          ))
       }
 
       "parse it successfully using decimals" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp = 10.5") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition =
-              Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(10.5))))
-          )))
+        val query = "SELECT name FROM people WHERE timestamp = 10.5"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition =
+                Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(10.5))))
+            )
+          ))
       }
 
       "parse it successfully using string" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp = word_word") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition =
-              Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue("word_word"))))
-          )))
+        val query = "SELECT name FROM people WHERE timestamp = word_word"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue("word_word"))))
+            )
+          ))
       }
     }
 
     "receive a select containing a like selection" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE name like $ame$") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(LikeExpression(dimension = "name", value = "$ame$")))
-          )))
+        val query = "SELECT name FROM people WHERE name like $ame$"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(LikeExpression(dimension = "name", value = "$ame$")))
+            )
+          ))
       }
 
       "parse it successfully with predicate containing special characters" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE name like $a_m-e$") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_m-e$")))
-          )))
+        val query = "SELECT name FROM people WHERE name like $a_m-e$"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_m-e$")))
+            )
+          ))
       }
     }
 
     "receive a select containing a GTE selection" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp >= 10") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(ComparisonExpression(dimension = "timestamp",
-                                                            comparison = GreaterOrEqualToOperator,
-                                                            value = AbsoluteComparisonValue(10L))))
-          )))
+        val query = "SELECT name FROM people WHERE timestamp >= 10"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(ComparisonExpression(dimension = "timestamp",
+                                               comparison = GreaterOrEqualToOperator,
+                                               value = AbsoluteComparisonValue(10L))))
+            )
+          ))
       }
     }
 
     "receive a select containing a GT AND a = selection" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT name FROM people WHERE timestamp > 2 AND timestamp = 4") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp",
-                                                 comparison = GreaterThanOperator,
-                                                 value = AbsoluteComparisonValue(2L)),
-              operator = AndOperator,
-              expression2 = EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(4L))
-            )))
-          )))
+        val query = "SELECT name FROM people WHERE timestamp > 2 AND timestamp = 4"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(TupledLogicalExpression(
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterThanOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
+                operator = AndOperator,
+                expression2 = EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(4L))
+              )))
+            )
+          ))
       }
 
       "parse it successfully using decimal values" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT name FROM people WHERE timestamp > 2.4 AND timestamp = 4") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp",
-                                                 comparison = GreaterThanOperator,
-                                                 value = AbsoluteComparisonValue(2.4)),
-              operator = AndOperator,
-              expression2 = EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(4L))
-            )))
-          )))
+        val query = "SELECT name FROM people WHERE timestamp > 2.4 AND timestamp = 4"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(TupledLogicalExpression(
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterThanOperator,
+                                                   value = AbsoluteComparisonValue(2.4)),
+                operator = AndOperator,
+                expression2 = EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(4L))
+              )))
+            )
+          ))
       }
 
     }
 
     "receive a select containing a GT AND a LTE selection" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT name FROM people WHERE timestamp > 2 AND timestamp <= 4") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp",
-                                                 comparison = GreaterThanOperator,
-                                                 value = AbsoluteComparisonValue(2L)),
-              operator = AndOperator,
-              expression2 = ComparisonExpression(dimension = "timestamp",
-                                                 comparison = LessOrEqualToOperator,
-                                                 value = AbsoluteComparisonValue(4L))
-            )))
-          )))
+        val query = "SELECT name FROM people WHERE timestamp > 2 AND timestamp <= 4"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(TupledLogicalExpression(
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterThanOperator,
+                                                   value = AbsoluteComparisonValue(2L)),
+                operator = AndOperator,
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(4L))
+              )))
+            )
+          ))
       }
 
       "parse it successfully using decimal values" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT name FROM people WHERE timestamp > 2.5 AND timestamp <= 4.01") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(TupledLogicalExpression(
-              expression1 = ComparisonExpression(dimension = "timestamp",
-                                                 comparison = GreaterThanOperator,
-                                                 value = AbsoluteComparisonValue(2.5)),
-              operator = AndOperator,
-              expression2 = ComparisonExpression(dimension = "timestamp",
-                                                 comparison = LessOrEqualToOperator,
-                                                 value = AbsoluteComparisonValue(4.01))
-            )))
-          )))
+        val query = "SELECT name FROM people WHERE timestamp > 2.5 AND timestamp <= 4.01"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(TupledLogicalExpression(
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterThanOperator,
+                                                   value = AbsoluteComparisonValue(2.5)),
+                operator = AndOperator,
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessOrEqualToOperator,
+                                                   value = AbsoluteComparisonValue(4.01))
+              )))
+            )
+          ))
       }
     }
 
     "receive a select containing a GTE OR a LT selection" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT name FROM people WHERE NOT timestamp >= 2 OR timestamp < 4") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(NotExpression(
-              expression = TupledLogicalExpression(
-                expression1 = ComparisonExpression(dimension = "timestamp",
-                                                   comparison = GreaterOrEqualToOperator,
-                                                   value = AbsoluteComparisonValue(2L)),
-                operator = OrOperator,
-                expression2 = ComparisonExpression(dimension = "timestamp",
-                                                   comparison = LessThanOperator,
-                                                   value = AbsoluteComparisonValue(4L))
-              )
-            )))
-          )))
+        val query = "SELECT name FROM people WHERE NOT timestamp >= 2 OR timestamp < 4"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(NotExpression(
+                  expression = TupledLogicalExpression(
+                    expression1 = ComparisonExpression(dimension = "timestamp",
+                                                       comparison = GreaterOrEqualToOperator,
+                                                       value = AbsoluteComparisonValue(2L)),
+                    operator = OrOperator,
+                    expression2 = ComparisonExpression(dimension = "timestamp",
+                                                       comparison = LessThanOperator,
+                                                       value = AbsoluteComparisonValue(4L))
+                  )
+                )))
+            )
+          ))
       }
     }
 
     "receive a select containing a ordering statement" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT * FROM people ORDER BY name") should be(
-          Success(
-            SelectSQLStatement(db = "db",
-                               namespace = "registry",
-                               metric = "people",
-                               distinct = false,
-                               fields = AllFields(),
-                               order = Some(AscOrderOperator("name")))))
+        val query = "SELECT * FROM people ORDER BY name"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(query,
+                                    SelectSQLStatement(db = "db",
+                                                       namespace = "registry",
+                                                       metric = "people",
+                                                       distinct = false,
+                                                       fields = AllFields(),
+                                                       order = Some(AscOrderOperator("name")))))
       }
     }
 
     "receive a select containing a limit statement" should {
       "parse it successfully" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT * FROM people LIMIT 10") should be(
-          Success(
-            SelectSQLStatement(db = "db",
-                               namespace = "registry",
-                               metric = "people",
-                               distinct = false,
-                               fields = AllFields(),
-                               limit = Some(LimitOperator(10)))))
+        val query = "SELECT * FROM people LIMIT 10"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(query,
+                                    SelectSQLStatement(db = "db",
+                                                       namespace = "registry",
+                                                       metric = "people",
+                                                       distinct = false,
+                                                       fields = AllFields(),
+                                                       limit = Some(LimitOperator(10)))))
       }
     }
 
     "receive a complex select containing a range selection a desc ordering statement and a limit statement" should {
       "parse it successfully" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "SELECT name FROM people WHERE timestamp IN (2,4) ORDER BY name DESC LIMIT 5") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp",
-                                                       value1 = AbsoluteComparisonValue(2),
-                                                       value2 = AbsoluteComparisonValue(4)))),
-            order = Some(DescOrderOperator(dimension = "name")),
-            limit = Some(LimitOperator(5))
-          )))
+        val query = "SELECT name FROM people WHERE timestamp IN (2,4) ORDER BY name DESC LIMIT 5"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(RangeExpression(dimension = "timestamp",
+                                          value1 = AbsoluteComparisonValue(2),
+                                          value2 = AbsoluteComparisonValue(4)))),
+              order = Some(DescOrderOperator(dimension = "name")),
+              limit = Some(LimitOperator(5))
+            )
+          ))
       }
       "parse it successfully ignoring case" in {
-        parser.parse(db = "db",
-                     namespace = "registry",
-                     input = "sElect name FrOm people where timestamp in (2,4) Order bY name dEsc limit 5") should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(RangeExpression(dimension = "timestamp",
-                                                       value1 = AbsoluteComparisonValue(2),
-                                                       value2 = AbsoluteComparisonValue(4)))),
-            order = Some(DescOrderOperator(dimension = "name")),
-            limit = Some(LimitOperator(5))
-          )))
+        val query = "sElect name FrOm people where timestamp in (2,4) Order bY name dEsc limit 5"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(RangeExpression(dimension = "timestamp",
+                                          value1 = AbsoluteComparisonValue(2),
+                                          value2 = AbsoluteComparisonValue(4)))),
+              order = Some(DescOrderOperator(dimension = "name")),
+              limit = Some(LimitOperator(5))
+            )
+          ))
       }
     }
 
     "receive a complex select containing 3 conditions a desc ordering statement and a limit statement" should {
       "parse it successfully" in {
-        parser.parse(
-          db = "db",
-          namespace = "registry",
-          input =
-            "SELECT name FROM people WHERE name like $an$ and surname = pippo and timestamp IN (2,4)  ORDER BY name DESC LIMIT 5"
-        ) should be(
-          Success(SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(TupledLogicalExpression(
-              LikeExpression("name", "$an$"),
-              AndOperator,
-              TupledLogicalExpression(
-                EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo")),
+        val query =
+          "SELECT name FROM people WHERE name like $an$ and surname = pippo and timestamp IN (2,4)  ORDER BY name DESC LIMIT 5"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(TupledLogicalExpression(
+                LikeExpression("name", "$an$"),
                 AndOperator,
-                RangeExpression(dimension = "timestamp",
-                                value1 = AbsoluteComparisonValue(2),
-                                AbsoluteComparisonValue(4))
-              )
-            ))),
-            order = Some(DescOrderOperator(dimension = "name")),
-            limit = Some(LimitOperator(5))
-          )))
+                TupledLogicalExpression(
+                  EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo")),
+                  AndOperator,
+                  RangeExpression(dimension = "timestamp",
+                                  value1 = AbsoluteComparisonValue(2),
+                                  AbsoluteComparisonValue(4))
+                )
+              ))),
+              order = Some(DescOrderOperator(dimension = "name")),
+              limit = Some(LimitOperator(5))
+            )
+          ))
       }
     }
 
     "receive a complex select containing a equality selection a desc ordering statement and a limit statement" in {
-      parser.parse(
-        db = "db",
-        namespace = "registry",
-        input = "select * from AreaOccupancy where name=MeetingArea order by timestamp desc limit 1") shouldBe
-        Success(
+      val query = "select * from AreaOccupancy where name=MeetingArea order by timestamp desc limit 1"
+      parser.parse(db = "db", namespace = "registry", input = query) shouldBe
+        SqlStatementParserSuccess(
+          query,
           SelectSQLStatement(
             db = "db",
             namespace = "registry",
@@ -498,15 +575,15 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             condition = Some(Condition(EqualityExpression(dimension = "name", AbsoluteComparisonValue("MeetingArea")))),
             order = Some(DescOrderOperator(dimension = "timestamp")),
             limit = Some(LimitOperator(1))
-          ))
+          )
+        )
     }
 
     "receive a select containing condition of nullable" in {
-      parser.parse(
-        db = "db",
-        namespace = "registry",
-        input = "select * from AreaOccupancy where name=MeetingArea and name is null order by timestamp desc limit 1") shouldBe
-        Success(
+      val query = "select * from AreaOccupancy where name=MeetingArea and name is null order by timestamp desc limit 1"
+      parser.parse(db = "db", namespace = "registry", input = query) shouldBe
+        SqlStatementParserSuccess(
+          query,
           SelectSQLStatement(
             db = "db",
             namespace = "registry",
@@ -520,16 +597,16 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
                                         NullableExpression("name")))),
             order = Some(DescOrderOperator(dimension = "timestamp")),
             limit = Some(LimitOperator(1))
-          ))
+          )
+        )
     }
 
     "receive a select containing a condition of not nullable" in {
-      parser.parse(
-        db = "db",
-        namespace = "registry",
-        input =
-          "select * from AreaOccupancy where name=MeetingArea and name is not null order by timestamp desc limit 1") shouldBe
-        Success(
+      val query =
+        "select * from AreaOccupancy where name=MeetingArea and name is not null order by timestamp desc limit 1"
+      parser.parse(db = "db", namespace = "registry", input = query) shouldBe
+        SqlStatementParserSuccess(
+          query,
           SelectSQLStatement(
             db = "db",
             namespace = "registry",
@@ -545,89 +622,99 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
                 ))),
             order = Some(DescOrderOperator(dimension = "timestamp")),
             limit = Some(LimitOperator(1))
-          ))
+          )
+        )
     }
 
     "receive a select containing two conditions of not nullable" in {
-      parser.parse(
-        db = "db",
-        namespace = "registry",
-        input =
-          "select * from AreaOccupancy where name=MeetingArea and name is not null or floor is not null order by timestamp desc limit 1"
-      ) shouldBe
-        Success(
+      val query =
+        "select * from AreaOccupancy where name=MeetingArea and name is not null or floor is not null order by timestamp desc limit 1"
+      parser.parse(db = "db", namespace = "registry", input = query) shouldBe
+        SqlStatementParserSuccess(
+          query,
           SelectSQLStatement(
             db = "db",
             namespace = "registry",
             metric = "AreaOccupancy",
             distinct = false,
             fields = AllFields(),
-            condition = Some(Condition(TupledLogicalExpression(
-              EqualityExpression(dimension = "name", AbsoluteComparisonValue("MeetingArea")),
-              AndOperator,
-              TupledLogicalExpression(
-                NotExpression(NullableExpression("name")),
-                OrOperator,
-                NotExpression(NullableExpression("floor"))
-              )
-            ))),
+            condition = Some(
+              Condition(TupledLogicalExpression(
+                EqualityExpression(dimension = "name", AbsoluteComparisonValue("MeetingArea")),
+                AndOperator,
+                TupledLogicalExpression(
+                  NotExpression(NullableExpression("name")),
+                  OrOperator,
+                  NotExpression(NullableExpression("floor"))
+                )
+              ))),
             order = Some(DescOrderOperator(dimension = "timestamp")),
             limit = Some(LimitOperator(1))
-          ))
+          )
+        )
     }
 
     "receive a select with where condition on string dimension with spaces" in {
-      parser.parse(db = "db",
-                   namespace = "registry",
-                   input = "select name from people where name = 'string spaced' limit 5") should be(
-        Success(SelectSQLStatement(
-          db = "db",
-          namespace = "registry",
-          metric = "people",
-          distinct = false,
-          fields = ListFields(List(Field("name", None))),
-          condition =
-            Some(Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("string spaced")))),
-          limit = Some(LimitOperator(5))
-        )))
+      val query = "select name from people where name = 'string spaced' limit 5"
+      parser.parse(db = "db", namespace = "registry", input = query) should be(
+        SqlStatementParserSuccess(
+          query,
+          SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition =
+              Some(Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("string spaced")))),
+            limit = Some(LimitOperator(5))
+          )
+        ))
     }
 
     "receive a select with where condition on string dimension with one char" in {
-      parser.parse(db = "db", namespace = "registry", input = "select name from people where name = 'a' limit 5") should be(
-        Success(SelectSQLStatement(
-          db = "db",
-          namespace = "registry",
-          metric = "people",
-          distinct = false,
-          fields = ListFields(List(Field("name", None))),
-          condition = Some(Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("a")))),
-          limit = Some(LimitOperator(5))
-        )))
+      val query = "select name from people where name = 'a' limit 5"
+      parser.parse(db = "db", namespace = "registry", input = query) should be(
+        SqlStatementParserSuccess(
+          query,
+          SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("a")))),
+            limit = Some(LimitOperator(5))
+          )
+        ))
     }
 
     "receive random string sequences" should {
       "fail" in {
-        parser.parse(db = "db", namespace = "registry", input = "fkjdskjfdlsf") shouldBe 'failure
+        parser.parse(db = "db", namespace = "registry", input = "fkjdskjfdlsf") shouldBe a[SqlStatementParserFailure]
       }
     }
 
     "receive wrong fields" should {
       "fail" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name surname FROM people") shouldBe 'failure
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name,surname age FROM people") shouldBe 'failure
+        parser.parse(db = "db", namespace = "registry", input = "SELECT name surname FROM people") shouldBe a[
+          SqlStatementParserFailure]
+        parser.parse(db = "db", namespace = "registry", input = "SELECT name,surname age FROM people") shouldBe a[
+          SqlStatementParserFailure]
       }
     }
 
     "receive query with distinct in wrong order " should {
       "fail" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT name, distinct surname FROM people") shouldBe 'failure
+        parser.parse(db = "db", namespace = "registry", input = "SELECT name, distinct surname FROM people") shouldBe a[
+          SqlStatementParserFailure]
       }
     }
 
     "receive a wrong metric without where clause" should {
       "fail" in {
         val f = parser.parse(db = "db", namespace = "registry", input = "SELECT name,surname FROM people cats dogs")
-        f shouldBe 'failure
+        f shouldBe a[SqlStatementParserFailure]
       }
     }
 
@@ -635,7 +722,8 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
       "fail" in {
         parser.parse(db = "db",
                      namespace = "registry",
-                     input = "SELECT name,surname FROM people cats dogs WHERE timestamp > 10") shouldBe 'failure
+                     input = "SELECT name,surname FROM people cats dogs WHERE timestamp > 10") shouldBe a[
+          SqlStatementParserFailure]
       }
     }
   }


### PR DESCRIPTION
This PR aims at 
* creating an isolated object `QueryEnriched` which apply filters to a query.
This object can be reused in other parts of the codebase (e.g. in WebSockets)
* improving SQL and command parser result structures. 
The main benefit is to avoid usage of `Try` in favour of a dedicated adt 
