### PR TITLE
[HOTFIX] Discard empty time buckets

### DIFF
--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSimpleStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSimpleStatementsSpec.scala
@@ -150,7 +150,10 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
         val expected = probe.expectMsgType[MetricsGot]
 
         expected.namespace shouldBe namespace
-        expected.metrics shouldBe Set(LongMetric.name, DoubleMetric.name, AggregationLongMetric.name, AggregationDoubleMetric.name)
+        expected.metrics shouldBe Set(LongMetric.name,
+                                      DoubleMetric.name,
+                                      AggregationLongMetric.name,
+                                      AggregationDoubleMetric.name)
 
       }
     }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
@@ -169,7 +169,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           probe.expectMsgType[SelectStatementExecuted]
         }
 
-        expected.values.size shouldBe 7
+        expected.values.size shouldBe 6
 
         expected.values shouldBe Seq(
           Bit(0, 1L, Map("lowerBound"      -> 0L, "upperBound"      -> 10000L), Map()),
@@ -177,8 +177,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           Bit(40000, 1L, Map("lowerBound"  -> 40000L, "upperBound"  -> 70000L), Map()),
           Bit(70000, 1L, Map("lowerBound"  -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(100000, 1L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
-          Bit(130000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(160000, 0L, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
+          Bit(130000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
         )
 
       }
@@ -239,8 +238,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
         expected.values.size shouldBe 2
 
         expected.values shouldBe Seq(
-          Bit(130000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(160000, 0L, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
+          Bit(100000, 1L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
+          Bit(130000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
         )
       }
 
@@ -269,8 +268,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
         expected.values.size shouldBe 2
 
         expected.values shouldBe Seq(
-          Bit(130000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(160000, 0L, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
+          Bit(100000, 1L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
+          Bit(130000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
         )
       }
 
@@ -328,7 +327,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           probe.expectMsgType[SelectStatementExecuted]
         }
 
-        expected.values.size shouldBe 7
+        expected.values.size shouldBe 6
 
         expected.values shouldBe Seq(
           Bit(0, 1L, Map("lowerBound"      -> 0L, "upperBound"      -> 10000L), Map()),
@@ -336,8 +335,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           Bit(40000, 1L, Map("lowerBound"  -> 40000L, "upperBound"  -> 70000L), Map()),
           Bit(70000, 1L, Map("lowerBound"  -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(100000, 1L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
-          Bit(130000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(160000, 0L, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
+          Bit(130000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
         )
 
       }
@@ -399,14 +397,13 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           probe.expectMsgType[SelectStatementExecuted]
         }
 
-        expected.values.size shouldBe 5
+        expected.values.size shouldBe 4
 
         expected.values shouldBe Seq(
           Bit(60000, 1L, Map("lowerBound"  -> 60000L, "upperBound"  -> 70000L), Map()),
           Bit(70000, 1L, Map("lowerBound"  -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(100000, 1L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
-          Bit(130000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(160000, 0L, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
+          Bit(130000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
         )
       }
 
@@ -528,7 +525,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           probe.expectMsgType[SelectStatementExecuted]
         }
 
-        expected.values.size shouldBe 7
+        expected.values.size shouldBe 6
 
         expected.values shouldBe Seq(
           Bit(0, 1L, Map("lowerBound"      -> 0L, "upperBound"      -> 10000L), Map()),
@@ -536,8 +533,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           Bit(40000, 7L, Map("lowerBound"  -> 40000L, "upperBound"  -> 70000L), Map()),
           Bit(70000, 5L, Map("lowerBound"  -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(100000, 3L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
-          Bit(130000, 2L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(160000, 0L, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
+          Bit(130000, 2L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
         )
 
       }
@@ -596,7 +592,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           probe.expectMsgType[SelectStatementExecuted]
         }
 
-        expected.values.size shouldBe 7
+        expected.values.size shouldBe 6
 
         expected.values shouldBe Seq(
           Bit(0, 1.5, Map("lowerBound"      -> 0L, "upperBound"      -> 10000L), Map()),
@@ -604,8 +600,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           Bit(40000, 7.5, Map("lowerBound"  -> 40000L, "upperBound"  -> 70000L), Map()),
           Bit(70000, 5.5, Map("lowerBound"  -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(100000, 3.5, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
-          Bit(130000, 2.5, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(160000, 0.0, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
+          Bit(130000, 2.5, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
         )
 
       }
@@ -664,7 +659,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           probe.expectMsgType[SelectStatementExecuted]
         }
 
-        expected.values.size shouldBe 7
+        expected.values.size shouldBe 6
 
         expected.values shouldBe Seq(
           Bit(0, 1L, Map("lowerBound"      -> 0L, "upperBound"      -> 10000L), Map()),
@@ -672,8 +667,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           Bit(40000, 7L, Map("lowerBound"  -> 40000L, "upperBound"  -> 70000L), Map()),
           Bit(70000, 5L, Map("lowerBound"  -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(100000, 3L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
-          Bit(130000, 2L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(160000, 0L, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
+          Bit(130000, 2L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
         )
 
       }
@@ -732,7 +726,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           probe.expectMsgType[SelectStatementExecuted]
         }
 
-        expected.values.size shouldBe 7
+        expected.values.size shouldBe 6
 
         expected.values shouldBe Seq(
           Bit(0, 1.5, Map("lowerBound"      -> 0L, "upperBound"      -> 10000L), Map()),
@@ -740,8 +734,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           Bit(40000, 7.5, Map("lowerBound"  -> 40000L, "upperBound"  -> 70000L), Map()),
           Bit(70000, 5.5, Map("lowerBound"  -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(100000, 3.5, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
-          Bit(130000, 2.5, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(160000, 0.0, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
+          Bit(130000, 2.5, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
         )
 
       }
@@ -800,7 +793,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           probe.expectMsgType[SelectStatementExecuted]
         }
 
-        expected.values.size shouldBe 7
+        expected.values.size shouldBe 6
 
         expected.values shouldBe Seq(
           Bit(0L, 1L, Map("lowerBound"      -> 0L, "upperBound"      -> 10000L), Map()),
@@ -808,8 +801,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           Bit(40000L, 7L, Map("lowerBound"  -> 40000L, "upperBound"  -> 70000L), Map()),
           Bit(70000L, 5L, Map("lowerBound"  -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(100000L, 3L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
-          Bit(130000L, 2L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(160000L, 0L, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
+          Bit(130000L, 2L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
         )
 
       }
@@ -868,7 +860,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           probe.expectMsgType[SelectStatementExecuted]
         }
 
-        expected.values.size shouldBe 7
+        expected.values.size shouldBe 6
 
         expected.values shouldBe Seq(
           Bit(0, 1.5, Map("lowerBound"      -> 0L, "upperBound"      -> 10000L), Map()),
@@ -876,8 +868,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
           Bit(40000, 7.5, Map("lowerBound"  -> 40000L, "upperBound"  -> 70000L), Map()),
           Bit(70000, 5.5, Map("lowerBound"  -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(100000, 3.5, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
-          Bit(130000, 2.5, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(160000, 0.0, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
+          Bit(130000, 2.5, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
         )
 
       }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/FacetRangeIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/FacetRangeIndex.scala
@@ -64,9 +64,10 @@ class FacetRangeIndex {
         throw new RuntimeException("Not implemented yet.")
     }
     toRecord(valueFieldType) {
-      facets.getTopChildren(0, rangeFieldName).labelValues.toSeq.map { lv =>
-        val structuredLabel = lv.label.split("-").map(_.toLong)
-        FacetRangeResult(structuredLabel(0), structuredLabel(1), lv.value)
+      facets.getTopChildren(0, rangeFieldName).labelValues.toSeq.collect {
+        case lv if lv.value.doubleValue > 0.0 =>
+          val structuredLabel = lv.label.split("-").map(_.toLong)
+          FacetRangeResult(structuredLabel(0), structuredLabel(1), lv.value)
       }
     }
   }

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/TemporalReadCoordinatorSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/TemporalReadCoordinatorSpec.scala
@@ -1,0 +1,451 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster
+
+import java.time.Duration
+
+import akka.cluster.{Cluster, MemberStatus}
+import io.radicalbit.nsdb.api.scala.NSDB
+import io.radicalbit.nsdb.client.rpc.converter.GrpcBitConverters._
+import io.radicalbit.nsdb.common.protocol._
+import io.radicalbit.nsdb.minicluster.converters.BitConverters.BitConverter
+import io.radicalbit.nsdb.test.MiniClusterSpec
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext}
+
+object TemporalDoubleMetric {
+
+  val name = "temporalDoubleMetric"
+
+  val testRecords: Seq[Bit] = Seq(
+    Bit(150000, 2.5, Map("surname" -> "Doe"), Map("name" -> "John")),
+    Bit(120000, 3.5, Map("surname" -> "Doe"), Map("name" -> "John")),
+    Bit(90000, 5.5, Map("surname" -> "Doe"), Map("name" -> "John")),
+    Bit(60000, 7.5, Map("surname" -> "Doe"), Map("name" -> "Bill")),
+    Bit(30000, 4.5, Map("surname" -> "Doe"), Map("name" -> "Frank")),
+    Bit(0, 1.5, Map("surname"     -> "Doe"), Map("name" -> "Frankie"))
+  )
+}
+
+object TemporalLongMetric {
+
+  val name = "temporalLongMetric"
+
+  val testRecords: Seq[Bit] = Seq(
+    Bit(150000L, 2L, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 15L, "height" -> 30.5)),
+    Bit(120000L, 3L, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 20L, "height" -> 30.5)),
+    Bit(90000L, 5L, Map("surname" -> "Doe"), Map("name" -> "John", "age"    -> 15L, "height" -> 30.5)),
+    Bit(60000L, 7L, Map("surname" -> "Doe"), Map("name" -> "Bill", "age"    -> 15L, "height" -> 31.0)),
+    Bit(30000L, 4L, Map("surname" -> "Doe"), Map("name" -> "Frank", "age"   -> 15L, "height" -> 32.0)),
+    Bit(0L, 1L, Map("surname"     -> "Doe"), Map("name" -> "Frankie", "age" -> 15L, "height" -> 32.0))
+  )
+}
+
+class TemporalReadCoordinatorSpec extends MiniClusterSpec {
+
+  override val replicationFactor: Int = 1
+  override val shardInterval: Duration = Duration.ofSeconds(30)
+
+  val db        = "db"
+  val namespace = "registry"
+
+  override def beforeAll(): Unit = {
+
+    super.beforeAll()
+
+    val firstNode = nodes.head
+
+    val nsdbConnection =
+      eventually {
+        Await.result(NSDB.connect(host = firstNode.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+      }
+
+    TemporalLongMetric.testRecords.map(_.asApiBit(db, namespace, TemporalLongMetric.name)).foreach { bit =>
+      eventually {
+        assert(Await.result(nsdbConnection.write(bit), 10.seconds).completedSuccessfully)
+      }
+    }
+
+    TemporalDoubleMetric.testRecords.map(_.asApiBit(db, namespace, TemporalDoubleMetric.name)).foreach { bit =>
+      eventually {
+        assert(Await.result(nsdbConnection.write(bit), 10.seconds).completedSuccessfully)
+      }
+    }
+
+    waitIndexing()
+  }
+
+  test("join cluster") {
+    eventually {
+      assert(
+        Cluster(nodes.head.system).state.members
+          .count(_.status == MemberStatus.Up) == nodes.size)
+    }
+  }
+
+  test("execute a temporal count query on a Long metric") {
+
+    nodes.foreach { n =>
+      val nsdb =
+        Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+      val query = nsdb
+        .db(db)
+        .namespace(namespace)
+        .query(s"select count(*) from ${TemporalLongMetric.name} group by interval 30s")
+
+      eventually {
+        val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+        assert(readRes.completedSuccessfully)
+        assert(readRes.records.size == 5)
+        assert(readRes.records.map(_.asBit) == Seq(
+          Bit(0,2L,Map("lowerBound" -> 0L, "upperBound" -> 30000L),Map()),
+          Bit(30000,1L,Map("lowerBound" -> 30000L, "upperBound" -> 60000L),Map()),
+          Bit(60000,1L,Map("lowerBound" -> 60000L, "upperBound" -> 90000L),Map()),
+          Bit(90000,1L,Map("lowerBound" -> 90000L, "upperBound" -> 120000L),Map()),
+          Bit(120000,1L,Map("lowerBound" -> 120000L, "upperBound" -> 150000L),Map())
+        )
+        )
+      }
+    }
+  }
+
+  test("execute a temporal count query when no shard is picked up") {
+    nodes.foreach { n =>
+      val nsdb =
+        Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+      val query = nsdb
+        .db(db)
+        .namespace(namespace)
+        .query(s"select count(*) from ${TemporalLongMetric.name} where timestamp > 200000 group by interval 30s")
+
+      eventually {
+        val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+        assert(readRes.completedSuccessfully)
+        assert(readRes.records.isEmpty)
+        assert(readRes.records.map(_.asBit) == Seq())
+      }
+    }
+  }
+
+  test("execute a temporal count query when only one shard is picked up") {
+    nodes.foreach { n =>
+      val nsdb =
+        Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+      val query = nsdb
+        .db(db)
+        .namespace(namespace)
+        .query(s"select count(*) from ${TemporalLongMetric.name} where timestamp > 100000 group by interval 30s")
+
+      eventually {
+        val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+        assert(readRes.completedSuccessfully)
+        assert(readRes.records.size == 2)
+        assert(readRes.records.map(_.asBit) == Seq(
+          Bit(100001, 1L, Map("lowerBound" -> 100001L, "upperBound" -> 120000L), Map()),
+          Bit(120000, 1L, Map("lowerBound" -> 120000L, "upperBound" -> 150000L), Map())
+        ))
+      }
+    }
+  }
+
+  test("execute a temporal count query with a limit") {
+    nodes.foreach { n =>
+      val nsdb =
+        Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+      val query = nsdb
+        .db(db)
+        .namespace(namespace)
+        .query(s"select count(*) from ${TemporalLongMetric.name} group by interval 30s limit 2")
+
+      eventually {
+        val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+        assert(readRes.completedSuccessfully)
+        assert(readRes.records.size == 2)
+        assert(readRes.records.map(_.asBit) == Seq(
+          Bit(90000, 1L, Map("lowerBound" -> 90000L, "upperBound" -> 120000L), Map()),
+          Bit(120000, 1L, Map("lowerBound" -> 120000L, "upperBound" -> 150000L), Map())
+        ))
+      }
+    }
+  }
+
+  test("execute a temporal count query when time ranges contain more than one value") {
+    nodes.foreach { n =>
+      val nsdb =
+        Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+      val query = nsdb
+        .db(db)
+        .namespace(namespace)
+        .query(s"select count(*) from ${TemporalLongMetric.name} group by interval 60s")
+
+      eventually {
+        val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+        assert(readRes.completedSuccessfully)
+        assert(readRes.records.size == 3)
+        assert(readRes.records.map(_.asBit) == Seq(
+          Bit(0, 3L, Map("lowerBound"      -> 0L, "upperBound"      -> 60000L), Map()),
+          Bit(60000, 2L, Map("lowerBound"  -> 60000L, "upperBound"  -> 120000L), Map()),
+          Bit(120000, 1L, Map("lowerBound"  -> 120000L, "upperBound"  -> 180000L), Map())
+        ))
+      }
+    }
+  }
+
+  test("execute a temporal count on a double metric") {
+    nodes.foreach { n =>
+      val nsdb =
+        Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+      val query = nsdb
+        .db(db)
+        .namespace(namespace)
+        .query(s"select count(*) from ${TemporalDoubleMetric.name} group by interval 30s")
+
+      eventually {
+        val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+        assert(readRes.completedSuccessfully)
+        assert(readRes.records.size == 5)
+        assert(readRes.records.map(_.asBit) == Seq(
+          Bit(0, 2L, Map("lowerBound" -> 0L, "upperBound" -> 30000L), Map()),
+          Bit(30000, 1L, Map("lowerBound" -> 30000L, "upperBound" -> 60000L), Map()),
+          Bit(60000, 1L, Map("lowerBound" -> 60000L, "upperBound" -> 90000L), Map()),
+          Bit(90000, 1L, Map("lowerBound" -> 90000L, "upperBound" -> 120000L), Map()),
+          Bit(120000, 1L, Map("lowerBound" -> 120000L, "upperBound" -> 150000L), Map())
+        ))
+      }
+    }
+  }
+
+  test("execute a temporal count on a double metric when time ranges contain more than one value") {
+    nodes.foreach { n =>
+      val nsdb =
+        Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+      val query = nsdb
+        .db(db)
+        .namespace(namespace)
+        .query(s"select count(*) from ${TemporalDoubleMetric.name} group by interval 60s")
+
+      eventually {
+        val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+        assert(readRes.completedSuccessfully)
+        assert(readRes.records.size == 3)
+        assert(readRes.records.map(_.asBit) == Seq(
+          Bit(0, 3L, Map("lowerBound"      -> 0L, "upperBound"      -> 60000L), Map()),
+          Bit(60000, 2L, Map("lowerBound"  -> 60000L, "upperBound"  -> 120000L), Map()),
+          Bit(120000, 1L, Map("lowerBound"  -> 120000L, "upperBound"  -> 180000L), Map())
+        ))
+      }
+    }
+  }
+
+  test("execute a temporal count with an interval higher than the shard interval")  {
+    nodes.foreach { n =>
+      val nsdb =
+        Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+      val query = nsdb
+        .db(db)
+        .namespace(namespace)
+        .query(s"select count(*) from ${TemporalDoubleMetric.name} group by interval 100s")
+
+      eventually {
+        val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+        assert(readRes.completedSuccessfully)
+        assert(readRes.records.size == 2)
+        assert(readRes.records.map(_.asBit) == Seq(
+          Bit(0, 3L, Map("lowerBound"     -> 0L, "upperBound"     -> 80000L), Map()),
+          Bit(80000, 3L, Map("lowerBound" -> 80000L, "upperBound" -> 180000L), Map())
+        ))
+      }
+    }
+  }
+
+  test("execute a temporal query in case of a where condition") {
+
+    nodes.foreach { n =>
+      val nsdb =
+        Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+      val query = nsdb
+        .db(db)
+        .namespace(namespace)
+        .query(s"select count(*) from ${TemporalDoubleMetric.name} where timestamp >= 60000 group by interval 100s")
+
+      eventually {
+        val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+        assert(readRes.completedSuccessfully)
+        assert(readRes.records.size == 2)
+        assert(readRes.records.map(_.asBit) == Seq(
+          Bit(60000, 1L, Map("lowerBound" -> 60000L, "upperBound" -> 80000L), Map()),
+          Bit(80000, 3L, Map("lowerBound" -> 80000L, "upperBound" -> 180000L), Map())
+        ))
+      }
+    }
+
+    }
+
+    test("execute a temporal query with sum aggregation on a double metric") {
+
+      nodes.foreach { n =>
+        val nsdb =
+          Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+        val query = nsdb
+          .db(db)
+          .namespace(namespace)
+          .query(s"select sum(*) from ${TemporalDoubleMetric.name} group by interval 30s")
+
+        eventually {
+          val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+          assert(readRes.completedSuccessfully)
+          assert(readRes.records.size == 5)
+          assert(readRes.records.map(_.asBit) == Seq(
+            Bit(0, 6.0 , Map("lowerBound" -> 0L, "upperBound" -> 30000L), Map()),
+            Bit(30000, 7.5, Map("lowerBound" -> 30000L, "upperBound" -> 60000L), Map()),
+            Bit(60000, 5.5, Map("lowerBound" -> 60000L, "upperBound" -> 90000L), Map()),
+            Bit(90000, 3.5, Map("lowerBound" -> 90000L, "upperBound" -> 120000L), Map()),
+            Bit(120000, 2.5, Map("lowerBound" -> 120000L, "upperBound" -> 150000L), Map())
+          ))
+        }
+      }
+    }
+
+  test("execute a temporal query with max aggregation") {
+
+    nodes.foreach { n =>
+      val nsdb =
+        Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+      val query = nsdb
+        .db(db)
+        .namespace(namespace)
+        .query(s"select max(*) from ${TemporalLongMetric.name} group by interval 30s")
+
+      eventually {
+        val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+        assert(readRes.completedSuccessfully)
+        assert(readRes.records.size == 5)
+        assert(readRes.records.map(_.asBit) == Seq(
+          Bit(0, 4L , Map("lowerBound" -> 0L, "upperBound" -> 30000L), Map()),
+          Bit(30000, 7L, Map("lowerBound" -> 30000L, "upperBound" -> 60000L), Map()),
+          Bit(60000, 5L, Map("lowerBound" -> 60000L, "upperBound" -> 90000L), Map()),
+          Bit(90000, 3L, Map("lowerBound" -> 90000L, "upperBound" -> 120000L), Map()),
+          Bit(120000, 2L, Map("lowerBound" -> 120000L, "upperBound" -> 150000L), Map())
+        ))
+      }
+    }
+  }
+
+  test("execute a temporal query with max aggregation on a double metric") {
+
+    nodes.foreach { n =>
+      val nsdb =
+        Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+      val query = nsdb
+        .db(db)
+        .namespace(namespace)
+        .query(s"select max(*) from ${TemporalDoubleMetric.name} group by interval 30s")
+
+      eventually {
+        val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+        assert(readRes.completedSuccessfully)
+        assert(readRes.records.size == 5)
+        assert(readRes.records.map(_.asBit) == Seq(
+          Bit(0, 4.5 , Map("lowerBound" -> 0L, "upperBound" -> 30000L), Map()),
+          Bit(30000, 7.5, Map("lowerBound" -> 30000L, "upperBound" -> 60000L), Map()),
+          Bit(60000, 5.5, Map("lowerBound" -> 60000L, "upperBound" -> 90000L), Map()),
+          Bit(90000, 3.5, Map("lowerBound" -> 90000L, "upperBound" -> 120000L), Map()),
+          Bit(120000, 2.5, Map("lowerBound" -> 120000L, "upperBound" -> 150000L), Map())
+        ))
+      }
+    }
+  }
+
+  test("execute a temporal query with min aggregation") {
+
+    nodes.foreach { n =>
+      val nsdb =
+        Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+      val query = nsdb
+        .db(db)
+        .namespace(namespace)
+        .query(s"select min(*) from ${TemporalLongMetric.name} group by interval 30s")
+
+      eventually {
+        val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+        assert(readRes.completedSuccessfully)
+        assert(readRes.records.size == 5)
+        assert(readRes.records.map(_.asBit) == Seq(
+          Bit(0, 1L , Map("lowerBound" -> 0L, "upperBound" -> 30000L), Map()),
+          Bit(30000, 7L, Map("lowerBound" -> 30000L, "upperBound" -> 60000L), Map()),
+          Bit(60000, 5L, Map("lowerBound" -> 60000L, "upperBound" -> 90000L), Map()),
+          Bit(90000, 3L, Map("lowerBound" -> 90000L, "upperBound" -> 120000L), Map()),
+          Bit(120000, 2L, Map("lowerBound" -> 120000L, "upperBound" -> 150000L), Map())
+        ))
+      }
+    }
+  }
+
+  test("execute a temporal query with min aggregation on a double metric") {
+
+    nodes.foreach { n =>
+      val nsdb =
+        Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
+
+      val query = nsdb
+        .db(db)
+        .namespace(namespace)
+        .query(s"select min(*) from ${TemporalDoubleMetric.name} group by interval 30s")
+
+      eventually {
+        val readRes = Await.result(nsdb.execute(query), 10.seconds)
+
+        assert(readRes.completedSuccessfully)
+        assert(readRes.records.size == 5)
+        assert(readRes.records.map(_.asBit) == Seq(
+          Bit(0, 1.5 , Map("lowerBound" -> 0L, "upperBound" -> 30000L), Map()),
+          Bit(30000, 7.5, Map("lowerBound" -> 30000L, "upperBound" -> 60000L), Map()),
+          Bit(60000, 5.5, Map("lowerBound" -> 60000L, "upperBound" -> 90000L), Map()),
+          Bit(90000, 3.5, Map("lowerBound" -> 90000L, "upperBound" -> 120000L), Map()),
+          Bit(120000, 2.5, Map("lowerBound" -> 120000L, "upperBound" -> 150000L), Map())
+        ))
+      }
+    }
+  }
+}

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/test/MiniClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/test/MiniClusterSpec.scala
@@ -29,15 +29,15 @@ trait MiniClusterSpec extends FunSuite with BeforeAndAfterAll with Eventually wi
 
   Logger.getLogger("io.grpc.internal").setLevel(Level.OFF)
 
-  val nodesNumber: Int = 3
-  val replicationFactor: Int = 2
-  val rootFolder: String = s"target/minicluster/$instanceId"
+  override val nodesNumber: Int = 3
+  override val replicationFactor: Int = 2
+  override val rootFolder: String = s"target/minicluster/$instanceId"
+  override val shardInterval: Duration = Duration.ofMillis(5)
+  override val passivateAfter: Duration = Duration.ofHours(1)
 
   implicit val formats = DefaultFormats
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(Span(20, Seconds))
-
-  def passivateAfter: Duration = Duration.ofHours(1)
 
   override def beforeAll(): Unit = {
     start(true)

--- a/nsdb-it/src/main/scala/io/radicalbit/nsdb/minicluster/MiniClusterStarter.scala
+++ b/nsdb-it/src/main/scala/io/radicalbit/nsdb/minicluster/MiniClusterStarter.scala
@@ -22,6 +22,7 @@ object MiniClusterStarter extends App with NsdbMiniCluster {
   override protected[this] def nodesNumber              = 3
   override protected[this] def replicationFactor: Int   = 2
   override protected[this] def rootFolder: String       = s"target/minicluster/$instanceId"
+  override protected[this] def shardInterval: Duration  = Duration.ofMillis(5)
   override protected[this] def passivateAfter: Duration = Duration.ofHours(1)
 
   start()

--- a/nsdb-it/src/main/scala/io/radicalbit/nsdb/minicluster/NSDbMiniClusterConfigProvider.scala
+++ b/nsdb-it/src/main/scala/io/radicalbit/nsdb/minicluster/NSDbMiniClusterConfigProvider.scala
@@ -25,6 +25,7 @@ trait NSDbMiniClusterConfigProvider extends NSDbConfigProvider {
 
   def hostname: String
   def storageDir: String
+  def shardInterval: Duration
   def passivateAfter: Duration
   def replicationFactor: Int
 
@@ -35,6 +36,7 @@ trait NSDbMiniClusterConfigProvider extends NSDbConfigProvider {
       .withValue("nsdb.grpc.interface", ConfigValueFactory.fromAnyRef(hostname))
       .withValue("nsdb.http.interface", ConfigValueFactory.fromAnyRef(hostname))
       .withValue("nsdb.storage.base-path", ConfigValueFactory.fromAnyRef(storageDir))
+      .withValue("nsdb.sharding.interval", ConfigValueFactory.fromAnyRef(shardInterval))
       .withValue("nsdb.cluster.replication-factor", ConfigValueFactory.fromAnyRef(replicationFactor))
       .resolve()
 

--- a/nsdb-it/src/main/scala/io/radicalbit/nsdb/minicluster/NSDbMiniClusterNode.scala
+++ b/nsdb-it/src/main/scala/io/radicalbit/nsdb/minicluster/NSDbMiniClusterNode.scala
@@ -22,6 +22,7 @@ import io.radicalbit.nsdb.cluster.NSDbActors
 
 class NSDbMiniClusterNode(val hostname: String,
                           val storageDir: String,
+                          val shardInterval: Duration,
                           val passivateAfter: Duration = Duration.ofHours(1),
                           val replicationFactor: Int)
     extends NSDBAkkaMiniCluster

--- a/nsdb-it/src/main/scala/io/radicalbit/nsdb/minicluster/NsdbMiniCluster.scala
+++ b/nsdb-it/src/main/scala/io/radicalbit/nsdb/minicluster/NsdbMiniCluster.scala
@@ -31,6 +31,7 @@ trait NsdbMiniCluster extends LazyLogging {
 
   protected[this] def rootFolder: String
   protected[this] def nodesNumber: Int
+  protected[this] def shardInterval: Duration
   protected[this] def passivateAfter: Duration
   protected[this] def replicationFactor: Int
 
@@ -41,6 +42,7 @@ trait NsdbMiniCluster extends LazyLogging {
       new NSDbMiniClusterNode(
         hostname = s"$startingHostname${i + 1}",
         storageDir = s"$rootFolder/data$i",
+        shardInterval = shardInterval,
         passivateAfter = passivateAfter,
         replicationFactor = replicationFactor
       )).toSet


### PR DESCRIPTION
This PR allows avoiding non-efficient management of time ranges in case of a temporal query.
All the buckets that have a zero value (for all the possible aggregations) will be discarded.

Also, the integration tests have been improved. Now it's possible to easily set the shard interval for a single test class and also many integration tests for temporal queries have been added