### PR TITLE
Improve Special Characters Support

### DIFF
--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -104,13 +104,13 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
   private val CloseRoundBracket = ")"
   private val temporalInterval  = "INTERVAL" ignoreCase
 
-  private val chars                      = """(^(?!now)[a-zA-Z_][a-zA-Z0-9_]*)""".r
-  private val charsWithDashes            = """(^(?!now)[a-zA-Z_][a-zA-Z0-9_\-]*[a-zA-Z0-9]*)""".r
-  private val charWithDAshesAndWildcards = """([a-zA-Z0-9_\-$]+)""".r
-  private val digits                     = """([0-9]+)""".r
-  private val intValue                   = digits ^^ { _.toInt }
-  private val longValue                  = digits ^^ { _.toLong }
-  private val doubleValue                = """([0-9]+)\.([0-9]+)""".r ^^ { _.toDouble }
+  private val chars            = """(^(?!now)[a-zA-Z_][a-zA-Z0-9_]*)""".r
+  private val charsWithDashes  = """(^(?!now)[a-zA-Z_][a-zA-Z0-9_\-]*[a-zA-Z0-9]*)""".r
+  private val charWithSpecials = """([a-zA-Z0-9_\-$.:]+)""".r
+  private val digits           = """([0-9]+)""".r
+  private val intValue         = digits ^^ { _.toInt }
+  private val longValue        = digits ^^ { _.toLong }
+  private val doubleValue      = """([0-9]+)\.([0-9]+)""".r ^^ { _.toDouble }
 
   private val field = chars ^^ { e =>
     Field(e, None)
@@ -125,7 +125,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
     case strings: List[String] => strings.mkString(" ")
   }
 
-  private val stringValueWithWildcards = (charWithDAshesAndWildcards | (("'" ?) ~> (charWithDAshesAndWildcards +) <~ ("'" ?))) ^^ {
+  private val stringValueWithWildcards = (charWithSpecials | (("'" ?) ~> (charWithSpecials +) <~ ("'" ?))) ^^ {
     case string: String        => string
     case strings: List[String] => strings.mkString(" ")
   }

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -107,8 +107,8 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
   private val letter          = """[a-zA-Z_]"""
   private val digit           = """[0-9]"""
   private val letterOrDigit   = """[a-zA-Z0-9_]"""
-  private val specialChar     = """[a-zA-Z0-9_\-\.:]"""
-  private val specialWildCard = """[a-zA-Z0-9_\-$\.:]"""
+  private val specialChar     = """[a-zA-Z0-9_\-\.:~]"""
+  private val specialWildCard = """[a-zA-Z0-9_\-$\.:~]"""
 
   private val standardString = s"""($letter$letterOrDigit*)""".r
   private val specialString  = s"""($letter$specialChar*$letterOrDigit*)""".r

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -104,28 +104,33 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
   private val CloseRoundBracket = ")"
   private val temporalInterval  = "INTERVAL" ignoreCase
 
-  private val chars            = """(^(?!now)[a-zA-Z_][a-zA-Z0-9_]*)""".r
-  private val charsWithDashes  = """(^(?!now)[a-zA-Z_][a-zA-Z0-9_\-]*[a-zA-Z0-9]*)""".r
-  private val charWithSpecials = """([a-zA-Z0-9_\-$.:]+)""".r
-  private val digits           = """([0-9]+)""".r
-  private val intValue         = digits ^^ { _.toInt }
-  private val longValue        = digits ^^ { _.toLong }
-  private val doubleValue      = """([0-9]+)\.([0-9]+)""".r ^^ { _.toDouble }
+  private val letter          = """[a-zA-Z_]"""
+  private val digit           = """[0-9]"""
+  private val letterOrDigit   = """[a-zA-Z0-9_]"""
+  private val specialChar     = """[a-zA-Z0-9_\-\.:]"""
+  private val specialWildCard = """[a-zA-Z0-9_\-$\.:]"""
 
-  private val field = chars ^^ { e =>
+  private val standardString = s"""($letter$letterOrDigit*)""".r
+  private val specialString  = s"""($letter$specialChar*$letterOrDigit*)""".r
+  private val wildCardString = s"""($specialWildCard+)""".r
+  private val digits         = s"""($digit+)""".r
+  private val intValue       = digits ^^ { _.toInt }
+  private val longValue      = digits ^^ { _.toLong }
+  private val doubleValue    = s"""($digit+)[.]($digit+)""".r ^^ { _.toDouble }
+
+  private val field = standardString ^^ { e =>
     Field(e, None)
   }
-  private val aggField = ((sum | min | max | count | first | last | avg) <~ OpenRoundBracket) ~ (chars | All) <~ CloseRoundBracket ^^ {
-    e =>
-      Field(e._2, Some(e._1))
+  private val aggField = ((sum | min | max | count | first | last | avg) <~ OpenRoundBracket) ~ (standardString | All) <~ CloseRoundBracket ^^ {
+    case aggregation ~ name => Field(name, Some(aggregation))
   }
-  private val dimension = chars
-  private val stringValue = (charsWithDashes | (("'" ?) ~> (charsWithDashes +) <~ ("'" ?))) ^^ {
+  private val dimension = standardString
+  private val stringValue = (specialString | (("'" ?) ~> (specialString +) <~ ("'" ?))) ^^ {
     case string: String        => string
     case strings: List[String] => strings.mkString(" ")
   }
 
-  private val stringValueWithWildcards = (charWithSpecials | (("'" ?) ~> (charWithSpecials +) <~ ("'" ?))) ^^ {
+  private val stringValueWithWildcards = (wildCardString | (("'" ?) ~> (wildCardString +) <~ ("'" ?))) ^^ {
     case string: String        => string
     case strings: List[String] => strings.mkString(" ")
   }
@@ -198,8 +203,8 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
 
   lazy val orTupledLogicalExpression: PackratParser[TupledLogicalExpression] = tupledLogicalExpression(Or, OrOperator)
 
-  lazy val equalityExpression: PackratParser[EqualityExpression] = (dimension <~ Equal) ~ (stringValue.map(n =>
-    AbsoluteComparisonValue(n)) | comparisonTerm) ^^ {
+  lazy val equalityExpression: PackratParser[EqualityExpression] = (dimension <~ Equal) ~ (comparisonTerm | stringValue
+    .map(n => AbsoluteComparisonValue(n))) ^^ {
     case dim ~ v => EqualityExpression(dim, v)
   }
 

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -106,7 +106,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
 
   private val chars                      = """(^(?!now)[a-zA-Z_][a-zA-Z0-9_]*)""".r
   private val charsWithDashes            = """(^(?!now)[a-zA-Z_][a-zA-Z0-9_\-]*[a-zA-Z0-9]*)""".r
-  private val charWithDAshesAndWildcards = """(^[a-zA-Z_$][a-zA-Z0-9_\-$]*[a-zA-Z0-9$])""".r
+  private val charWithDAshesAndWildcards = """([a-zA-Z0-9_\-$]+)""".r
   private val digits                     = """([0-9]+)""".r
   private val intValue                   = digits ^^ { _.toInt }
   private val longValue                  = digits ^^ { _.toLong }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
@@ -99,24 +99,6 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
       }
     }
 
-    "receive a select containing a like selection" should {
-      "parse it successfully with predicate containing special characters" in {
-        val query = "SELECT name FROM people WHERE (name like $a_m-e$)"
-        parser.parse(db = "db", namespace = "registry", input = query) should be(
-          SqlStatementParserSuccess(
-            query,
-            SelectSQLStatement(
-              db = "db",
-              namespace = "registry",
-              metric = "people",
-              distinct = false,
-              fields = ListFields(List(Field("name", None))),
-              condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_m-e$")))
-            )
-          ))
-      }
-    }
-
     "receive a select containing a GTE selection" should {
       "parse it successfully" in {
         val query = "SELECT name FROM people WHERE (timestamp >= 10)"

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLEqExpressionSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLEqExpressionSpec.scala
@@ -97,7 +97,7 @@ class SelectSQLEqExpressionSpec extends WordSpec with Matchers {
       }
 
       "parse it successfully on string dimension with special characters" in {
-        val query = "select name from people where name = '_spe.cial:_-' limit 5"
+        val query = "select name from people where name = '_spe.cial~:_-' limit 5"
         parser.parse(db = "db", namespace = "registry", input = query) should be(
           SqlStatementParserSuccess(
             query,
@@ -108,14 +108,14 @@ class SelectSQLEqExpressionSpec extends WordSpec with Matchers {
               distinct = false,
               fields = ListFields(List(Field("name", None))),
               condition = Some(
-                Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("_spe.cial:_-")))),
+                Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("_spe.cial~:_-")))),
               limit = Some(LimitOperator(5))
             )
           ))
       }
 
       "parse it successfully on string dimension with special characters and spaces" in {
-        val query = "select name from people where name = '_special:_- with. space' limit 5"
+        val query = "select name from people where name = '_spe~cial:_- with. space' limit 5"
         parser.parse(db = "db", namespace = "registry", input = query) should be(
           SqlStatementParserSuccess(
             query,
@@ -126,7 +126,7 @@ class SelectSQLEqExpressionSpec extends WordSpec with Matchers {
               distinct = false,
               fields = ListFields(List(Field("name", None))),
               condition = Some(Condition(
-                EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("_special:_- with. space")))),
+                EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("_spe~cial:_- with. space")))),
               limit = Some(LimitOperator(5))
             )
           ))

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLEqExpressionSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLEqExpressionSpec.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.sql.parser
+
+import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.sql.parser.StatementParserResult.{SqlStatementParserFailure, SqlStatementParserSuccess}
+import org.scalatest.{Matchers, WordSpec}
+
+class SelectSQLEqExpressionSpec extends WordSpec with Matchers {
+
+  private val parser = new SQLStatementParser
+
+  "A SQL parser instance" when {
+
+    "receive a select containing a = selection" should {
+      "parse it successfully" in {
+        val query = "SELECT name FROM people WHERE timestamp = 10"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition =
+                Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(10L))))
+            )
+          ))
+      }
+
+      "parse it successfully using decimals" in {
+        val query = "SELECT name FROM people WHERE timestamp = 10.5"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition =
+                Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(10.5))))
+            )
+          ))
+      }
+
+      "parse it successfully using string" in {
+        val query = "SELECT name FROM people WHERE timestamp = word_word"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue("word_word"))))
+            )
+          ))
+      }
+
+      "parse it successfully on string dimension with spaces" in {
+        val query = "select name from people where name = 'string spaced' limit 5"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("string spaced")))),
+              limit = Some(LimitOperator(5))
+            )
+          ))
+      }
+
+      "parse it successfully on string dimension with special characters" in {
+        val query = "select name from people where name = '_spe.cial:_-' limit 5"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(
+                Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("_spe.cial:_-")))),
+              limit = Some(LimitOperator(5))
+            )
+          ))
+      }
+
+      "parse it successfully on string dimension with special characters and spaces" in {
+        val query = "select name from people where name = '_special:_- with. space' limit 5"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(
+                EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("_special:_- with. space")))),
+              limit = Some(LimitOperator(5))
+            )
+          ))
+      }
+
+      "parse it successfully on string dimension with one char" in {
+        val query = "select name from people where name = 'a' limit 5"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("a")))),
+              limit = Some(LimitOperator(5))
+            )
+          ))
+      }
+
+      "not allow wildcard char" in {
+        val query = "select name from people where name = 'a$' limit 5"
+        parser.parse(db = "db", namespace = "registry", input = query) shouldBe a[SqlStatementParserFailure]
+      }
+    }
+  }
+}

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLLikeExpressionSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLLikeExpressionSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.sql.parser
+
+import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.sql.parser.StatementParserResult.SqlStatementParserSuccess
+import org.scalatest._
+
+class SelectSQLLikeExpressionSpec extends WordSpec with Matchers {
+
+  private val parser = new SQLStatementParser
+
+  "A SQL parser instance" when {
+
+    "receive a select containing a like selection" should {
+
+      "parse it successfully" in {
+        val query = "SELECT name FROM people WHERE name like $ame$"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(LikeExpression(dimension = "name", value = "$ame$")))
+            )
+          ))
+      }
+
+      "parse it successfully with predicate containing special characters" in {
+        val query = "SELECT name FROM people WHERE name like $a_m-e$"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_m-e$")))
+            )
+          ))
+      }
+
+      "parse it successfully with predicate containing special characters and spaces" in {
+        val query = "SELECT name FROM people WHERE name like '$a_m- e$'"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_m- e$")))
+            )
+          ))
+      }
+
+      "parse it successfully with predicate inside a bracket" in {
+        val query = "SELECT name FROM people WHERE (name like $a_m-e$)"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_m-e$")))
+            )
+          ))
+      }
+    }
+  }
+
+}

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLLikeExpressionSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLLikeExpressionSpec.scala
@@ -61,7 +61,7 @@ class SelectSQLLikeExpressionSpec extends WordSpec with Matchers {
       }
 
       "parse it successfully with predicate containing special characters and spaces" in {
-        val query = "SELECT name FROM people WHERE name like '$a_:m.- :e$'"
+        val query = "SELECT name FROM people WHERE name like '$a_:m.- :~e$'"
         parser.parse(db = "db", namespace = "registry", input = query) should be(
           SqlStatementParserSuccess(
             query,
@@ -71,7 +71,7 @@ class SelectSQLLikeExpressionSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               fields = ListFields(List(Field("name", None))),
-              condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_:m.- :e$")))
+              condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_:m.- :~e$")))
             )
           ))
       }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLLikeExpressionSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLLikeExpressionSpec.scala
@@ -45,7 +45,7 @@ class SelectSQLLikeExpressionSpec extends WordSpec with Matchers {
       }
 
       "parse it successfully with predicate containing special characters" in {
-        val query = "SELECT name FROM people WHERE name like $a_m-e$"
+        val query = "SELECT name FROM people WHERE name like $a_:m-e$"
         parser.parse(db = "db", namespace = "registry", input = query) should be(
           SqlStatementParserSuccess(
             query,
@@ -55,13 +55,13 @@ class SelectSQLLikeExpressionSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               fields = ListFields(List(Field("name", None))),
-              condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_m-e$")))
+              condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_:m-e$")))
             )
           ))
       }
 
       "parse it successfully with predicate containing special characters and spaces" in {
-        val query = "SELECT name FROM people WHERE name like '$a_m- e$'"
+        val query = "SELECT name FROM people WHERE name like '$a_:m.- :e$'"
         parser.parse(db = "db", namespace = "registry", input = query) should be(
           SqlStatementParserSuccess(
             query,
@@ -71,7 +71,7 @@ class SelectSQLLikeExpressionSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               fields = ListFields(List(Field("name", None))),
-              condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_m- e$")))
+              condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_:m.- :e$")))
             )
           ))
       }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
@@ -225,59 +225,6 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
       }
     }
 
-    "receive a select containing a = selection" should {
-      "parse it successfully" in {
-        val query = "SELECT name FROM people WHERE timestamp = 10"
-        parser.parse(db = "db", namespace = "registry", input = query) should be(
-          SqlStatementParserSuccess(
-            query,
-            SelectSQLStatement(
-              db = "db",
-              namespace = "registry",
-              metric = "people",
-              distinct = false,
-              fields = ListFields(List(Field("name", None))),
-              condition =
-                Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(10L))))
-            )
-          ))
-      }
-
-      "parse it successfully using decimals" in {
-        val query = "SELECT name FROM people WHERE timestamp = 10.5"
-        parser.parse(db = "db", namespace = "registry", input = query) should be(
-          SqlStatementParserSuccess(
-            query,
-            SelectSQLStatement(
-              db = "db",
-              namespace = "registry",
-              metric = "people",
-              distinct = false,
-              fields = ListFields(List(Field("name", None))),
-              condition =
-                Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(10.5))))
-            )
-          ))
-      }
-
-      "parse it successfully using string" in {
-        val query = "SELECT name FROM people WHERE timestamp = word_word"
-        parser.parse(db = "db", namespace = "registry", input = query) should be(
-          SqlStatementParserSuccess(
-            query,
-            SelectSQLStatement(
-              db = "db",
-              namespace = "registry",
-              metric = "people",
-              distinct = false,
-              fields = ListFields(List(Field("name", None))),
-              condition = Some(
-                Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue("word_word"))))
-            )
-          ))
-      }
-    }
-
     "receive a select containing a GTE selection" should {
       "parse it successfully" in {
         val query = "SELECT name FROM people WHERE timestamp >= 10"
@@ -618,41 +565,6 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
             limit = Some(LimitOperator(1))
           )
         )
-    }
-
-    "receive a select with where condition on string dimension with spaces" in {
-      val query = "select name from people where name = 'string spaced' limit 5"
-      parser.parse(db = "db", namespace = "registry", input = query) should be(
-        SqlStatementParserSuccess(
-          query,
-          SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition =
-              Some(Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("string spaced")))),
-            limit = Some(LimitOperator(5))
-          )
-        ))
-    }
-
-    "receive a select with where condition on string dimension with one char" in {
-      val query = "select name from people where name = 'a' limit 5"
-      parser.parse(db = "db", namespace = "registry", input = query) should be(
-        SqlStatementParserSuccess(
-          query,
-          SelectSQLStatement(
-            db = "db",
-            namespace = "registry",
-            metric = "people",
-            distinct = false,
-            fields = ListFields(List(Field("name", None))),
-            condition = Some(Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("a")))),
-            limit = Some(LimitOperator(5))
-          )
-        ))
     }
 
     "receive random string sequences" should {

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
@@ -278,40 +278,6 @@ class SelectSQLStatementSpec extends WordSpec with Matchers {
       }
     }
 
-    "receive a select containing a like selection" should {
-      "parse it successfully" in {
-        val query = "SELECT name FROM people WHERE name like $ame$"
-        parser.parse(db = "db", namespace = "registry", input = query) should be(
-          SqlStatementParserSuccess(
-            query,
-            SelectSQLStatement(
-              db = "db",
-              namespace = "registry",
-              metric = "people",
-              distinct = false,
-              fields = ListFields(List(Field("name", None))),
-              condition = Some(Condition(LikeExpression(dimension = "name", value = "$ame$")))
-            )
-          ))
-      }
-
-      "parse it successfully with predicate containing special characters" in {
-        val query = "SELECT name FROM people WHERE name like $a_m-e$"
-        parser.parse(db = "db", namespace = "registry", input = query) should be(
-          SqlStatementParserSuccess(
-            query,
-            SelectSQLStatement(
-              db = "db",
-              namespace = "registry",
-              metric = "people",
-              distinct = false,
-              fields = ListFields(List(Field("name", None))),
-              condition = Some(Condition(LikeExpression(dimension = "name", value = "$a_m-e$")))
-            )
-          ))
-      }
-    }
-
     "receive a select containing a GTE selection" should {
       "parse it successfully" in {
         val query = "SELECT name FROM people WHERE timestamp >= 10"


### PR DESCRIPTION
This PR has the purpose of:
* improving like expressions by adding the support of quotes and thus string with spaces
(e.g. `select * from metrics where field like 'string with space'`)
* improving like and equal expression by adding the support for the following special chars
`_`, `-`, `:`, `~`
 (e.g. `select name from people where name = '_spe~cial:_- with. space'`)