### PR TITLE
Bound Sql Statements Results to the Internal Type System

### DIFF
--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/package.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/package.scala
@@ -129,6 +129,12 @@ package object common {
         case x: java.lang.Float   => NSDbNumericType(x.floatValue().toDouble)
         case x: java.lang.Double  => NSDbNumericType(x.doubleValue())
       }
+
+    def unapply(numeric: NSDbNumericType): Option[Number] = numeric match {
+      case NSDbLongType(v)   => Some(v)
+      case NSDbIntType(v)    => Some(v)
+      case NSDbDoubleType(v) => Some(v)
+    }
   }
 
   case class NSDbIntType(rawValue: Int) extends NSDbNumericType {

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -64,11 +64,11 @@ final case class Condition(expression: Expression)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(
   Array(
-    new JsonSubTypes.Type(value = classOf[ComparisonExpression[_]], name = "ComparisonExpression"),
-    new JsonSubTypes.Type(value = classOf[EqualityExpression[_]], name = "EqualityExpression"),
+    new JsonSubTypes.Type(value = classOf[ComparisonExpression], name = "ComparisonExpression"),
+    new JsonSubTypes.Type(value = classOf[EqualityExpression], name = "EqualityExpression"),
     new JsonSubTypes.Type(value = classOf[LikeExpression], name = "LikeExpression"),
     new JsonSubTypes.Type(value = classOf[NullableExpression], name = "NullableExpression"),
-    new JsonSubTypes.Type(value = classOf[RangeExpression[_]], name = "RangeExpression"),
+    new JsonSubTypes.Type(value = classOf[RangeExpression], name = "RangeExpression"),
     new JsonSubTypes.Type(value = classOf[TupledLogicalExpression], name = "TupledLogicalExpression"),
     new JsonSubTypes.Type(value = classOf[NotExpression], name = "NotExpression")
   ))
@@ -97,7 +97,7 @@ final case class TupledLogicalExpression(expression1: Expression,
   * @param comparison comparison operator (e.g. >, >=, <, <=).
   * @param value the value to compare the dimension with.
   */
-final case class ComparisonExpression[T](dimension: String, comparison: ComparisonOperator, value: ComparisonValue[T])
+final case class ComparisonExpression(dimension: String, comparison: ComparisonOperator, value: ComparisonValue)
     extends Expression
 
 /**
@@ -106,22 +106,21 @@ final case class ComparisonExpression[T](dimension: String, comparison: Comparis
   * @param value1 lower boundary.
   * @param value2 upper boundary.
   */
-final case class RangeExpression[T](dimension: String, value1: ComparisonValue[T], value2: ComparisonValue[T])
-    extends Expression
+final case class RangeExpression(dimension: String, value1: ComparisonValue, value2: ComparisonValue) extends Expression
 
 /**
   * Simple equality expression e.g. dimension = value.
   * @param dimension dimension name.
   * @param value value to check the equality with.
   */
-final case class EqualityExpression[T](dimension: String, value: ComparisonValue[T]) extends Expression
+final case class EqualityExpression(dimension: String, value: ComparisonValue) extends Expression
 
 /**
   * Simple like expression for varchar dimensions e.g. dimension like value.
   * @param dimension dimension name.
   * @param value string value with wildcards.
   */
-final case class LikeExpression(dimension: String, value: String) extends Expression
+final case class LikeExpression(dimension: String, value: NSDbType) extends Expression
 
 /**
   * Simple nullable expression e.g. dimension is null.
@@ -196,22 +195,22 @@ final case class LimitOperator(value: Int) extends NSDbSerializable
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(
   Array(
-    new JsonSubTypes.Type(value = classOf[AbsoluteComparisonValue[_]], name = "AbsoluteComparisonValue"),
-    new JsonSubTypes.Type(value = classOf[RelativeComparisonValue[_]], name = "RelativeComparisonValue")
+    new JsonSubTypes.Type(value = classOf[AbsoluteComparisonValue], name = "AbsoluteComparisonValue"),
+    new JsonSubTypes.Type(value = classOf[RelativeComparisonValue], name = "RelativeComparisonValue")
   ))
-sealed trait ComparisonValue[+T] {
-  def value: T
+sealed trait ComparisonValue {
+  def value: NSDbType
 }
 
 object ComparisonValue {
-  def unapply[T](cv: ComparisonValue[T]): Option[T] = Some(cv.value)
+  def unapply(cv: ComparisonValue): Option[NSDbType] = Some(cv.value)
 }
 
 /**
   * Class that represent an absolute comparison value
   * @param value the absolute value
   */
-final case class AbsoluteComparisonValue[T](override val value: T) extends ComparisonValue[T]
+final case class AbsoluteComparisonValue(override val value: NSDbType) extends ComparisonValue
 
 /**
   * Class that represent a relative comparison value.
@@ -220,8 +219,11 @@ final case class AbsoluteComparisonValue[T](override val value: T) extends Compa
   * @param quantity the quantity of the relative time
   * @param unitMeasure the unit measure of the relative time (s, m, h, d)
   */
-final case class RelativeComparisonValue[T](override val value: T, operator: String, quantity: T, unitMeasure: String)
-    extends ComparisonValue[T]
+final case class RelativeComparisonValue(override val value: NSDbType,
+                                         operator: String,
+                                         quantity: Int,
+                                         unitMeasure: String)
+    extends ComparisonValue
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(
@@ -304,38 +306,28 @@ final case class SelectSQLStatement(override val db: String,
   /**
     * Parses a simple string expression into a [[Expression]] e.g. `dimension > value`.
     * @param dimension the dimension to apply the expression.
-    * @param value the expression value.
+    * @param valueOpt the expression value.
     * @param operator the operator.
     * @return the parsed [[Expression]].
     */
-  private def filterToExpression[T](dimension: String,
-                                    value: Option[NSDbType],
-                                    operator: String): Option[Expression] = {
-    operator.toUpperCase match {
-      case ">" =>
-        Some(
-          ComparisonExpression(dimension, GreaterThanOperator, value.map(v => AbsoluteComparisonValue(v.rawValue)).get))
-      case ">=" =>
-        Some(
-          ComparisonExpression(dimension,
-                               GreaterOrEqualToOperator,
-                               value.map(v => AbsoluteComparisonValue(v.rawValue)).get))
-      case "=" => Some(EqualityExpression(dimension, value.map(v => AbsoluteComparisonValue(v.rawValue)).get))
-      case "<=" =>
-        Some(
-          ComparisonExpression(dimension,
-                               LessOrEqualToOperator,
-                               value.map(v => AbsoluteComparisonValue(v.rawValue)).get))
-      case "<" =>
-        Some(ComparisonExpression(dimension, LessThanOperator, value.map(v => AbsoluteComparisonValue(v.rawValue)).get))
-      case "LIKE"      => Some(LikeExpression(dimension, value.get.rawValue.asInstanceOf[String]))
-      case "ISNULL"    => Some(NullableExpression(dimension))
-      case "ISNOTNULL" => Some(NotExpression(NullableExpression(dimension)))
+  private def filterToExpression(dimension: String, valueOpt: Option[NSDbType], operator: String): Option[Expression] =
+    (operator.toUpperCase, valueOpt) match {
+      case (">", Some(value)) =>
+        Some(ComparisonExpression(dimension, GreaterThanOperator, AbsoluteComparisonValue(value)))
+      case (">=", Some(value)) =>
+        Some(ComparisonExpression(dimension, GreaterOrEqualToOperator, AbsoluteComparisonValue(value)))
+      case ("=", Some(value)) => Some(EqualityExpression(dimension, AbsoluteComparisonValue(value)))
+      case ("<=", Some(value)) =>
+        Some(ComparisonExpression(dimension, LessOrEqualToOperator, AbsoluteComparisonValue(value)))
+      case ("<", Some(value)) =>
+        Some(ComparisonExpression(dimension, LessThanOperator, AbsoluteComparisonValue(value)))
+      case ("LIKE", Some(value)) => Some(LikeExpression(dimension, value))
+      case ("ISNULL", None)      => Some(NullableExpression(dimension))
+      case ("ISNOTNULL", None)   => Some(NotExpression(NullableExpression(dimension)))
       case op @ _ =>
         logger.warn("Ignored filter with invalid operator: {}", op)
         None
     }
-  }
 
   /**
     * Returns a new instance enriched with a simple expression got from a string e.g. `dimension > value`.

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -221,7 +221,7 @@ final case class AbsoluteComparisonValue(override val value: NSDbType) extends C
   */
 final case class RelativeComparisonValue(override val value: NSDbType,
                                          operator: String,
-                                         quantity: Int,
+                                         quantity: Long,
                                          unitMeasure: String)
     extends ComparisonValue
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializer.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializer.scala
@@ -96,10 +96,10 @@ class StandardCommitLogSerializer extends CommitLogSerializer with TypeSupport {
     * @return deserialized value instance casted into the correct class
     */
   private def argument(clazz: String): NSDbType = {
-    val longClazz: String = classOf[NSDbLongType].getCanonicalName
-    val intClazz          = classOf[NSDbIntType].getCanonicalName
-    val doubleClazz       = classOf[NSDbDoubleType].getCanonicalName
-    val stringClazz       = classOf[NSDbStringType].getCanonicalName
+    val longClazz   = classOf[NSDbLongType].getCanonicalName
+    val intClazz    = classOf[NSDbIntType].getCanonicalName
+    val doubleClazz = classOf[NSDbDoubleType].getCanonicalName
+    val stringClazz = classOf[NSDbStringType].getCanonicalName
 
     clazz match {
       case `longClazz`   => NSDbType(Long.box(readByteBuffer.read.toLong))

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/actor/FakeReadCoordinator.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/actor/FakeReadCoordinator.scala
@@ -49,12 +49,12 @@ class FakeReadCoordinator extends Actor {
                                                    MetricNotFound(statement.metric))
       }
     case ExecuteStatement(statement)
-        if statement.condition.isDefined && statement.condition.get.expression.isInstanceOf[RangeExpression[_]] =>
+        if statement.condition.isDefined && statement.condition.get.expression.isInstanceOf[RangeExpression] =>
       StatementParser.parseStatement(statement, Schema(statement.metric, bits.head)) match {
         case Right(_) =>
-          val e = statement.condition.get.expression.asInstanceOf[RangeExpression[_]]
+          val e = statement.condition.get.expression.asInstanceOf[RangeExpression]
           val filteredBits = bits.filter(bit =>
-            bit.timestamp <= e.value2.value.toString.toLong && bit.timestamp >= e.value1.value.toString.toLong)
+            bit.timestamp <= e.value2.value.rawValue.toString.toLong && bit.timestamp >= e.value1.value.rawValue.toString.toLong)
           sender ! SelectStatementExecuted(statement, filteredBits)
         case Left(errorMessage) => sender ! SelectStatementFailed(statement, errorMessage)
       }

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CustomSerializerForTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CustomSerializerForTest.scala
@@ -18,23 +18,23 @@ package io.radicalbit.nsdb.web
 
 import io.radicalbit.nsdb.common.statement.RelativeComparisonValue
 import org.json4s.{CustomSerializer, JObject, JString}
-import org.json4s.JsonAST.{JField, JLong}
+import org.json4s.JsonAST.{JField, JInt, JLong}
 
 case object CustomSerializerForTest
-    extends CustomSerializer[RelativeComparisonValue[_]](_ =>
+    extends CustomSerializer[RelativeComparisonValue](_ =>
       ({
         case JObject(
             List(JField("value", JLong(0L)),
                  JField("operator", JString(operator)),
-                 JField("quantity", JLong(quantity)),
+                 JField("quantity", JInt(quantity)),
                  JField("unitMeasure", JString(unitMeasure)))) =>
-          RelativeComparisonValue(0L, operator, quantity, unitMeasure)
+          RelativeComparisonValue(0L, operator, quantity.intValue, unitMeasure)
       }, {
-        case RelativeComparisonValue(_, operator, quantity: Long, unitMeasure) =>
+        case RelativeComparisonValue(_, operator, quantity: Int, unitMeasure) =>
           JObject(
             List(JField("value", JLong(0L)),
                  JField("operator", JString(operator)),
-                 JField("quantity", JLong(quantity)),
+                 JField("quantity", JInt(quantity)),
                  JField("unitMeasure", JString(unitMeasure))))
 
       }))

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CustomSerializerForTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CustomSerializerForTest.scala
@@ -30,11 +30,11 @@ case object CustomSerializerForTest
                  JField("unitMeasure", JString(unitMeasure)))) =>
           RelativeComparisonValue(0L, operator, quantity.intValue, unitMeasure)
       }, {
-        case RelativeComparisonValue(_, operator, quantity: Int, unitMeasure) =>
+        case RelativeComparisonValue(_, operator, quantity: Long, unitMeasure) =>
           JObject(
             List(JField("value", JLong(0L)),
                  JField("operator", JString(operator)),
-                 JField("quantity", JInt(quantity)),
+                 JField("quantity", JLong(quantity)),
                  JField("unitMeasure", JString(unitMeasure))))
 
       }))

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -135,7 +135,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
 
   // def instead val because timestamp should be calculated everytime but there is a problem with
   // more than one "now - something" in the same query because "now" will be different for each condition
-  private def delta: PackratParser[ComparisonValue] = now ~> (("+" | "-") ~ intValue ~ timeMeasure).? ^^ {
+  private def delta: PackratParser[ComparisonValue] = now ~> (("+" | "-") ~ longValue ~ timeMeasure).? ^^ {
     case Some("+" ~ v ~ ((unitMeasure, timeInterval))) =>
       RelativeComparisonValue(System.currentTimeMillis() + v * timeInterval, "+", v, unitMeasure)
     case Some("-" ~ v ~ ((unitMeasure, timeInterval))) =>

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -135,7 +135,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
 
   // def instead val because timestamp should be calculated everytime but there is a problem with
   // more than one "now - something" in the same query because "now" will be different for each condition
-  private def delta: PackratParser[ComparisonValue[Long]] = now ~> (("+" | "-") ~ longValue ~ timeMeasure).? ^^ {
+  private def delta: PackratParser[ComparisonValue] = now ~> (("+" | "-") ~ intValue ~ timeMeasure).? ^^ {
     case Some("+" ~ v ~ ((unitMeasure, timeInterval))) =>
       RelativeComparisonValue(System.currentTimeMillis() + v * timeInterval, "+", v, unitMeasure)
     case Some("-" ~ v ~ ((unitMeasure, timeInterval))) =>
@@ -193,7 +193,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
 
   lazy val orTupledLogicalExpression: PackratParser[TupledLogicalExpression] = tupledLogicalExpression(Or, OrOperator)
 
-  lazy val equalityExpression: PackratParser[EqualityExpression[Any]] = (dimension <~ Equal) ~ (stringValue.map(n =>
+  lazy val equalityExpression: PackratParser[EqualityExpression] = (dimension <~ Equal) ~ (stringValue.map(n =>
     AbsoluteComparisonValue(n)) | comparisonTerm) ^^ {
     case dim ~ v => EqualityExpression(dim, v)
   }
@@ -212,7 +212,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
   private lazy val comparisonExpressionRule = comparisonExpressionGT | comparisonExpressionGTE | comparisonExpressionLT | comparisonExpressionLTE
 
   private def comparisonExpression(operator: String,
-                                   comparisonOperator: ComparisonOperator): Parser[ComparisonExpression[AnyVal]] =
+                                   comparisonOperator: ComparisonOperator): Parser[ComparisonExpression] =
     (dimension <~ operator) ~ comparisonTerm ^^ {
       case d ~ v =>
         ComparisonExpression(d, comparisonOperator, v)

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
@@ -141,7 +141,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               condition = Some(
                 Condition(ComparisonExpression(dimension = "timestamp",
                                                comparison = GreaterOrEqualToOperator,
-                                               value = AbsoluteComparisonValue(10)))),
+                                               value = AbsoluteComparisonValue(10L)))),
               groupBy = Some(SimpleGroupByAggregation("name"))
             )
           ))
@@ -352,12 +352,12 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               condition = Some(Condition(TupledLogicalExpression(
-                expression1 = ComparisonExpression[Long](dimension = "timestamp",
-                                                         comparison = GreaterThanOperator,
-                                                         value = AbsoluteComparisonValue(1)),
-                expression2 = ComparisonExpression[Long](dimension = "timestamp",
-                                                         comparison = LessThanOperator,
-                                                         value = AbsoluteComparisonValue(100)),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterThanOperator,
+                                                   value = AbsoluteComparisonValue(1L)),
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessThanOperator,
+                                                   value = AbsoluteComparisonValue(100L)),
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(CountAggregation)))),
@@ -377,12 +377,12 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               condition = Some(Condition(TupledLogicalExpression(
-                expression1 = ComparisonExpression[Long](dimension = "timestamp",
-                                                         comparison = GreaterThanOperator,
-                                                         value = AbsoluteComparisonValue(1)),
-                expression2 = ComparisonExpression[Long](dimension = "timestamp",
-                                                         comparison = LessThanOperator,
-                                                         value = AbsoluteComparisonValue(100)),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterThanOperator,
+                                                   value = AbsoluteComparisonValue(1L)),
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessThanOperator,
+                                                   value = AbsoluteComparisonValue(100L)),
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(CountAggregation)))),
@@ -402,12 +402,12 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               condition = Some(Condition(TupledLogicalExpression(
-                expression1 = ComparisonExpression[Long](dimension = "timestamp",
-                                                         comparison = GreaterThanOperator,
-                                                         value = AbsoluteComparisonValue(1)),
-                expression2 = ComparisonExpression[Long](dimension = "timestamp",
-                                                         comparison = LessThanOperator,
-                                                         value = AbsoluteComparisonValue(100)),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterThanOperator,
+                                                   value = AbsoluteComparisonValue(1L)),
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessThanOperator,
+                                                   value = AbsoluteComparisonValue(100L)),
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(SumAggregation)))),
@@ -427,12 +427,12 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               condition = Some(Condition(TupledLogicalExpression(
-                expression1 = ComparisonExpression[Long](dimension = "timestamp",
-                                                         comparison = GreaterThanOperator,
-                                                         value = AbsoluteComparisonValue(1)),
-                expression2 = ComparisonExpression[Long](dimension = "timestamp",
-                                                         comparison = LessThanOperator,
-                                                         value = AbsoluteComparisonValue(100)),
+                expression1 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = GreaterThanOperator,
+                                                   value = AbsoluteComparisonValue(1L)),
+                expression2 = ComparisonExpression(dimension = "timestamp",
+                                                   comparison = LessThanOperator,
+                                                   value = AbsoluteComparisonValue(100L)),
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(AvgAggregation)))),

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
@@ -62,8 +62,8 @@ class DeleteSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               condition = Condition(
                 RangeExpression(dimension = "timestamp",
-                                value1 = AbsoluteComparisonValue(2),
-                                value2 = AbsoluteComparisonValue(4)))
+                                value1 = AbsoluteComparisonValue(2L),
+                                value2 = AbsoluteComparisonValue(4L)))
             )
           ))
       }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
@@ -16,6 +16,7 @@
 
 package io.radicalbit.nsdb.sql.parser
 
+import io.radicalbit.nsdb.common.NSDbLongType
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult._
 import org.scalatest.OptionValues._
@@ -46,11 +47,12 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[EqualityExpression[_]]
+          selectSQLStatement.condition.value.expression.asInstanceOf[EqualityExpression]
 
-        val firstTimestamp = expression.value.asInstanceOf[RelativeComparisonValue[Long]]
+        val firstTimestamp = expression.value.asInstanceOf[RelativeComparisonValue]
 
-        firstTimestamp.value shouldBe now - 10 * seconds +- timestampTolerance
+        firstTimestamp.value shouldBe a[NSDbLongType]
+        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 10 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 10
         firstTimestamp.unitMeasure shouldBe "s"
@@ -69,11 +71,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[ComparisonExpression[_]]
+          selectSQLStatement.condition.value.expression.asInstanceOf[ComparisonExpression]
 
-        val firstTimestamp = expression.value.asInstanceOf[RelativeComparisonValue[Long]]
+        val firstTimestamp = expression.value.asInstanceOf[RelativeComparisonValue]
 
-        firstTimestamp.value shouldBe now - 10 * seconds +- timestampTolerance
+        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 10 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 10
         firstTimestamp.unitMeasure shouldBe "s"
@@ -90,11 +92,11 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[ComparisonExpression[_]]
+          selectSQLStatement.condition.value.expression.asInstanceOf[ComparisonExpression]
 
-        val firstTimestamp = expression.value.asInstanceOf[AbsoluteComparisonValue[Long]]
+        val firstTimestamp = expression.value.asInstanceOf[AbsoluteComparisonValue]
 
-        firstTimestamp.value shouldBe now +- timestampTolerance
+        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now +- timestampTolerance
       }
 
       "parse it successfully relative time with double comparison condition (AND)" in {
@@ -104,24 +106,24 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
                        input = "SELECT name FROM people WHERE timestamp < now AND age >= 18")
 
         val now = System.currentTimeMillis()
-        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        result shouldBe a[SqlStatementParserSuccess]
         val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
-        statement.isInstanceOf[SelectSQLStatement] shouldBe true
+        statement shouldBe a[SelectSQLStatement]
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val condition =
           selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
 
-        val timestampExpression = condition.expression1.asInstanceOf[ComparisonExpression[Long]]
-        val ageExpression       = condition.expression2.asInstanceOf[ComparisonExpression[Int]]
+        val timestampExpression = condition.expression1.asInstanceOf[ComparisonExpression]
+        val ageExpression       = condition.expression2.asInstanceOf[ComparisonExpression]
 
-        val timestampComparison = timestampExpression.value.asInstanceOf[AbsoluteComparisonValue[Long]]
-        val ageComparison       = ageExpression.value.asInstanceOf[AbsoluteComparisonValue[Int]]
+        val timestampComparison = timestampExpression.value.asInstanceOf[AbsoluteComparisonValue]
+        val ageComparison       = ageExpression.value.asInstanceOf[AbsoluteComparisonValue]
 
-        timestampComparison.value shouldBe now +- timestampTolerance
+        timestampComparison.value.asInstanceOf[NSDbLongType].rawValue shouldBe now +- timestampTolerance
         timestampExpression.comparison shouldBe LessThanOperator
 
-        ageComparison.value shouldBe 18
+        ageComparison.value.rawValue shouldBe 18
         ageExpression.comparison shouldBe GreaterOrEqualToOperator
 
       }
@@ -141,26 +143,26 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
 
         val firstTimestamp =
-          expression.expression1.asInstanceOf[ComparisonExpression[_]].value.asInstanceOf[AbsoluteComparisonValue[Long]]
+          expression.expression1.asInstanceOf[ComparisonExpression].value.asInstanceOf[AbsoluteComparisonValue]
         val secondExpression = expression.expression2.asInstanceOf[TupledLogicalExpression]
         val secondTimestamp =
           secondExpression.expression1
-            .asInstanceOf[ComparisonExpression[_]]
+            .asInstanceOf[ComparisonExpression]
             .value
-            .asInstanceOf[RelativeComparisonValue[Long]]
+            .asInstanceOf[RelativeComparisonValue]
         val thirdTimestamp = secondExpression.expression2
-          .asInstanceOf[EqualityExpression[_]]
+          .asInstanceOf[EqualityExpression]
           .value
-          .asInstanceOf[RelativeComparisonValue[Long]]
+          .asInstanceOf[RelativeComparisonValue]
 
-        firstTimestamp.value shouldBe now +- timestampTolerance
+        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now +- timestampTolerance
 
-        secondTimestamp.value shouldBe now - 2 * hours +- timestampTolerance
+        secondTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 2 * hours +- timestampTolerance
         secondTimestamp.operator shouldBe "-"
         secondTimestamp.quantity shouldBe 2
         secondTimestamp.unitMeasure shouldBe "h"
 
-        thirdTimestamp.value shouldBe now + 4 * minutes +- timestampTolerance
+        thirdTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 4 * minutes +- timestampTolerance
         thirdTimestamp.operator shouldBe "+"
         thirdTimestamp.quantity shouldBe 4
         thirdTimestamp.unitMeasure shouldBe "m"
@@ -181,16 +183,16 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
 
         val firstTimestamp =
-          expression.expression1.asInstanceOf[ComparisonExpression[_]].value.asInstanceOf[RelativeComparisonValue[Long]]
+          expression.expression1.asInstanceOf[ComparisonExpression].value.asInstanceOf[RelativeComparisonValue]
         val secondTimestamp =
-          expression.expression2.asInstanceOf[ComparisonExpression[_]].value.asInstanceOf[RelativeComparisonValue[Long]]
+          expression.expression2.asInstanceOf[ComparisonExpression].value.asInstanceOf[RelativeComparisonValue]
 
-        firstTimestamp.value shouldBe now + 5 * seconds +- timestampTolerance
+        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 5 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "+"
         firstTimestamp.quantity shouldBe 5
         firstTimestamp.unitMeasure shouldBe "s"
 
-        secondTimestamp.value shouldBe now - 8 * days +- timestampTolerance
+        secondTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 8 * days +- timestampTolerance
         secondTimestamp.operator shouldBe "-"
         secondTimestamp.quantity shouldBe 8
         secondTimestamp.unitMeasure shouldBe "d"
@@ -212,29 +214,29 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
 
         val firstTimestamp =
-          expression.expression1.asInstanceOf[ComparisonExpression[_]].value.asInstanceOf[RelativeComparisonValue[Long]]
+          expression.expression1.asInstanceOf[ComparisonExpression].value.asInstanceOf[RelativeComparisonValue]
         val secondExpression = expression.expression2.asInstanceOf[TupledLogicalExpression]
         val secondTimestamp =
           secondExpression.expression1
-            .asInstanceOf[ComparisonExpression[_]]
+            .asInstanceOf[ComparisonExpression]
             .value
-            .asInstanceOf[RelativeComparisonValue[Long]]
+            .asInstanceOf[RelativeComparisonValue]
         val thirdTimestamp = secondExpression.expression2
-          .asInstanceOf[EqualityExpression[_]]
+          .asInstanceOf[EqualityExpression]
           .value
-          .asInstanceOf[RelativeComparisonValue[Long]]
+          .asInstanceOf[RelativeComparisonValue]
 
-        firstTimestamp.value shouldBe now + 30 * days +- timestampTolerance
+        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 30 * days +- timestampTolerance
         firstTimestamp.operator shouldBe "+"
         firstTimestamp.quantity shouldBe 30
         firstTimestamp.unitMeasure shouldBe "d"
 
-        secondTimestamp.value shouldBe now - 2 * hours +- timestampTolerance
+        secondTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 2 * hours +- timestampTolerance
         secondTimestamp.operator shouldBe "-"
         secondTimestamp.quantity shouldBe 2
         secondTimestamp.unitMeasure shouldBe "h"
 
-        thirdTimestamp.value shouldBe now + 4 * minutes +- timestampTolerance
+        thirdTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 4 * minutes +- timestampTolerance
         thirdTimestamp.operator shouldBe "+"
         thirdTimestamp.quantity shouldBe 4
         thirdTimestamp.unitMeasure shouldBe "m"
@@ -256,31 +258,31 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
 
         val thirdTimestamp =
-          expression.expression2.asInstanceOf[EqualityExpression[_]].value.asInstanceOf[RelativeComparisonValue[Long]]
+          expression.expression2.asInstanceOf[EqualityExpression].value.asInstanceOf[RelativeComparisonValue]
 
         val secondExpression = expression.expression1.asInstanceOf[TupledLogicalExpression]
         val firstTimestamp =
           secondExpression.expression1
-            .asInstanceOf[ComparisonExpression[_]]
+            .asInstanceOf[ComparisonExpression]
             .value
-            .asInstanceOf[RelativeComparisonValue[Long]]
+            .asInstanceOf[RelativeComparisonValue]
         val secondTimestamp =
           secondExpression.expression2
-            .asInstanceOf[ComparisonExpression[_]]
+            .asInstanceOf[ComparisonExpression]
             .value
-            .asInstanceOf[RelativeComparisonValue[Long]]
+            .asInstanceOf[RelativeComparisonValue]
 
-        firstTimestamp.value shouldBe now + 30 * days +- timestampTolerance
+        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 30 * days +- timestampTolerance
         firstTimestamp.operator shouldBe "+"
         firstTimestamp.quantity shouldBe 30
         firstTimestamp.unitMeasure shouldBe "d"
 
-        secondTimestamp.value shouldBe now - 2 * hours +- timestampTolerance
+        secondTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 2 * hours +- timestampTolerance
         secondTimestamp.operator shouldBe "-"
         secondTimestamp.quantity shouldBe 2
         secondTimestamp.unitMeasure shouldBe "h"
 
-        thirdTimestamp.value shouldBe now + 4 * minutes +- timestampTolerance
+        thirdTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 4 * minutes +- timestampTolerance
         thirdTimestamp.operator shouldBe "+"
         thirdTimestamp.quantity shouldBe 4
         thirdTimestamp.unitMeasure shouldBe "m"
@@ -298,17 +300,17 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[_]]
+          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression]
 
-        val firstTimestamp  = expression.value1.asInstanceOf[RelativeComparisonValue[Long]]
-        val secondTimestamp = expression.value2.asInstanceOf[RelativeComparisonValue[Long]]
+        val firstTimestamp  = expression.value1.asInstanceOf[RelativeComparisonValue]
+        val secondTimestamp = expression.value2.asInstanceOf[RelativeComparisonValue]
 
         expression.dimension shouldBe "timestamp"
-        firstTimestamp.value shouldBe now - 2 * seconds +- timestampTolerance
+        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 2 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 2
         firstTimestamp.unitMeasure shouldBe "s"
-        secondTimestamp.value shouldBe now + 4 * seconds +- timestampTolerance
+        secondTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 4 * seconds +- timestampTolerance
         secondTimestamp.operator shouldBe "+"
         secondTimestamp.quantity shouldBe 4
         secondTimestamp.unitMeasure shouldBe "s"
@@ -326,17 +328,17 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[_]]
+          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression]
 
-        val firstTimestamp  = expression.value1.asInstanceOf[RelativeComparisonValue[Long]]
-        val secondTimestamp = expression.value2.asInstanceOf[RelativeComparisonValue[Long]]
+        val firstTimestamp  = expression.value1.asInstanceOf[RelativeComparisonValue]
+        val secondTimestamp = expression.value2.asInstanceOf[RelativeComparisonValue]
 
         expression.dimension shouldBe "timestamp"
-        firstTimestamp.value shouldBe now - 2 * seconds +- timestampTolerance
+        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 2 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 2
         firstTimestamp.unitMeasure shouldBe "s"
-        secondTimestamp.value shouldBe now + 4 * seconds +- timestampTolerance
+        secondTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 4 * seconds +- timestampTolerance
         secondTimestamp.operator shouldBe "+"
         secondTimestamp.quantity shouldBe 4
         secondTimestamp.unitMeasure shouldBe "s"
@@ -354,15 +356,15 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
         val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression[_]]
+          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression]
 
-        val firstTimestamp = expression.value1.asInstanceOf[RelativeComparisonValue[Long]]
+        val firstTimestamp = expression.value1.asInstanceOf[RelativeComparisonValue]
         expression.dimension shouldBe "timestamp"
-        firstTimestamp.value shouldBe now - 2 * seconds +- timestampTolerance
+        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 2 * seconds +- timestampTolerance
         firstTimestamp.operator shouldBe "-"
         firstTimestamp.quantity shouldBe 2
         firstTimestamp.unitMeasure shouldBe "s"
-        expression.value2 shouldBe AbsoluteComparisonValue(5)
+        expression.value2 shouldBe AbsoluteComparisonValue(5L)
       }
 
     }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
@@ -205,9 +205,9 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
           namespace = "registry",
           input =
             "SELECT name FROM people WHERE timestamp < now + 30d and timestamp > now - 2h AND timestamp = now + 4m")
-        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
+        result shouldBe a[SqlStatementParserSuccess]
         val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
-        statement.isInstanceOf[SelectSQLStatement] shouldBe true
+        statement shouldBe a[SelectSQLStatement]
         val now = System.currentTimeMillis()
 
         val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
@@ -283,8 +283,8 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
                 ),
                 operator = AndOperator,
                 expression2 = RangeExpression(dimension = "timestamp",
-                                              value1 = AbsoluteComparisonValue(2),
-                                              value2 = AbsoluteComparisonValue(4))
+                                              value1 = AbsoluteComparisonValue(2L),
+                                              value2 = AbsoluteComparisonValue(4L))
               ))),
               order = Some(DescOrderOperator(dimension = "name")),
               limit = Some(LimitOperator(5))
@@ -315,8 +315,8 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
                   EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo")),
                   AndOperator,
                   RangeExpression(dimension = "timestamp",
-                                  value1 = AbsoluteComparisonValue(2),
-                                  value2 = AbsoluteComparisonValue(4))
+                                  value1 = AbsoluteComparisonValue(2L),
+                                  value2 = AbsoluteComparisonValue(4L))
                 )
               ))),
               order = Some(DescOrderOperator(dimension = "name")),
@@ -412,8 +412,8 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
                   ),
                   operator = AndOperator,
                   expression2 = RangeExpression(dimension = "timestamp",
-                                                value1 = AbsoluteComparisonValue(2),
-                                                value2 = AbsoluteComparisonValue(4))
+                                                value1 = AbsoluteComparisonValue(2L),
+                                                value2 = AbsoluteComparisonValue(4L))
                 ),
                 expression2 = NotExpression(NullableExpression("code")),
                 operator = AndOperator

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
@@ -501,8 +501,8 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
               fields = ListFields(List(Field("name", None))),
               condition = Some(
                 Condition(RangeExpression(dimension = "timestamp",
-                                          value1 = AbsoluteComparisonValue(2),
-                                          value2 = AbsoluteComparisonValue(4)))),
+                                          value1 = AbsoluteComparisonValue(2L),
+                                          value2 = AbsoluteComparisonValue(4L)))),
               order = Some(DescOrderOperator(dimension = "name")),
               limit = Some(LimitOperator(5))
             )
@@ -521,8 +521,8 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
               fields = ListFields(List(Field("name", None))),
               condition = Some(
                 Condition(RangeExpression(dimension = "timestamp",
-                                          value1 = AbsoluteComparisonValue(2),
-                                          value2 = AbsoluteComparisonValue(4)))),
+                                          value1 = AbsoluteComparisonValue(2L),
+                                          value2 = AbsoluteComparisonValue(4L)))),
               order = Some(DescOrderOperator(dimension = "name")),
               limit = Some(LimitOperator(5))
             )
@@ -550,8 +550,8 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
                   EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo")),
                   AndOperator,
                   RangeExpression(dimension = "timestamp",
-                                  value1 = AbsoluteComparisonValue(2),
-                                  AbsoluteComparisonValue(4))
+                                  value1 = AbsoluteComparisonValue(2L),
+                                  AbsoluteComparisonValue(4L))
                 )
               ))),
               order = Some(DescOrderOperator(dimension = "name")),


### PR DESCRIPTION
This PR has the purpose to _erase_ the generic type of the following objects

* `ComparisonExpression`
* `EqualityExpression`
* `RangeExpression`

Those objects depend now by the internal type system