### PR TITLE
Add Real-Time Filters

### DIFF
--- a/docs/Websocket.md
+++ b/docs/Websocket.md
@@ -25,6 +25,7 @@ The  `retention_size` number of retained messages for each query. It's not manda
 
 **Data params**:
 In order to subscribe a query, after connection is opened, user has to send a POST request providing `db`, `namespace`, `metric` and the query to be subscribed to.
+
 As for Rest Apis, It is possible to specify dynamic filters.<br/> 
 Those filters are internally chained to the provided query where condition using the `AND` operator  
 ```json

--- a/docs/Websocket.md
+++ b/docs/Websocket.md
@@ -24,14 +24,28 @@ The  `retention_size` number of retained messages for each query. It's not manda
 `/ws-stream?refresh_period=200&retention_size=10`
 
 **Data params**:
-In order to subscribe a query, after connection is being opened, user has to send a POST request providing `db`, `namespace`, `metric` and the query to be subscribed to.
-
+In order to subscribe a query, after connection is opened, user has to send a POST request providing `db`, `namespace`, `metric` and the query to be subscribed to.
+As for Rest Apis, It is possible to specify dynamic filters.<br/> 
+Those filters are internally chained to the provided query where condition using the `AND` operator  
 ```json
 {
     "db": "[string]",
     "namespace": "[string]",
     "metric": "[string]",
-    "queryString" : "[string]"
+    "queryString" : "[string]",
+    "from": "[optional timestamp in epoch format]",
+    "to": "[optional timestamp in epoch format]",
+    "filters": "[optional array of Filter]"
+}
+```
+
+Filter object is defines as below:
+
+```json
+{
+    "dimension": "[string]",
+    "value": "[string|numerical depending on dimension type]",
+    "operator" : "[string which value must me in [=, >, >=, <, <=, like]]"
 }
 ```
 
@@ -43,6 +57,35 @@ In order to subscribe a query, after connection is being opened, user has to sen
     "namespace": "namespace",
     "metric": "metric",
     "queryString" : "select * from metric limit 1"
+}
+```
+
+```json
+{
+    "db": "db",
+    "namespace": "namespace",
+    "metric": "people",
+    "queryString": "select * from people limit 100",
+    "from": 0,
+    "to": 100000
+}
+```
+
+```json
+{
+    "db": "db",
+    "namespace": "namespace",
+    "metric": "people",
+    "queryString": "select * from people limit 100",
+    "from": 0,
+    "to": 100000,
+    "filters": [{ "dimension": "dimName1",
+                  "value" : "value",
+                  "operator": "=" },
+                { "dimension": "dimName2",
+                  "value" : 1,
+                  "operator": "=" }
+                ]
 }
 ```
 

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/Bit.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/Bit.scala
@@ -39,7 +39,7 @@ trait TimeSeriesRecord {
 }
 
 /**
-  * Nsdb time series record.
+  * NSDb time series record.
   * A time series record is an object composed of:
   *
   * - a Long timestamp

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -30,6 +30,13 @@ import org.scalatest._
 
 import scala.concurrent.duration._
 
+class EmptyReadCoordinator extends Actor {
+  def receive: Receive = {
+    case ExecuteStatement(statement) =>
+      sender() ! SelectStatementExecuted(statement, values = Seq.empty)
+  }
+}
+
 class PublisherActorSpec
     extends TestKit(ActorSystem("PublisherActorSpec"))
     with ImplicitSender
@@ -37,13 +44,6 @@ class PublisherActorSpec
     with Matchers
     with OneInstancePerTest
     with BeforeAndAfter {
-
-  class EmptyReadCoordinator extends Actor {
-    def receive: Receive = {
-      case ExecuteStatement(statement) =>
-        sender() ! SelectStatementExecuted(statement, values = Seq.empty)
-    }
-  }
 
   val probe      = TestProbe()
   val probeActor = probe.testActor

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -30,13 +30,6 @@ import org.scalatest._
 
 import scala.concurrent.duration._
 
-class FakeReadCoordinatorActor extends Actor {
-  def receive: Receive = {
-    case ExecuteStatement(statement) =>
-      sender() ! SelectStatementExecuted(statement, values = Seq.empty)
-  }
-}
-
 class PublisherActorSpec
     extends TestKit(ActorSystem("PublisherActorSpec"))
     with ImplicitSender
@@ -45,12 +38,19 @@ class PublisherActorSpec
     with OneInstancePerTest
     with BeforeAndAfter {
 
+  class EmptyReadCoordinator extends Actor {
+    def receive: Receive = {
+      case ExecuteStatement(statement) =>
+        sender() ! SelectStatementExecuted(statement, values = Seq.empty)
+    }
+  }
+
   val probe      = TestProbe()
   val probeActor = probe.testActor
   val publisherActor =
     TestActorRef[PublisherActor](
       PublisherActor.props(
-        system.actorOf(Props[FakeReadCoordinatorActor].withDispatcher("akka.actor.control-aware-dispatcher"))))
+        system.actorOf(Props[EmptyReadCoordinator].withDispatcher("akka.actor.control-aware-dispatcher"))))
 
   val testSqlStatement = SelectSQLStatement(
     db = "db",

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
@@ -18,102 +18,17 @@ package io.radicalbit.nsdb.web
 
 import akka.actor.ActorRef
 import akka.event.LoggingAdapter
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.util.Timeout
 import com.typesafe.config.Config
-import io.radicalbit.nsdb.common._
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel._
-import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.security.http.NSDBAuthProvider
 import io.radicalbit.nsdb.web.routes._
 import io.radicalbit.nsdb.web.swagger.SwaggerDocService
-import io.radicalbit.nsdb.web.validation.FieldErrorInfo
 import org.json4s.Formats
-import spray.json._
 
 import scala.concurrent.ExecutionContext
-
-object Formats extends DefaultJsonProtocol with SprayJsonSupport {
-
-  implicit object NSDbTypeJsonFormat extends RootJsonFormat[NSDbType] {
-    def write(c: NSDbType): JsValue = c match {
-      case NSDbDoubleType(v) => JsNumber(v)
-      case NSDbLongType(v)   => JsNumber(v)
-      case NSDbIntType(v)    => JsNumber(v)
-      case NSDbStringType(v) => JsString(v.toString)
-    }
-    def read(value: JsValue): NSDbType = value match {
-      case JsNumber(v) if v.scale > 0   => NSDbDoubleType(v.doubleValue)
-      case JsNumber(v) if v.isValidLong => NSDbLongType(v.longValue)
-      case JsNumber(v) if v.isValidInt  => NSDbIntType(v.intValue)
-      case JsString(v)                  => NSDbStringType(v)
-    }
-  }
-
-  implicit object NSDbNumericTypeJsonFormat extends RootJsonFormat[NSDbNumericType] {
-    def write(c: NSDbNumericType): JsValue = c match {
-      case NSDbDoubleType(v) => JsNumber(v)
-      case NSDbLongType(v)   => JsNumber(v)
-      case NSDbIntType(v)    => JsNumber(v)
-    }
-    def read(value: JsValue): NSDbNumericType = value match {
-      case JsNumber(v) if v.scale > 0   => NSDbDoubleType(v.doubleValue)
-      case JsNumber(v) if v.isValidLong => NSDbLongType(v.longValue)
-      case JsNumber(v) if v.isValidInt  => NSDbIntType(v.intValue)
-    }
-  }
-
-  implicit object NSDbLongTypeJsonFormat extends RootJsonFormat[NSDbLongType] {
-    def write(v: NSDbLongType): JsValue = JsNumber(v.rawValue)
-    def read(value: JsValue): NSDbLongType = value match {
-      case JsNumber(v) if v.isValidLong => NSDbLongType(v.longValue)
-      case JsNumber(v) if v.isValidInt  => NSDbLongType(v.longValue)
-      case v                            => deserializationError(s"value $v cannot be use as a long value")
-    }
-  }
-
-  implicit def enumFormat[T <: Enumeration](implicit enu: T): RootJsonFormat[T#Value] =
-    new RootJsonFormat[T#Value] {
-      def write(obj: T#Value): JsValue = JsString(obj.toString)
-      def read(json: JsValue): T#Value = {
-        json match {
-          case JsString(txt) => enu.withName(txt.replace(" ", "").toUpperCase)
-          case somethingElse =>
-            throw DeserializationException(s"Expected a value from enum $enu instead of $somethingElse")
-        }
-      }
-    }
-
-  implicit val FilterOperatorFormat: RootJsonFormat[FilterOperators.Value]  = enumFormat(FilterOperators)
-  implicit val CheckOperatorFormat: RootJsonFormat[NullableOperators.Value] = enumFormat(NullableOperators)
-  implicit val FilterByValueFormat                                          = jsonFormat3(FilterByValue.apply)
-  implicit val FilterNullableValueFormat                                    = jsonFormat2(FilterNullableValue.apply)
-
-  implicit object FilterJsonFormat extends RootJsonFormat[Filter] {
-    def write(a: Filter) = a match {
-      case f: FilterByValue       => f.toJson
-      case f: FilterNullableValue => f.toJson
-    }
-    def read(value: JsValue): Filter =
-      value.asJsObject.fields.get("value") match {
-        case Some(_) => value.convertTo[FilterByValue]
-        case None    => value.convertTo[FilterNullableValue]
-      }
-  }
-
-  implicit val QbFormat = jsonFormat8(QueryBody.apply)
-
-  implicit val QvbFormat = jsonFormat4(QueryValidationBody.apply)
-
-  implicit val BitFormat = jsonFormat4(Bit.apply)
-
-  implicit val InsertBodyFormat = jsonFormat4(InsertBody.apply)
-
-  implicit val FieldErrorInfoFormat = jsonFormat2(FieldErrorInfo.apply)
-
-}
 
 class ApiResources(val publisherActor: ActorRef,
                    val readCoordinator: ActorRef,

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJson.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJson.scala
@@ -26,7 +26,20 @@ import io.radicalbit.nsdb.web.routes._
 import io.radicalbit.nsdb.web.validation.FieldErrorInfo
 import spray.json._
 
-object NSDbJsonProtocol extends DefaultJsonProtocol with SprayJsonSupport {
+import scala.util.Try
+
+object NSDbJson extends DefaultJsonProtocol with SprayJsonSupport {
+
+  implicit class NSDbJsValue(raw: JsValue) {
+    def convertOpt[T: JsonReader]: Option[T] =
+      Try(jsonReader[T].read(raw)).toOption
+
+    def convertEither[T: JsonReader]: Either[String, T] =
+      Try(jsonReader[T].read(raw)) match {
+        case scala.util.Success(obj) => Right(obj)
+        case scala.util.Failure(ex)  => Left(ex.getMessage)
+      }
+  }
 
   implicit object NSDbTypeJsonFormat extends RootJsonFormat[NSDbType] {
     def write(c: NSDbType): JsValue = c match {

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJsonProtocol.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJsonProtocol.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.web
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import io.radicalbit.nsdb.actors.RealTimeProtocol.Events._
+import io.radicalbit.nsdb.actors.RealTimeProtocol.RealTimeOutGoingMessage
+import io.radicalbit.nsdb.common._
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.web.actor.StreamActor.RegisterQuery
+import io.radicalbit.nsdb.web.routes._
+import io.radicalbit.nsdb.web.validation.FieldErrorInfo
+import spray.json._
+
+object NSDbJsonProtocol extends DefaultJsonProtocol with SprayJsonSupport {
+
+  implicit object NSDbTypeJsonFormat extends RootJsonFormat[NSDbType] {
+    def write(c: NSDbType): JsValue = c match {
+      case NSDbDoubleType(v) => JsNumber(v)
+      case NSDbLongType(v)   => JsNumber(v)
+      case NSDbIntType(v)    => JsNumber(v)
+      case NSDbStringType(v) => JsString(v)
+    }
+    def read(value: JsValue): NSDbType = value match {
+      case JsNumber(v) if v.scale > 0   => NSDbDoubleType(v.doubleValue)
+      case JsNumber(v) if v.isValidLong => NSDbLongType(v.longValue)
+      case JsNumber(v) if v.isValidInt  => NSDbIntType(v.intValue)
+      case JsString(v)                  => NSDbStringType(v)
+    }
+  }
+
+  implicit object NSDbNumericTypeJsonFormat extends RootJsonFormat[NSDbNumericType] {
+    def write(c: NSDbNumericType): JsValue = c match {
+      case NSDbDoubleType(v) => JsNumber(v)
+      case NSDbLongType(v)   => JsNumber(v)
+      case NSDbIntType(v)    => JsNumber(v)
+    }
+    def read(value: JsValue): NSDbNumericType = value match {
+      case JsNumber(v) if v.scale > 0   => NSDbDoubleType(v.doubleValue)
+      case JsNumber(v) if v.isValidLong => NSDbLongType(v.longValue)
+      case JsNumber(v) if v.isValidInt  => NSDbIntType(v.intValue)
+    }
+  }
+
+  implicit object NSDbLongTypeJsonFormat extends RootJsonFormat[NSDbLongType] {
+    def write(c: NSDbLongType): JsValue = JsNumber(c.rawValue)
+    def read(value: JsValue): NSDbLongType = value match {
+      case JsNumber(v) if v.isValidLong => NSDbLongType(v.longValue)
+      case JsNumber(v) if v.isValidInt  => NSDbLongType(v.intValue)
+      case json                         => deserializationError(s"cannot deserialize a long from $json")
+    }
+  }
+
+  implicit def enumFormat[T <: Enumeration](implicit enu: T): RootJsonFormat[T#Value] =
+    new RootJsonFormat[T#Value] {
+      def write(obj: T#Value): JsValue = JsString(obj.toString)
+      def read(json: JsValue): T#Value = {
+        json match {
+          case JsString(txt) => enu.withName(txt.replace(" ", "").toUpperCase)
+          case somethingElse =>
+            throw DeserializationException(s"Expected a value from enum $enu instead of $somethingElse")
+        }
+      }
+    }
+
+  implicit val FilterOperatorFormat: RootJsonFormat[FilterOperators.Value]    = enumFormat(FilterOperators)
+  implicit val CheckOperatorFormat: RootJsonFormat[NullableOperators.Value]   = enumFormat(NullableOperators)
+  implicit val FilterByValueFormat: RootJsonFormat[FilterByValue]             = jsonFormat3(FilterByValue.apply)
+  implicit val FilterNullableValueFormat: RootJsonFormat[FilterNullableValue] = jsonFormat2(FilterNullableValue.apply)
+
+  implicit object FilterJsonFormat extends RootJsonFormat[Filter] {
+    def write(a: Filter) = a match {
+      case f: FilterByValue       => f.toJson
+      case f: FilterNullableValue => f.toJson
+    }
+    def read(value: JsValue): Filter =
+      value.asJsObject.fields.get("value") match {
+        case Some(_) => value.convertTo[FilterByValue]
+        case None    => value.convertTo[FilterNullableValue]
+      }
+  }
+
+  implicit val QbRegisterQueryFormat: RootJsonFormat[RegisterQuery] = jsonFormat7(RegisterQuery.apply)
+
+  implicit val QbFormat: RootJsonFormat[QueryBody] = jsonFormat8(QueryBody.apply)
+
+  implicit val QvbFormat: RootJsonFormat[QueryValidationBody] = jsonFormat4(QueryValidationBody.apply)
+
+  implicit val BitFormat: RootJsonFormat[Bit] = jsonFormat4(Bit.apply)
+
+  implicit val InsertBodyFormat: RootJsonFormat[InsertBody] = jsonFormat4(InsertBody.apply)
+
+  implicit val FieldErrorInfoFormat: RootJsonFormat[FieldErrorInfo] = jsonFormat2(FieldErrorInfo.apply)
+
+  implicit object RealTimeOutGoingMessageWriter extends JsonWriter[RealTimeOutGoingMessage] {
+
+    implicit val subscribedByQueryStringFormat: RootJsonFormat[SubscribedByQueryString] = jsonFormat5(
+      SubscribedByQueryString.apply)
+    implicit val SubscriptionByQueryStringFailedFormat: RootJsonFormat[SubscriptionByQueryStringFailed] = jsonFormat5(
+      SubscriptionByQueryStringFailed.apply)
+    implicit val recordsPublishedFormat: RootJsonFormat[RecordsPublished] = jsonFormat3(RecordsPublished.apply)
+    implicit val errorResponseFormat: RootJsonFormat[ErrorResponse]       = jsonFormat1(ErrorResponse.apply)
+
+    def write(a: RealTimeOutGoingMessage): JsValue = a match {
+      case msg: SubscribedByQueryString         => msg.toJson
+      case msg: SubscriptionByQueryStringFailed => msg.toJson
+      case msg: RecordsPublished                => msg.toJson
+      case msg: ErrorResponse                   => msg.toJson
+    }
+  }
+}

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
@@ -26,8 +26,9 @@ import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import com.typesafe.config.Config
-import io.radicalbit.nsdb.security.NsdbSecurity
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel._
+import io.radicalbit.nsdb.security.NsdbSecurity
+import org.json4s.Formats
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -41,6 +42,8 @@ trait WebResources extends WsResources with SSLSupport { this: NsdbSecurity =>
 
   import CORSSupport._
   import VersionHeader._
+
+  implicit def formats: Formats
 
   def config: Config
 

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
@@ -27,13 +27,12 @@ import akka.http.scaladsl.server._
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import io.radicalbit.nsdb.security.http.NSDBAuthProvider
-import io.radicalbit.nsdb.web.NSDbJsonProtocol._
+import io.radicalbit.nsdb.web.NSDbJson._
 import io.radicalbit.nsdb.web.actor.StreamActor
 import io.radicalbit.nsdb.web.actor.StreamActor._
 import spray.json._
 
 import scala.collection.JavaConverters._
-import scala.util.Try
 
 trait WsResources {
 
@@ -81,7 +80,7 @@ trait WsResources {
       Flow[Message]
         .map {
           case TextMessage.Strict(text) =>
-            Try(text.parseJson.convertTo[RegisterQuery]).toOption getOrElse s"Message $text not handled by receiver"
+            text.parseJson.convertOpt[RegisterQuery] getOrElse s"Message $text not handled by receiver"
           case _ => "Message not handled by receiver"
         }
         .to(Sink.actorRef(connectedWsActor, Terminate))

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/DataApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/DataApi.scala
@@ -48,7 +48,7 @@ case class InsertBody(@(ApiModelProperty @field)(value = "database name") db: St
 @Path("/data")
 trait DataApi {
 
-  import io.radicalbit.nsdb.web.NSDbJsonProtocol._
+  import io.radicalbit.nsdb.web.NSDbJson._
   import io.radicalbit.nsdb.web.validation.ValidationDirective._
   import io.radicalbit.nsdb.web.validation.Validators._
 

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/DataApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/DataApi.scala
@@ -48,7 +48,7 @@ case class InsertBody(@(ApiModelProperty @field)(value = "database name") db: St
 @Path("/data")
 trait DataApi {
 
-  import io.radicalbit.nsdb.web.Formats._
+  import io.radicalbit.nsdb.web.NSDbJsonProtocol._
   import io.radicalbit.nsdb.web.validation.ValidationDirective._
   import io.radicalbit.nsdb.web.validation.Validators._
 

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
@@ -24,8 +24,9 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.pattern.ask
 import akka.util.Timeout
+import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 import io.radicalbit.nsdb.common.{NSDbLongType, NSDbType}
-import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.common.protocol.{Bit, NSDbSerializable}
 import io.radicalbit.nsdb.common.statement.{SQLStatement, SelectSQLStatement}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.ExecuteStatement
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
@@ -58,7 +59,13 @@ object NullableOperators extends Enumeration {
 }
 
 @ApiModel(description = "Filter sealed trait", subTypes = Array(classOf[FilterNullableValue], classOf[FilterByValue]))
-sealed trait Filter
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(
+  Array(
+    new JsonSubTypes.Type(value = classOf[FilterByValue], name = "FilterByValue"),
+    new JsonSubTypes.Type(value = classOf[Generic], name = "FilterNullableValue")
+  ))
+sealed trait Filter extends NSDbSerializable
 
 case object Filter {
   def unapply(arg: Filter): Option[(String, Option[NSDbType], String)] =
@@ -108,7 +115,7 @@ case class QueryBody(@(ApiModelProperty @field)(value = "database name") db: Str
 @Path("/query")
 trait QueryApi {
 
-  import io.radicalbit.nsdb.web.Formats._
+  import io.radicalbit.nsdb.web.NSDbJsonProtocol._
 
   def readCoordinator: ActorRef
   def authenticationProvider: NSDBAuthProvider
@@ -155,7 +162,7 @@ trait QueryApi {
                     case Success(SelectStatementExecuted(_, values)) =>
                       complete(HttpEntity(ContentTypes.`application/json`,
                                           write(QueryResponse(values, qb.parsed.map(_ => statement)))))
-                    case Success(SelectStatementFailed(_, reason, MetricNotFound(metric))) =>
+                    case Success(SelectStatementFailed(_, reason, MetricNotFound(_))) =>
                       complete(HttpResponse(NotFound, entity = reason))
                     case Success(SelectStatementFailed(_, reason, _)) =>
                       complete(HttpResponse(InternalServerError, entity = reason))

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
@@ -115,7 +115,7 @@ case class QueryBody(@(ApiModelProperty @field)(value = "database name") db: Str
 @Path("/query")
 trait QueryApi {
 
-  import io.radicalbit.nsdb.web.NSDbJsonProtocol._
+  import io.radicalbit.nsdb.web.NSDbJson._
 
   def readCoordinator: ActorRef
   def authenticationProvider: NSDBAuthProvider

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryValidationApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryValidationApi.scala
@@ -49,7 +49,7 @@ case class QueryValidationBody(@(ApiModelProperty @field)(value = "database name
 @Path("/query/validate")
 trait QueryValidationApi {
 
-  import io.radicalbit.nsdb.web.NSDbJsonProtocol._
+  import io.radicalbit.nsdb.web.NSDbJson._
 
   def readCoordinator: ActorRef
   def authenticationProvider: NSDBAuthProvider

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryValidationApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryValidationApi.scala
@@ -49,7 +49,7 @@ case class QueryValidationBody(@(ApiModelProperty @field)(value = "database name
 @Path("/query/validate")
 trait QueryValidationApi {
 
-  import io.radicalbit.nsdb.web.Formats._
+  import io.radicalbit.nsdb.web.NSDbJsonProtocol._
 
   def readCoordinator: ActorRef
   def authenticationProvider: NSDBAuthProvider

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/actor/EmptyReadCoordinator.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/actor/EmptyReadCoordinator.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.actor
+
+import akka.actor.Actor
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.ExecuteStatement
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.SelectStatementExecuted
+
+class EmptyReadCoordinator extends Actor {
+  def receive: Receive = {
+    case ExecuteStatement(statement) =>
+      sender() ! SelectStatementExecuted(statement, values = Seq.empty)
+  }
+}

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/DataApiTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/DataApiTest.scala
@@ -29,7 +29,7 @@ import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.MapInput
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.InputMapped
 import io.radicalbit.nsdb.security.http.{EmptyAuthorization, NSDBAuthProvider}
 import io.radicalbit.nsdb.web.DataApiTest.FakeWriteCoordinator
-import io.radicalbit.nsdb.web.NSDbJsonProtocol._
+import io.radicalbit.nsdb.web.NSDbJson._
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes.{DataApi, InsertBody}
 import io.radicalbit.nsdb.web.validation.{FieldErrorInfo, ModelValidationRejection}

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/DataApiTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/DataApiTest.scala
@@ -29,7 +29,7 @@ import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.MapInput
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.InputMapped
 import io.radicalbit.nsdb.security.http.{EmptyAuthorization, NSDBAuthProvider}
 import io.radicalbit.nsdb.web.DataApiTest.FakeWriteCoordinator
-import io.radicalbit.nsdb.web.Formats._
+import io.radicalbit.nsdb.web.NSDbJsonProtocol._
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes.{DataApi, InsertBody}
 import io.radicalbit.nsdb.web.validation.{FieldErrorInfo, ModelValidationRejection}

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiSpec.scala
@@ -207,8 +207,8 @@ class QueryApiSpec extends FlatSpec with Matchers with ScalatestRouteTest {
                       "namespace",
                       "metric",
                       "select * from metric limit 1",
-                      Some(NSDbLongType(100)),
-                      Some(NSDbLongType(200)),
+                      Some(NSDbLongType(1L)),
+                      Some(NSDbLongType(2L)),
                       None,
                       None)
 
@@ -220,17 +220,7 @@ class QueryApiSpec extends FlatSpec with Matchers with ScalatestRouteTest {
       recordString shouldBe
         """{
         |  "records" : [ {
-        |    "timestamp" : 100,
-        |    "value" : 1,
-        |    "dimensions" : {
-        |      "name" : "name",
-        |      "number" : 2
-        |    },
-        |    "tags" : {
-        |      "country" : "country"
-        |    }
-        |  }, {
-        |    "timestamp" : 200,
+        |    "timestamp" : 2,
         |    "value" : 3,
         |    "dimensions" : {
         |      "name" : "name",
@@ -325,8 +315,8 @@ class QueryApiSpec extends FlatSpec with Matchers with ScalatestRouteTest {
                       "namespace",
                       "metric",
                       "select * from metric limit 1",
-                      Some(NSDbLongType(1)),
-                      Some(NSDbLongType(2)),
+                      Some(NSDbLongType(1L)),
+                      Some(NSDbLongType(2L)),
                       None,
                       None)
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiSpec.scala
@@ -25,7 +25,7 @@ import akka.util.Timeout
 import io.radicalbit.nsdb.actor.FakeReadCoordinator
 import io.radicalbit.nsdb.common.NSDbLongType
 import io.radicalbit.nsdb.security.http.{EmptyAuthorization, NSDBAuthProvider}
-import io.radicalbit.nsdb.web.NSDbJsonProtocol._
+import io.radicalbit.nsdb.web.NSDbJson._
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes._
 import org.json4s._

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiSpec.scala
@@ -25,7 +25,7 @@ import akka.util.Timeout
 import io.radicalbit.nsdb.actor.FakeReadCoordinator
 import io.radicalbit.nsdb.common.NSDbLongType
 import io.radicalbit.nsdb.security.http.{EmptyAuthorization, NSDBAuthProvider}
-import io.radicalbit.nsdb.web.Formats._
+import io.radicalbit.nsdb.web.NSDbJsonProtocol._
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes._
 import org.json4s._

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryParserApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryParserApiSpec.scala
@@ -23,7 +23,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.util.Timeout
 import io.radicalbit.nsdb.actor.FakeReadCoordinator
 import io.radicalbit.nsdb.security.http.{EmptyAuthorization, NSDBAuthProvider}
-import io.radicalbit.nsdb.web.Formats._
+import io.radicalbit.nsdb.web.NSDbJsonProtocol._
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes._
 import org.json4s._

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryParserApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryParserApiSpec.scala
@@ -23,7 +23,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.util.Timeout
 import io.radicalbit.nsdb.actor.FakeReadCoordinator
 import io.radicalbit.nsdb.security.http.{EmptyAuthorization, NSDBAuthProvider}
-import io.radicalbit.nsdb.web.NSDbJsonProtocol._
+import io.radicalbit.nsdb.web.NSDbJson._
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes._
 import org.json4s._

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryValidationApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryValidationApiSpec.scala
@@ -24,7 +24,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.util.Timeout
 import io.radicalbit.nsdb.actor.FakeReadCoordinator
 import io.radicalbit.nsdb.security.http.{EmptyAuthorization, NSDBAuthProvider}
-import io.radicalbit.nsdb.web.NSDbJsonProtocol._
+import io.radicalbit.nsdb.web.NSDbJson._
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes._
 import org.json4s._

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryValidationApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryValidationApiSpec.scala
@@ -24,7 +24,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.util.Timeout
 import io.radicalbit.nsdb.actor.FakeReadCoordinator
 import io.radicalbit.nsdb.security.http.{EmptyAuthorization, NSDBAuthProvider}
-import io.radicalbit.nsdb.web.Formats._
+import io.radicalbit.nsdb.web.NSDbJsonProtocol._
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes._
 import org.json4s._

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeApiSpec.scala
@@ -16,17 +16,17 @@
 
 package io.radicalbit.nsdb.web
 
-import akka.actor.{Actor, Props}
+import akka.actor.Props
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.testkit.{ScalatestRouteTest, WSProbe}
+import io.radicalbit.nsdb.actor.EmptyReadCoordinator
 import io.radicalbit.nsdb.actors.PublisherActor
 import io.radicalbit.nsdb.actors.RealTimeProtocol.Events.{SubscribedByQueryString, SubscriptionByQueryStringFailed}
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Schema
-import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.{ExecuteStatement, PublishRecord}
-import io.radicalbit.nsdb.protocol.MessageProtocol.Events.SelectStatementExecuted
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.PublishRecord
 import io.radicalbit.nsdb.security.http.EmptyAuthorization
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import org.json4s._
@@ -34,13 +34,6 @@ import org.json4s.jackson.JsonMethods._
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.concurrent.duration._
-
-class FakeReadCoordinatorActor extends Actor {
-  def receive: Receive = {
-    case ExecuteStatement(statement) =>
-      sender() ! SelectStatementExecuted(statement, values = Seq.empty)
-  }
-}
 
 class RealTimeApiSpec extends WordSpec with ScalatestRouteTest with Matchers with WsResources {
 
@@ -50,7 +43,7 @@ class RealTimeApiSpec extends WordSpec with ScalatestRouteTest with Matchers wit
 
   val basePath = "target/test_index/WebSocketTest"
 
-  val publisherActor = system.actorOf(PublisherActor.props(system.actorOf(Props[FakeReadCoordinatorActor])))
+  val publisherActor = system.actorOf(PublisherActor.props(system.actorOf(Props[EmptyReadCoordinator])))
 
   val wsStandardResources = wsResources(publisherActor, new EmptyAuthorization)
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeFiltersSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeFiltersSpec.scala
@@ -30,7 +30,7 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.PublishRecord
 import io.radicalbit.nsdb.security.http.EmptyAuthorization
-import io.radicalbit.nsdb.web.NSDbJsonProtocol.RealTimeOutGoingMessageWriter._
+import io.radicalbit.nsdb.web.NSDbJson.RealTimeOutGoingMessageWriter._
 import org.scalatest.{Matchers, WordSpec}
 import spray.json._
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeFiltersSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeFiltersSpec.scala
@@ -19,6 +19,7 @@ package io.radicalbit.nsdb.web
 import akka.actor.Props
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.testkit.{ScalatestRouteTest, WSProbe}
+import io.radicalbit.nsdb.actor.EmptyReadCoordinator
 import io.radicalbit.nsdb.actors.PublisherActor
 import io.radicalbit.nsdb.actors.RealTimeProtocol.Events.{SubscribedByQueryString, SubscriptionByQueryStringFailed}
 import io.radicalbit.nsdb.common.protocol.Bit
@@ -39,7 +40,7 @@ class RealTimeFiltersSpec extends WordSpec with ScalatestRouteTest with Matchers
 
   val basePath = "target/test_index/WebSocketTest"
 
-  val publisherActor = system.actorOf(PublisherActor.props(system.actorOf(Props[FakeReadCoordinatorActor])))
+  val publisherActor = system.actorOf(PublisherActor.props(system.actorOf(Props[EmptyReadCoordinator])))
 
   val wsStandardResources = wsResources(publisherActor, new EmptyAuthorization)
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeFiltersSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeFiltersSpec.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.web
+
+import akka.actor.Props
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.testkit.{ScalatestRouteTest, WSProbe}
+import io.radicalbit.nsdb.actors.PublisherActor
+import io.radicalbit.nsdb.actors.RealTimeProtocol.Events.{SubscribedByQueryString, SubscriptionByQueryStringFailed}
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.model.Schema
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.PublishRecord
+import io.radicalbit.nsdb.security.http.EmptyAuthorization
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.concurrent.duration._
+
+class RealTimeFiltersSpec extends WordSpec with ScalatestRouteTest with Matchers with WsResources {
+
+  override def logger: LoggingAdapter = system.log
+
+  implicit val formats = DefaultFormats
+
+  val basePath = "target/test_index/WebSocketTest"
+
+  val publisherActor = system.actorOf(PublisherActor.props(system.actorOf(Props[FakeReadCoordinatorActor])))
+
+  val wsStandardResources = wsResources(publisherActor, new EmptyAuthorization)
+
+  "Real Time Filter" should {
+
+    "register a query and receive events with a single filter over Long" in {
+
+      val wsClient = WSProbe()
+
+      WS("/ws-stream", wsClient.flow) ~> wsStandardResources ~>
+        check {
+
+          isWebSocketUpgrade shouldEqual true
+
+          wsClient.sendMessage(
+            """{
+              |"db":"db",
+              |"namespace":"registry",
+              |"metric":"people",
+              |"queryString":"select * from people limit 1",
+              |"filters" : [{
+              |"dimension": "value",
+              |"value": 1,
+              |"operator": "="
+              |}]
+              |}""".stripMargin
+          )
+
+          val firstSubscribed = wsClient.expectMessage().asTextMessage.getStrictText
+          parse(firstSubscribed).extractOpt[SubscribedByQueryString].isDefined shouldBe true
+
+          val bit = Bit(System.currentTimeMillis(), 1, Map.empty, Map.empty)
+          publisherActor ! PublishRecord("db", "registry", "people", bit, Schema("people", bit))
+          publisherActor ! PublishRecord("db", "registry", "animals", bit, Schema("people", bit))
+
+          val firstRecordsPublished = wsClient.expectMessage().asTextMessage.getStrictText
+
+          (parse(firstRecordsPublished) \ "records").extract[JArray].arr.size shouldBe 1
+          wsClient.expectNoMessage(5 seconds)
+        }
+    }
+
+    "register a query and receive events with a single filter over Long with a compatible String filter provided" in {
+
+      val wsClient = WSProbe()
+
+      WS("/ws-stream", wsClient.flow) ~> wsStandardResources ~>
+        check {
+
+          isWebSocketUpgrade shouldEqual true
+
+          wsClient.sendMessage(
+            """{
+                |"db":"db",
+                |"namespace":"registry",
+                |"metric":"people",
+                |"queryString":"select * from people limit 1",
+                |"filters" : [{
+                |"dimension": "value",
+                |"value": "1",
+                |"operator": "="
+                |}]
+                |}""".stripMargin
+          )
+
+          val firstSubscribed = wsClient.expectMessage().asTextMessage.getStrictText
+          parse(firstSubscribed).extractOpt[SubscribedByQueryString].isDefined shouldBe true
+
+          val bit = Bit(System.currentTimeMillis(), 1, Map.empty, Map.empty)
+          publisherActor ! PublishRecord("db", "registry", "people", bit, Schema("people", bit))
+          publisherActor ! PublishRecord("db", "registry", "animals", bit, Schema("people", bit))
+
+          val firstRecordsPublished = wsClient.expectMessage().asTextMessage.getStrictText
+
+          (parse(firstRecordsPublished) \ "records").extract[JArray].arr.size shouldBe 1
+          wsClient.expectNoMessage(5 seconds)
+        }
+    }
+
+    "register a query and receive events with a single filter over Long with a not compatible String filter provided" in {
+
+      val wsClient = WSProbe()
+
+      WS("/ws-stream", wsClient.flow) ~> wsStandardResources ~>
+        check {
+
+          isWebSocketUpgrade shouldEqual true
+
+          wsClient.sendMessage(
+            """{
+              |"db":"db",
+              |"namespace":"registry",
+              |"metric":"people",
+              |"queryString":"select * from people limit 1",
+              |"filters" : [{
+              |"dimension": "value",
+              |"value": "vf",
+              |"operator": "="
+              |}]
+              |}""".stripMargin
+          )
+
+          val firstSubscribed = wsClient.expectMessage().asTextMessage.getStrictText
+          parse(firstSubscribed).extractOpt[SubscriptionByQueryStringFailed].isDefined shouldBe true
+
+          wsClient.expectNoMessage(5 seconds)
+        }
+    }
+
+    "register a query and receive events with a single filter over Long and a time range" in {
+
+      val wsClient = WSProbe()
+
+      WS("/ws-stream", wsClient.flow) ~> wsStandardResources ~>
+        check {
+
+          isWebSocketUpgrade shouldEqual true
+
+          wsClient.sendMessage(
+            """{
+                |"db":"db",
+                |"namespace":"registry",
+                |"metric":"people",
+                |"queryString":"select * from people limit 1",
+                |"from": 0,
+                |"to": 100,
+                |"filters" : [{
+                |"dimension": "value",
+                |"value": 1,
+                |"operator": "="
+                |}]
+                |}""".stripMargin
+          )
+
+          val firstSubscribed = wsClient.expectMessage().asTextMessage.getStrictText
+          parse(firstSubscribed).extractOpt[SubscribedByQueryString].isDefined shouldBe true
+
+          val bit = Bit(System.currentTimeMillis(), 1, Map.empty, Map.empty)
+          publisherActor ! PublishRecord("db", "registry", "people", bit, Schema("people", bit))
+          publisherActor ! PublishRecord("db", "registry", "animals", bit, Schema("people", bit))
+
+          val firstRecordsPublished = wsClient.expectMessage().asTextMessage.getStrictText
+
+          (parse(firstRecordsPublished) \ "records").extract[JArray].arr.size shouldBe 1
+          wsClient.expectNoMessage(5 seconds)
+        }
+    }
+  }
+
+}


### PR DESCRIPTION
This PR aims at adding real-time filters to the WebSockets APIs.
Basically, as per the documentation, it is possible to specify a time range ad an array of conditions that will be chained to the query where clause using the and operator

For example, It's possible to use the following json to subscribe to a query.

```
{
    "db": "db",
    "namespace": "namespace",
    "metric": "people",
    "queryString": "select * from people limit 100",
    "from": 0,
    "to": 100000,
    "filters": [{ "dimension": "dimName1",
                  "value" : "value",
                  "operator": "=" },
                { "dimension": "dimName2",
                  "value" : 1,
                  "operator": "=" }
                ]
}
```

That json will be processed by the `QueryEnriched` class that will produce the following query:

`select * from people where timestamp > 0 AND timestamp < 100000 and timName1 = value and dimName2 = 1`