### PR TITLE
Temporal Average Index Retrieval

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -238,7 +238,7 @@ class ReadCoordinator(metadataCoordinator: ActorRef,
                   )
                 }.map(limitAndOrder(_, statement, schema))
 
-              case Right(ParsedAggregatedQuery(_, _, _, agg: InternalCountSimpleAggregation, _, _)) =>
+              case Right(ParsedAggregatedQuery(_, _, _, agg: InternalCountStandardAggregation, _, _)) =>
                 gatherAndGroupNodeResults(statement, statement.groupBy.get.field, schema, uniqueLocationsByNode) {
                   bits =>
                     Bit(
@@ -249,7 +249,7 @@ class ReadCoordinator(metadataCoordinator: ActorRef,
                     )
                 }.map(limitAndOrder(_, statement, schema, Some(agg)))
 
-              case Right(ParsedAggregatedQuery(_, _, _, InternalAvgSimpleAggregation(groupField, _), _, _)) =>
+              case Right(ParsedAggregatedQuery(_, _, _, InternalAvgStandardAggregation(groupField, _), _, _)) =>
                 gatherAndGroupNodeResults(statement, statement.groupBy.get.field, schema, uniqueLocationsByNode) {
                   bits =>
                     val v                              = schema.value.indexType.asInstanceOf[NumericType[_]]

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
@@ -315,7 +315,7 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
           }
 
           shardResults.pipeTo(sender)
-        case Right(ParsedAggregatedQuery(_, _, _, _: InternalCountSimpleAggregation, _, _)) =>
+        case Right(ParsedAggregatedQuery(_, _, _, _: InternalCountStandardAggregation, _, _)) =>
           val filteredIndexes =
             actorsForLocations(locations)
 
@@ -329,7 +329,7 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
 
           shardResults.pipeTo(sender)
 
-        case Right(ParsedAggregatedQuery(_, _, _, InternalAvgSimpleAggregation(groupField, _), _, _)) =>
+        case Right(ParsedAggregatedQuery(_, _, _, InternalAvgStandardAggregation(groupField, _), _, _)) =>
           val filteredIndexes =
             actorsForLocations(locations)
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -85,10 +85,10 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
         case Right(ParsedSimpleQuery(_, _, q, true, limit, fields, _)) if fields.lengthCompare(1) == 0 =>
           handleNoIndexResults(
             Try(facetIndexes.executeDistinctFieldCountIndex(q, fields.map(_.name).head, None, limit)))
-        case Right(ParsedAggregatedQuery(_, _, q, InternalCountSimpleAggregation(groupField, _), _, limit)) =>
+        case Right(ParsedAggregatedQuery(_, _, q, InternalCountStandardAggregation(groupField, _), _, limit)) =>
           handleNoIndexResults(
             Try(facetIndexes.executeCountFacet(q, groupField, None, limit, schema.fieldsMap(groupField).indexType)))
-        case Right(ParsedAggregatedQuery(_, _, q, InternalSumSimpleAggregation(groupField, _), _, limit)) =>
+        case Right(ParsedAggregatedQuery(_, _, q, InternalSumStandardAggregation(groupField, _), _, limit)) =>
           handleNoIndexResults(
             Try(
               facetIndexes.executeSumFacet(q,
@@ -97,7 +97,7 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
                                            limit,
                                            schema.fieldsMap(groupField).indexType,
                                            schema.value.indexType)))
-        case Right(ParsedAggregatedQuery(_, _, q, InternalAvgSimpleAggregation(groupField, _), _, _)) =>
+        case Right(ParsedAggregatedQuery(_, _, q, InternalAvgStandardAggregation(groupField, _), _, _)) =>
           handleNoIndexResults(
             Try(
               facetIndexes.executeSumAndCountFacet(q,
@@ -106,13 +106,13 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
                                                    None,
                                                    schema.fieldsMap(groupField).indexType,
                                                    schema.value.indexType)))
-        case Right(ParsedAggregatedQuery(_, _, q, InternalFirstSimpleAggregation(groupField, _), _, _)) =>
+        case Right(ParsedAggregatedQuery(_, _, q, InternalFirstStandardAggregation(groupField, _), _, _)) =>
           handleNoIndexResults(Try(index.getFirstGroupBy(q, schema, groupField)))
-        case Right(ParsedAggregatedQuery(_, _, q, InternalLastSimpleAggregation(groupField, _), _, _)) =>
+        case Right(ParsedAggregatedQuery(_, _, q, InternalLastStandardAggregation(groupField, _), _, _)) =>
           handleNoIndexResults(Try(index.getLastGroupBy(q, schema, groupField)))
-        case Right(ParsedAggregatedQuery(_, _, q, InternalMaxSimpleAggregation(groupField, _), _, _)) =>
+        case Right(ParsedAggregatedQuery(_, _, q, InternalMaxStandardAggregation(groupField, _), _, _)) =>
           handleNoIndexResults(Try(index.getMaxGroupBy(q, schema, groupField)))
-        case Right(ParsedAggregatedQuery(_, _, q, InternalMinSimpleAggregation(groupField, _), _, _)) =>
+        case Right(ParsedAggregatedQuery(_, _, q, InternalMinStandardAggregation(groupField, _), _, _)) =>
           handleNoIndexResults(Try(index.getMinGroupBy(q, schema, groupField)))
         case Right(ParsedTemporalAggregatedQuery(_, _, q, _, InternalCountTemporalAggregation, _, _, _)) =>
           handleNoIndexResults(

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AllFacetIndexes.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AllFacetIndexes.scala
@@ -114,9 +114,6 @@ class AllFacetIndexes(basePath: String,
             .fold(sumBit)(countBit =>
               sumBit.copy(value = 0.0, tags = Map("count" -> countBit.value, "sum" -> sumBit.value)))
         }
-
-      case _ =>
-        throw new RuntimeException("Not implemented yet.")
     }
 
   def executeDistinctFieldCountIndex(query: Query, field: String, sort: Option[Sort], limit: Int): Seq[Bit] =

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/FacetRangeIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/FacetRangeIndex.scala
@@ -35,7 +35,7 @@ class FacetRangeIndex {
 
   protected[index] def executeRangeFacet(searcher: IndexSearcher,
                                          query: Query,
-                                         aggregationType: InternalTemporalAggregation,
+                                         aggregationType: InternalTemporalSingleAggregation,
                                          rangeFieldName: String,
                                          valueFieldName: String,
                                          valueFieldType: Option[IndexType[_]],
@@ -59,9 +59,6 @@ class FacetRangeIndex {
         new LongRangeFacetDoubleMinMax(rangeFieldName, valueFieldName, true, fc, luceneRanges: _*)
       case (InternalMinTemporalAggregation, _) =>
         new LongRangeFacetLongMinMax(rangeFieldName, valueFieldName, true, fc, luceneRanges: _*)
-      case (InternalAvgTemporalAggregation, _) =>
-        // TODO: to implement
-        throw new RuntimeException("Not implemented yet.")
     }
     toRecord(valueFieldType) {
       facets.getTopChildren(0, rangeFieldName).labelValues.toSeq.collect {

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -48,7 +48,7 @@ package object post_proc {
       case Some(_: InternalTemporalAggregation) =>
         val temporalSortedResults = chainedResults.sortBy(_.timestamp)
         statement.limit.map(_.value).map(v => temporalSortedResults.takeRight(v)) getOrElse temporalSortedResults
-      case Some(InternalCountSimpleAggregation(_, _)) if statement.order.exists(_.dimension == "value") =>
+      case Some(InternalCountStandardAggregation(_, _)) if statement.order.exists(_.dimension == "value") =>
         implicit val ord: Ordering[Any] =
           (if (statement.order.get.isInstanceOf[DescOrderOperator]) Ordering[Long].reverse
            else Ordering[Long]).asInstanceOf[Ordering[Any]]
@@ -164,27 +164,27 @@ package object post_proc {
 
   def internalAggregationProcessing(bits: Seq[Bit],
                                     schema: Schema,
-                                    aggregationType: InternalSimpleAggregationType): Bit = {
+                                    aggregationType: InternalStandardAggregation): Bit = {
     val v                              = schema.value.indexType.asInstanceOf[NumericType[_]]
     implicit val numeric: Numeric[Any] = v.numeric
     aggregationType match {
-      case _: InternalMaxSimpleAggregation =>
+      case _: InternalMaxStandardAggregation =>
         Bit(0,
             NSDbNumericType(bits.map(_.value.rawValue).max),
             foldMapOfBit(bits, bit => bit.dimensions),
             foldMapOfBit(bits, bit => bit.tags))
-      case _: InternalMinSimpleAggregation =>
+      case _: InternalMinStandardAggregation =>
         Bit(0,
             NSDbNumericType(bits.map(_.value.rawValue).min),
             foldMapOfBit(bits, bit => bit.dimensions),
             foldMapOfBit(bits, bit => bit.tags))
-      case _: InternalSumSimpleAggregation =>
+      case _: InternalSumStandardAggregation =>
         Bit(0,
             NSDbNumericType(bits.map(_.value.rawValue).sum),
             foldMapOfBit(bits, bit => bit.dimensions),
             foldMapOfBit(bits, bit => bit.tags))
-      case _: InternalFirstSimpleAggregation => bits.minBy(_.timestamp)
-      case _: InternalLastSimpleAggregation  => bits.maxBy(_.timestamp)
+      case _: InternalFirstStandardAggregation => bits.minBy(_.timestamp)
+      case _: InternalLastStandardAggregation  => bits.maxBy(_.timestamp)
     }
   }
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/AllFacetIndexSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/AllFacetIndexSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.index
+
+import java.nio.file.Paths
+import java.util.UUID
+
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.common.{NSDbDoubleType, NSDbLongType}
+import io.radicalbit.nsdb.index.StorageStrategy.Memory
+import io.radicalbit.nsdb.model.{Location, TimeRange}
+import io.radicalbit.nsdb.statement.StatementParser.InternalAvgTemporalAggregation
+import org.apache.lucene.search.MatchAllDocsQuery
+import org.apache.lucene.store.MMapDirectory
+import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
+
+class AllFacetIndexSpec extends WordSpec with Matchers with OneInstancePerTest {
+
+  "AllFacetIndex" should {
+    "Combine Results for temporal average calculation" in {
+      val basePath = s"target/test_index/${UUID.randomUUID}"
+
+      val location = Location("metric", "node", 0, 100)
+      val directory =
+        new MMapDirectory(Paths.get(basePath, "db", "namespace", "shards", s"${location.shardName}"))
+
+      val timeSeriesIndex = new TimeSeriesIndex(directory)
+
+      val records: Seq[Bit] = (0 to 50).map { i =>
+        Bit(timestamp = i.toLong,
+            value = i.toLong,
+            dimensions = Map("dimension" -> s"dimension_${i / 10}"),
+            tags = Map("tag"             -> s"tag_${i / 10}"))
+      }
+
+      implicit val writer = timeSeriesIndex.getWriter
+      records.foreach(timeSeriesIndex.write)
+      writer.close()
+
+      val ranges: Seq[TimeRange] = Seq(
+        TimeRange(0L, 10L, true, false),
+        TimeRange(10L, 20L, true, false),
+        TimeRange(20L, 30L, true, false),
+        TimeRange(30L, 40L, true, false),
+        TimeRange(40L, 50L, true, false)
+      )
+
+      val searcher      = timeSeriesIndex.getSearcher
+      val allFacetIndex = new AllFacetIndexes(basePath, "db", "namespace", location, Memory)
+
+      allFacetIndex.executeRangeFacet(searcher,
+                                      new MatchAllDocsQuery,
+                                      InternalAvgTemporalAggregation,
+                                      "timestamp",
+                                      "value",
+                                      Some(BIGINT()),
+                                      ranges) shouldBe Seq(
+        Bit(0,
+            NSDbDoubleType(0.0),
+            Map("lowerBound" -> NSDbLongType(0), "upperBound" -> NSDbLongType(10)),
+            Map("count"      -> NSDbLongType(10), "sum"       -> NSDbLongType(45))),
+        Bit(10,
+            NSDbDoubleType(0.0),
+            Map("lowerBound" -> NSDbLongType(10), "upperBound" -> NSDbLongType(20)),
+            Map("count"      -> NSDbLongType(10), "sum"        -> NSDbLongType(145))),
+        Bit(20,
+            NSDbDoubleType(0.0),
+            Map("lowerBound" -> NSDbLongType(20), "upperBound" -> NSDbLongType(30)),
+            Map("count"      -> NSDbLongType(10), "sum"        -> NSDbLongType(245))),
+        Bit(30,
+            NSDbDoubleType(0.0),
+            Map("lowerBound" -> NSDbLongType(30), "upperBound" -> NSDbLongType(40)),
+            Map("count"      -> NSDbLongType(10), "sum"        -> NSDbLongType(345))),
+        Bit(40,
+            NSDbDoubleType(0.0),
+            Map("lowerBound" -> NSDbLongType(40), "upperBound" -> NSDbLongType(50)),
+            Map("count"      -> NSDbLongType(10), "sum"        -> NSDbLongType(445)))
+      )
+    }
+  }
+
+}

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeRangeFacetTest.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeRangeFacetTest.scala
@@ -19,51 +19,58 @@ package io.radicalbit.nsdb.index
 import java.nio.file.Paths
 import java.util.UUID
 
+import io.radicalbit.nsdb.common.NSDbLongType
 import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.model.TimeRange
+import io.radicalbit.nsdb.statement.StatementParser.InternalCountTemporalAggregation
 import org.apache.lucene.document.LongPoint
-import org.apache.lucene.facet.range.{LongRange, LongRangeFacetCounts}
-import org.apache.lucene.facet.{FacetResult, FacetsCollector}
 import org.apache.lucene.index.Term
 import org.apache.lucene.search.{MatchAllDocsQuery, TermQuery}
 import org.apache.lucene.store.MMapDirectory
-import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
+import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
 
-class TimeRangeFacetTest extends FlatSpec with Matchers with OneInstancePerTest {
+class TimeRangeFacetTest extends WordSpec with Matchers with OneInstancePerTest {
 
-  "TimeSeriesIndex" should "supports facet range query on timestamp without where conditions" in {
-    val timeSeriesIndex = new TimeSeriesIndex(new MMapDirectory(Paths.get(s"target/test_index/${UUID.randomUUID}")))
+  "FacetRangeIndex" should {
+    "supports facet range query on timestamp without where conditions" in {
+      val timeSeriesIndex = new TimeSeriesIndex(new MMapDirectory(Paths.get(s"target/test_index/${UUID.randomUUID}")))
 
-    val records: Seq[Bit] = (0 to 30).map { i =>
-      Bit(timestamp = i.toLong,
-          value = i,
-          dimensions = Map("dimension" -> s"dimension_${i / 4}"),
-          tags = Map("tag"             -> s"tag_${i / 4}"))
+      val records: Seq[Bit] = (0 to 30).map { i =>
+        Bit(timestamp = i.toLong,
+            value = i,
+            dimensions = Map("dimension" -> s"dimension_${i / 4}"),
+            tags = Map("tag"             -> s"tag_${i / 4}"))
+      }
+
+      implicit val writer = timeSeriesIndex.getWriter
+      records.foreach(timeSeriesIndex.write)
+      writer.close()
+
+      val ranges: Seq[TimeRange] = Seq(
+        TimeRange(0L, 10L, true, false),
+        TimeRange(10L, 20L, true, false),
+        TimeRange(20L, 30L, true, false)
+      )
+
+      val searcher        = timeSeriesIndex.getSearcher
+      val query           = new MatchAllDocsQuery()
+      val facetRangeIndex = new FacetRangeIndex
+
+      facetRangeIndex.executeRangeFacet(searcher,
+                                        query,
+                                        InternalCountTemporalAggregation,
+                                        "timestamp",
+                                        "value",
+                                        Some(BIGINT()),
+                                        ranges) shouldBe Seq(
+        Bit(0, NSDbLongType(10), Map("lowerBound"  -> NSDbLongType(0), "upperBound"  -> NSDbLongType(10)), Map()),
+        Bit(10, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(10), "upperBound" -> NSDbLongType(20)), Map()),
+        Bit(20, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(20), "upperBound" -> NSDbLongType(30)), Map())
+      )
     }
-
-    implicit val writer = timeSeriesIndex.getWriter
-    records.foreach(timeSeriesIndex.write)
-    writer.close()
-
-    val ranges: Seq[LongRange] = Seq(
-      new LongRange("0-10", 0L, true, 10L, false),
-      new LongRange("10-20", 10L, true, 20L, false),
-      new LongRange("20-30", 20L, true, 30L, false)
-    )
-
-    val fc       = new FacetsCollector
-    val searcher = timeSeriesIndex.getSearcher
-    val query    = new MatchAllDocsQuery()
-    FacetsCollector.search(searcher, query, 0, fc)
-    val facets: LongRangeFacetCounts =
-      new LongRangeFacetCounts("timestamp", fc, ranges: _*)
-    val result: FacetResult = facets.getTopChildren(0, "timestamp")
-
-    result.labelValues.map(_.label).toList shouldBe List("0-10", "10-20", "20-30")
-    result.labelValues.map(_.value).toList shouldBe List(10, 10, 10)
-
   }
 
-  "TimeSeriesIndex" should "supports facet range query on timestamp with where condition on value" in {
+  "supports facet range query on timestamp with where condition on value" in {
     val timeSeriesIndex = new TimeSeriesIndex(new MMapDirectory(Paths.get(s"target/test_index/${UUID.randomUUID}")))
 
     val records: Seq[Bit] = (0 to 30).map { i =>
@@ -77,26 +84,30 @@ class TimeRangeFacetTest extends FlatSpec with Matchers with OneInstancePerTest 
     records.foreach(timeSeriesIndex.write)
     writer.close()
 
-    val ranges: Seq[LongRange] = Seq(
-      new LongRange("0-10", 0L, true, 10L, false),
-      new LongRange("10-20", 10L, true, 20L, false),
-      new LongRange("20-30", 20L, true, 30L, false)
+    val ranges: Seq[TimeRange] = Seq(
+      TimeRange(0L, 10L, true, false),
+      TimeRange(10L, 20L, true, false),
+      TimeRange(20L, 30L, true, false)
     )
 
-    val fc       = new FacetsCollector
-    val searcher = timeSeriesIndex.getSearcher
-    val query    = LongPoint.newRangeQuery("value", 10, Long.MaxValue)
-    FacetsCollector.search(searcher, query, 0, fc)
-    val facets: LongRangeFacetCounts =
-      new LongRangeFacetCounts("timestamp", fc, ranges: _*)
-    val result: FacetResult = facets.getTopChildren(0, "timestamp")
+    val searcher        = timeSeriesIndex.getSearcher
+    val query           = LongPoint.newRangeQuery("value", 10, Long.MaxValue)
+    val facetRangeIndex = new FacetRangeIndex
 
-    result.labelValues.map(_.label).toList shouldBe List("0-10", "10-20", "20-30")
-    result.labelValues.map(_.value).toList shouldBe List(0, 10, 10)
-
+    facetRangeIndex.executeRangeFacet(searcher,
+                                      query,
+                                      InternalCountTemporalAggregation,
+                                      "timestamp",
+                                      "value",
+                                      Some(BIGINT()),
+                                      ranges) shouldBe Seq(
+      Bit(0, NSDbLongType(0), Map("lowerBound"   -> NSDbLongType(0), "upperBound"  -> NSDbLongType(10)), Map()),
+      Bit(10, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(10), "upperBound" -> NSDbLongType(20)), Map()),
+      Bit(20, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(20), "upperBound" -> NSDbLongType(30)), Map())
+    )
   }
 
-  "TimeSeriesIndex" should "supports facet range query on timestamp with where condition on string dimension" in {
+  "supports facet range query on timestamp with where condition on string dimension" in {
     val timeSeriesIndex = new TimeSeriesIndex(new MMapDirectory(Paths.get(s"target/test_index/${UUID.randomUUID}")))
 
     val records: Seq[Bit] = (0 to 30).map { i =>
@@ -110,26 +121,31 @@ class TimeRangeFacetTest extends FlatSpec with Matchers with OneInstancePerTest 
     records.foreach(timeSeriesIndex.write)
     writer.close()
 
-    val ranges: Seq[LongRange] = Seq(
-      new LongRange("0-10", 0L, true, 10L, false),
-      new LongRange("10-20", 10L, true, 20L, false),
-      new LongRange("20-30", 20L, true, 30L, false)
+    val ranges: Seq[TimeRange] = Seq(
+      TimeRange(0L, 10L, true, false),
+      TimeRange(10L, 20L, true, false),
+      TimeRange(20L, 30L, true, false)
     )
 
-    val fc       = new FacetsCollector
-    val searcher = timeSeriesIndex.getSearcher
-    val query    = new TermQuery(new Term("dimension", "dimension_0"))
-    FacetsCollector.search(searcher, query, 0, fc)
-    val facets: LongRangeFacetCounts =
-      new LongRangeFacetCounts("timestamp", fc, ranges: _*)
-    val result: FacetResult = facets.getTopChildren(0, "timestamp")
+    val searcher        = timeSeriesIndex.getSearcher
+    val query           = new TermQuery(new Term("dimension", "dimension_0"))
+    val facetRangeIndex = new FacetRangeIndex
 
-    result.labelValues.map(_.label).toList shouldBe List("0-10", "10-20", "20-30")
-    result.labelValues.map(_.value).toList shouldBe List(10, 0, 0)
+    facetRangeIndex.executeRangeFacet(searcher,
+                                      query,
+                                      InternalCountTemporalAggregation,
+                                      "timestamp",
+                                      "value",
+                                      Some(BIGINT()),
+                                      ranges) shouldBe Seq(
+      Bit(0, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(0), "upperBound"  -> NSDbLongType(10)), Map()),
+      Bit(10, NSDbLongType(0), Map("lowerBound" -> NSDbLongType(10), "upperBound" -> NSDbLongType(20)), Map()),
+      Bit(20, NSDbLongType(0), Map("lowerBound" -> NSDbLongType(20), "upperBound" -> NSDbLongType(30)), Map())
+    )
 
   }
 
-  "TimeSeriesIndex" should "supports facet range query on timestamp with where condition on string tag" in {
+  "supports facet range query on timestamp with where condition on string tag" in {
     val timeSeriesIndex = new TimeSeriesIndex(new MMapDirectory(Paths.get(s"target/test_index/${UUID.randomUUID}")))
 
     val records: Seq[Bit] = (0 to 30).map { i =>
@@ -143,26 +159,30 @@ class TimeRangeFacetTest extends FlatSpec with Matchers with OneInstancePerTest 
     records.foreach(timeSeriesIndex.write)
     writer.close()
 
-    val ranges: Seq[LongRange] = Seq(
-      new LongRange("0-10", 0L, true, 10L, false),
-      new LongRange("10-20", 10L, true, 20L, false),
-      new LongRange("20-30", 20L, true, 30L, false)
+    val ranges: Seq[TimeRange] = Seq(
+      TimeRange(0L, 10L, true, false),
+      TimeRange(10L, 20L, true, false),
+      TimeRange(20L, 30L, true, false)
     )
 
-    val fc       = new FacetsCollector
-    val searcher = timeSeriesIndex.getSearcher
-    val query    = new TermQuery(new Term("tag", "tag_1"))
-    FacetsCollector.search(searcher, query, 0, fc)
-    val facets: LongRangeFacetCounts =
-      new LongRangeFacetCounts("timestamp", fc, ranges: _*)
-    val result: FacetResult = facets.getTopChildren(0, "timestamp")
+    val searcher        = timeSeriesIndex.getSearcher
+    val query           = new TermQuery(new Term("tag", "tag_1"))
+    val facetRangeIndex = new FacetRangeIndex
 
-    result.labelValues.map(_.label).toList shouldBe List("0-10", "10-20", "20-30")
-    result.labelValues.map(_.value).toList shouldBe List(0, 10, 0)
-
+    facetRangeIndex.executeRangeFacet(searcher,
+                                      query,
+                                      InternalCountTemporalAggregation,
+                                      "timestamp",
+                                      "value",
+                                      Some(BIGINT()),
+                                      ranges) shouldBe Seq(
+      Bit(0, NSDbLongType(0), Map("lowerBound"   -> NSDbLongType(0), "upperBound"  -> NSDbLongType(10)), Map()),
+      Bit(10, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(10), "upperBound" -> NSDbLongType(20)), Map()),
+      Bit(20, NSDbLongType(0), Map("lowerBound"  -> NSDbLongType(20), "upperBound" -> NSDbLongType(30)), Map())
+    )
   }
 
-  "TimeSeriesIndex" should "supports temporal facet aggregation query on timestamp with range on timestamp" in {
+  "supports temporal facet aggregation query on timestamp with range on timestamp" in {
     val timeSeriesIndex = new TimeSeriesIndex(new MMapDirectory(Paths.get(s"target/test_index/${UUID.randomUUID}")))
 
     val records: Seq[Bit] = (0 to 50).map { i =>
@@ -176,26 +196,31 @@ class TimeRangeFacetTest extends FlatSpec with Matchers with OneInstancePerTest 
     records.foreach(timeSeriesIndex.write)
     writer.close()
 
-    val ranges: Seq[LongRange] = Seq(
-      new LongRange("0-10", 0L, true, 10L, false),
-      new LongRange("10-20", 10L, true, 20L, false),
-      new LongRange("20-30", 20L, true, 30L, false),
-      new LongRange("30-40", 30L, true, 40L, false),
-      new LongRange("40-50", 40L, true, 50L, false)
+    val ranges: Seq[TimeRange] = Seq(
+      TimeRange(0L, 10L, true, false),
+      TimeRange(10L, 20L, true, false),
+      TimeRange(20L, 30L, true, false),
+      TimeRange(30L, 40L, true, false),
+      TimeRange(40L, 50L, true, false)
     )
 
-    val fc       = new FacetsCollector
-    val searcher = timeSeriesIndex.getSearcher
-    val query    = LongPoint.newRangeQuery("timestamp", 0, 20)
-    FacetsCollector.search(searcher, query, 0, fc)
-    val facets: LongRangeFacetCounts =
-      new LongRangeFacetCounts("timestamp", fc, ranges: _*)
-    val result: FacetResult = facets.getTopChildren(0, "timestamp")
+    val searcher        = timeSeriesIndex.getSearcher
+    val query           = LongPoint.newRangeQuery("timestamp", 0, 20)
+    val facetRangeIndex = new FacetRangeIndex
 
-    result.labelValues.map(_.label).toList shouldBe List("0-10", "10-20", "20-30", "30-40", "40-50")
-    // Range query conditions are inclusive
-    result.labelValues.map(_.value).toList shouldBe List(10, 10, 1, 0, 0)
-
+    facetRangeIndex.executeRangeFacet(searcher,
+                                      query,
+                                      InternalCountTemporalAggregation,
+                                      "timestamp",
+                                      "value",
+                                      Some(BIGINT()),
+                                      ranges) shouldBe Seq(
+      Bit(0, NSDbLongType(10), Map("lowerBound"  -> NSDbLongType(0), "upperBound"  -> NSDbLongType(10)), Map()),
+      Bit(10, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(10), "upperBound" -> NSDbLongType(20)), Map()),
+      Bit(20, NSDbLongType(1), Map("lowerBound"  -> NSDbLongType(20), "upperBound" -> NSDbLongType(30)), Map()),
+      Bit(30, NSDbLongType(0), Map("lowerBound"  -> NSDbLongType(30), "upperBound" -> NSDbLongType(40)), Map()),
+      Bit(40, NSDbLongType(0), Map("lowerBound"  -> NSDbLongType(40), "upperBound" -> NSDbLongType(50)), Map())
+    )
   }
 
 }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeRangeFacetTest.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeRangeFacetTest.scala
@@ -100,7 +100,6 @@ class TimeRangeFacetTest extends WordSpec with Matchers with OneInstancePerTest 
                                         "value",
                                         Some(BIGINT()),
                                         ranges) shouldBe Seq(
-        Bit(0, NSDbLongType(0), Map("lowerBound"   -> NSDbLongType(0), "upperBound"  -> NSDbLongType(10)), Map()),
         Bit(10, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(10), "upperBound" -> NSDbLongType(20)), Map()),
         Bit(20, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(20), "upperBound" -> NSDbLongType(30)), Map())
       )
@@ -137,9 +136,7 @@ class TimeRangeFacetTest extends WordSpec with Matchers with OneInstancePerTest 
                                         "value",
                                         Some(BIGINT()),
                                         ranges) shouldBe Seq(
-        Bit(0, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(0), "upperBound"  -> NSDbLongType(10)), Map()),
-        Bit(10, NSDbLongType(0), Map("lowerBound" -> NSDbLongType(10), "upperBound" -> NSDbLongType(20)), Map()),
-        Bit(20, NSDbLongType(0), Map("lowerBound" -> NSDbLongType(20), "upperBound" -> NSDbLongType(30)), Map())
+        Bit(0, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(0), "upperBound" -> NSDbLongType(10)), Map())
       )
 
     }
@@ -175,9 +172,7 @@ class TimeRangeFacetTest extends WordSpec with Matchers with OneInstancePerTest 
                                         "value",
                                         Some(BIGINT()),
                                         ranges) shouldBe Seq(
-        Bit(0, NSDbLongType(0), Map("lowerBound"   -> NSDbLongType(0), "upperBound"  -> NSDbLongType(10)), Map()),
-        Bit(10, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(10), "upperBound" -> NSDbLongType(20)), Map()),
-        Bit(20, NSDbLongType(0), Map("lowerBound"  -> NSDbLongType(20), "upperBound" -> NSDbLongType(30)), Map())
+        Bit(10, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(10), "upperBound" -> NSDbLongType(20)), Map())
       )
     }
 
@@ -216,9 +211,7 @@ class TimeRangeFacetTest extends WordSpec with Matchers with OneInstancePerTest 
                                         ranges) shouldBe Seq(
         Bit(0, NSDbLongType(10), Map("lowerBound"  -> NSDbLongType(0), "upperBound"  -> NSDbLongType(10)), Map()),
         Bit(10, NSDbLongType(10), Map("lowerBound" -> NSDbLongType(10), "upperBound" -> NSDbLongType(20)), Map()),
-        Bit(20, NSDbLongType(1), Map("lowerBound"  -> NSDbLongType(20), "upperBound" -> NSDbLongType(30)), Map()),
-        Bit(30, NSDbLongType(0), Map("lowerBound"  -> NSDbLongType(30), "upperBound" -> NSDbLongType(40)), Map()),
-        Bit(40, NSDbLongType(0), Map("lowerBound"  -> NSDbLongType(40), "upperBound" -> NSDbLongType(50)), Map())
+        Bit(20, NSDbLongType(1), Map("lowerBound"  -> NSDbLongType(20), "upperBound" -> NSDbLongType(30)), Map())
       )
     }
   }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
@@ -723,7 +723,7 @@ class StatementParserSpec extends WordSpec with Matchers {
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
-              InternalSumSimpleAggregation("age", "value")
+              InternalSumStandardAggregation("age", "value")
             ))
         )
       }
@@ -749,7 +749,7 @@ class StatementParserSpec extends WordSpec with Matchers {
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
-              InternalSumSimpleAggregation("country", "value")
+              InternalSumStandardAggregation("country", "value")
             ))
         )
       }
@@ -775,7 +775,7 @@ class StatementParserSpec extends WordSpec with Matchers {
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
-              InternalAvgSimpleAggregation("country", "value")
+              InternalAvgStandardAggregation("country", "value")
             ))
         )
       }
@@ -801,7 +801,7 @@ class StatementParserSpec extends WordSpec with Matchers {
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
-              InternalFirstSimpleAggregation("age", "value")
+              InternalFirstStandardAggregation("age", "value")
             ))
         )
       }
@@ -827,7 +827,7 @@ class StatementParserSpec extends WordSpec with Matchers {
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
-              InternalLastSimpleAggregation("country", "value")
+              InternalLastStandardAggregation("country", "value")
             ))
         )
       }
@@ -853,7 +853,7 @@ class StatementParserSpec extends WordSpec with Matchers {
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
-              InternalMaxSimpleAggregation("country", "value")
+              InternalMaxStandardAggregation("country", "value")
             ))
         )
       }
@@ -879,7 +879,7 @@ class StatementParserSpec extends WordSpec with Matchers {
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
-              InternalMinSimpleAggregation("country", "value")
+              InternalMinStandardAggregation("country", "value")
             ))
         )
       }
@@ -910,7 +910,7 @@ class StatementParserSpec extends WordSpec with Matchers {
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2L, 4L),
-              InternalMaxSimpleAggregation("country", "value"),
+              InternalMaxStandardAggregation("country", "value"),
               Some(new Sort(new SortField("value", SortField.Type.DOUBLE, true))),
               Some(5)
             ))
@@ -1138,7 +1138,7 @@ class StatementParserSpec extends WordSpec with Matchers {
                 .add(LongPoint.newRangeQuery("creationDate", Long.MinValue, Long.MaxValue),
                      BooleanClause.Occur.MUST_NOT)
                 .build(),
-              InternalSumSimpleAggregation("amount", "value"),
+              InternalSumStandardAggregation("amount", "value"),
               None,
               Some(5)
             ))


### PR DESCRIPTION
This PR adds the average retrieval from indexes for temporal average queries.
Essentially, the sum and the count are simultaneously retrieved and the results are combined in a single Bit.

Purpose of the post-processing phase will be to reduce all the partial results and therefore calculate the actual average.

The post-processing phase will be implemented in a future PR
