### PR TITLE
[HOTFIX] Fix unsubscribe child actors when downing

### DIFF
--- a/k8s/nsdb-cluster-stateful.yml
+++ b/k8s/nsdb-cluster-stateful.yml
@@ -43,7 +43,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: nsdb
-          image: weareradicalbit/nsdb:1.0.0-SNAPSHOT
+          image: weareradicalbit/nsdb:1.1.0-SNAPSHOT
           imagePullPolicy: IfNotPresent
           #health
           readinessProbe:
@@ -87,6 +87,8 @@ spec:
               value: "k8s-dns"
             - name: SHARD_INTERVAL
               value: "10d"
+            - name: REPLICATION_FACTOR
+              value: 2
 ---
 #headless
 apiVersion: v1

--- a/k8s/nsdb-cluster-stateful.yml
+++ b/k8s/nsdb-cluster-stateful.yml
@@ -88,7 +88,7 @@ spec:
             - name: SHARD_INTERVAL
               value: "10d"
             - name: REPLICATION_FACTOR
-              value: 2
+              value: "2"
 ---
 #headless
 apiVersion: v1


### PR DESCRIPTION
This PR fixes the unsubscribe child actor process in case one node gracefully leaves the cluster.

In case a node is restarted or gracefully stopped (the leave event is propagated by the Akka cluster) we ensure that the unsubscribe process takes place.
In case a node becomes unreachable and then it is downed forcefully the unsubscribe process will take place twice, but, since that is an idempotent operation, we can afford this.

