### PR TITLE
[HOTFIX] FirstLast & MinMax on null tags

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -428,7 +428,7 @@ class MetadataCoordinator(clusterListener: ActorRef,
         val currentTime = System.currentTimeMillis()
         getMetricInfo(db, namespace, metric) { metricInfo =>
           val retention = metricInfo.retention
-          if (retention > 0 && timestamp < currentTime - retention || timestamp > currentTime + retention)
+          if (retention > 0 && (timestamp < currentTime - retention || timestamp > currentTime + retention))
             Future(GetWriteLocationsBeyondRetention(db, namespace, metric, timestamp, metricInfo.retention))
           else {
             (metadataCache ? GetLocationsFromCache(db, namespace, metric))

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AbstractStructuredIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AbstractStructuredIndex.scala
@@ -162,17 +162,17 @@ abstract class AbstractStructuredIndex extends Index[Bit] with TypeSupport {
     val searcher = this.getSearcher
     searcher.search(query, collector)
 
-    collector.retrieveGroupHeads().toSeq.map { id =>
-      val doc = searcher.doc(id)
-      Bit(
-        timestamp = doc.getField(_keyField).numericValue().longValue(),
-        value = NSDbNumericType(doc.getField(_valueField).numericValue()),
-        dimensions = Map.empty,
-        tags = Map(doc.getField(groupTagName) match {
-          case f if f.numericValue() != null => f.name() -> NSDbType(f.numericValue())
-          case f                             => f.name() -> NSDbType(f.stringValue())
-        })
-      )
+    collector.retrieveGroupHeads().map(searcher.doc).collect {
+      case doc if doc.getField(groupTagName) != null =>
+        Bit(
+          timestamp = doc.getField(_keyField).numericValue().longValue(),
+          value = NSDbNumericType(doc.getField(_valueField).numericValue()),
+          dimensions = Map.empty,
+          tags = Map(doc.getField(groupTagName) match {
+            case f if f.numericValue() != null => f.name() -> NSDbType(f.numericValue())
+            case f                             => f.name() -> NSDbType(f.stringValue())
+          })
+        )
     }
   }
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/FirstLastIndexSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/FirstLastIndexSpec.scala
@@ -335,7 +335,7 @@ class FirstLastIndexSpec extends FlatSpec with Matchers with OneInstancePerTest 
             timestamp = i * (j + 1),
             value = i + 0.1,
             dimensions = Map("dimension" -> s"dimension_$i"),
-            tags = Map( "tag2" -> NSDbType(j.toLong), "tag3" -> NSDbType(j + 0.2))
+            tags = Map("tag2"            -> NSDbType(j.toLong), "tag3" -> NSDbType(j + 0.2))
           )
         timeSeriesIndex.write(testData)(writer).get
       }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/FirstLastIndexSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/FirstLastIndexSpec.scala
@@ -310,4 +310,57 @@ class FirstLastIndexSpec extends FlatSpec with Matchers with OneInstancePerTest 
     firstTag2 should contain(Bit(0, 0.1, Map.empty, Map("tag2" -> NSDbType(9L))))
   }
 
+  "TimeSeriesIndex" should "properly discard records with null group key in first and last aggregations" in {
+    val timeSeriesIndex =
+      new TimeSeriesIndex(new MMapDirectory(Paths.get("target", "test_first_last_index", UUID.randomUUID().toString)))
+
+    val writer = timeSeriesIndex.getWriter
+
+    (0 to 5).foreach { j =>
+      (0 to 10).foreach { i =>
+        val testData =
+          Bit(
+            timestamp = i * (j + 1),
+            value = i + 0.1,
+            dimensions = Map("dimension" -> s"dimension_$i"),
+            tags = Map("tag1"            -> NSDbType(s"tag_$j"), "tag2" -> NSDbType(j.toLong), "tag3" -> NSDbType(j + 0.2))
+          )
+        timeSeriesIndex.write(testData)(writer).get
+      }
+    }
+    (6 to 10).foreach { j =>
+      (0 to 10).foreach { i =>
+        val testData =
+          Bit(
+            timestamp = i * (j + 1),
+            value = i + 0.1,
+            dimensions = Map("dimension" -> s"dimension_$i"),
+            tags = Map( "tag2" -> NSDbType(j.toLong), "tag3" -> NSDbType(j + 0.2))
+          )
+        timeSeriesIndex.write(testData)(writer).get
+      }
+    }
+    writer.close()
+
+    val lastTag1 = timeSeriesIndex.getLastGroupBy(new MatchAllDocsQuery, DecimalValueSchema, "tag1")
+    lastTag1.size shouldBe 6
+    lastTag1 should contain(Bit(10, 10.1, Map.empty, Map("tag1" -> NSDbType("tag_0"))))
+    lastTag1 should contain(Bit(20, 10.1, Map.empty, Map("tag1" -> NSDbType("tag_1"))))
+    lastTag1 should contain(Bit(30, 10.1, Map.empty, Map("tag1" -> NSDbType("tag_2"))))
+    lastTag1 should contain(Bit(40, 10.1, Map.empty, Map("tag1" -> NSDbType("tag_3"))))
+    lastTag1 should contain(Bit(50, 10.1, Map.empty, Map("tag1" -> NSDbType("tag_4"))))
+    lastTag1 should contain(Bit(60, 10.1, Map.empty, Map("tag1" -> NSDbType("tag_5"))))
+
+    val firstTag1 =
+      timeSeriesIndex.getFirstGroupBy(new MatchAllDocsQuery, DecimalValueSchema, "tag1")
+    firstTag1.size shouldBe 6
+    firstTag1 should contain(Bit(0, 0.1, Map.empty, Map("tag1" -> NSDbType("tag_0"))))
+    firstTag1 should contain(Bit(0, 0.1, Map.empty, Map("tag1" -> NSDbType("tag_1"))))
+    firstTag1 should contain(Bit(0, 0.1, Map.empty, Map("tag1" -> NSDbType("tag_2"))))
+    firstTag1 should contain(Bit(0, 0.1, Map.empty, Map("tag1" -> NSDbType("tag_3"))))
+    firstTag1 should contain(Bit(0, 0.1, Map.empty, Map("tag1" -> NSDbType("tag_4"))))
+    firstTag1 should contain(Bit(0, 0.1, Map.empty, Map("tag1" -> NSDbType("tag_5"))))
+
+  }
+
 }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/MinMaxIndexSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/MinMaxIndexSpec.scala
@@ -336,7 +336,7 @@ class MinMaxIndexSpec extends FlatSpec with Matchers with OneInstancePerTest {
             timestamp = i * (j + 1),
             value = i + 0.1,
             dimensions = Map("dimension" -> s"dimension_$i"),
-            tags = Map( "tag2" -> NSDbType(j.toLong), "tag3" -> NSDbType(j + 0.2))
+            tags = Map("tag2"            -> NSDbType(j.toLong), "tag3" -> NSDbType(j + 0.2))
           )
         timeSeriesIndex.write(testData)(writer).get
       }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/MinMaxIndexSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/MinMaxIndexSpec.scala
@@ -310,4 +310,57 @@ class MinMaxIndexSpec extends FlatSpec with Matchers with OneInstancePerTest {
     minTag2 should contain(Bit(0, 0.1, Map.empty, Map("tag2" -> NSDbType(8L))))
     minTag2 should contain(Bit(0, 0.1, Map.empty, Map("tag2" -> NSDbType(9L))))
   }
+
+  "TimeSeriesIndex" should "properly discard records with null group key in min and max aggregations" in {
+    val timeSeriesIndex =
+      new TimeSeriesIndex(new MMapDirectory(Paths.get("target", "test_first_last_index", UUID.randomUUID().toString)))
+
+    val writer = timeSeriesIndex.getWriter
+
+    (0 to 5).foreach { j =>
+      (0 to 10).foreach { i =>
+        val testData =
+          Bit(
+            timestamp = i * (j + 1),
+            value = i + 0.1,
+            dimensions = Map("dimension" -> s"dimension_$i"),
+            tags = Map("tag1"            -> NSDbType(s"tag_$j"), "tag2" -> NSDbType(j.toLong), "tag3" -> NSDbType(j + 0.2))
+          )
+        timeSeriesIndex.write(testData)(writer).get
+      }
+    }
+    (6 to 10).foreach { j =>
+      (0 to 10).foreach { i =>
+        val testData =
+          Bit(
+            timestamp = i * (j + 1),
+            value = i + 0.1,
+            dimensions = Map("dimension" -> s"dimension_$i"),
+            tags = Map( "tag2" -> NSDbType(j.toLong), "tag3" -> NSDbType(j + 0.2))
+          )
+        timeSeriesIndex.write(testData)(writer).get
+      }
+    }
+    writer.close()
+
+    val lastTag1 = timeSeriesIndex.getMaxGroupBy(new MatchAllDocsQuery, DecimalValueSchema, "tag1")
+    lastTag1.size shouldBe 6
+    lastTag1 should contain(Bit(10, 10.1, Map.empty, Map("tag1" -> NSDbType("tag_0"))))
+    lastTag1 should contain(Bit(20, 10.1, Map.empty, Map("tag1" -> NSDbType("tag_1"))))
+    lastTag1 should contain(Bit(30, 10.1, Map.empty, Map("tag1" -> NSDbType("tag_2"))))
+    lastTag1 should contain(Bit(40, 10.1, Map.empty, Map("tag1" -> NSDbType("tag_3"))))
+    lastTag1 should contain(Bit(50, 10.1, Map.empty, Map("tag1" -> NSDbType("tag_4"))))
+    lastTag1 should contain(Bit(60, 10.1, Map.empty, Map("tag1" -> NSDbType("tag_5"))))
+
+    val firstTag1 =
+      timeSeriesIndex.getMinGroupBy(new MatchAllDocsQuery, DecimalValueSchema, "tag1")
+    firstTag1.size shouldBe 6
+    firstTag1 should contain(Bit(0, 0.1, Map.empty, Map("tag1" -> NSDbType("tag_0"))))
+    firstTag1 should contain(Bit(0, 0.1, Map.empty, Map("tag1" -> NSDbType("tag_1"))))
+    firstTag1 should contain(Bit(0, 0.1, Map.empty, Map("tag1" -> NSDbType("tag_2"))))
+    firstTag1 should contain(Bit(0, 0.1, Map.empty, Map("tag1" -> NSDbType("tag_3"))))
+    firstTag1 should contain(Bit(0, 0.1, Map.empty, Map("tag1" -> NSDbType("tag_4"))))
+    firstTag1 should contain(Bit(0, 0.1, Map.empty, Map("tag1" -> NSDbType("tag_5"))))
+
+  }
 }


### PR DESCRIPTION
This PR fixes a bug on group by queries on nullable tags in case of Min, Max, First and Last aggregation.
Now the null values are correctly discarded after facet collecting phase