### PR TITLE
[HOTFIX] GET query api

### DIFF
--- a/docs/RestApis.md
+++ b/docs/RestApis.md
@@ -21,7 +21,7 @@ Allow data retrieval from NSDb according to a provided query.
 
 **URL** : `/query`
 
-**Method** : `POST`
+**Method** : `POST`, `GET`
 
 **Auth required** : Depending on security configuration
 

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/Filters.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/Filters.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.web
+
+import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
+import io.radicalbit.nsdb.common.NSDbType
+import io.radicalbit.nsdb.common.protocol.NSDbSerializable
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.Generic
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+
+import scala.annotation.meta.field
+
+object Filters {
+
+  @ApiModel(description = "Filter Operators enumeration with [=, >, >=, <, <=, LIKE]")
+  object FilterOperators extends Enumeration {
+    val Equality       = Value("=")
+    val GreaterThan    = Value(">")
+    val GreaterOrEqual = Value(">=")
+    val LessThan       = Value("<")
+    val LessOrEqual    = Value("<=")
+    val Like           = Value("LIKE")
+  }
+
+  @ApiModel(description = "Filter Nullability Operators enumeration with [ISNULL, ISNOTNULL]")
+  object NullableOperators extends Enumeration {
+    val IsNull    = Value("ISNULL")
+    val IsNotNull = Value("ISNOTNULL")
+  }
+
+  @ApiModel(description = "Filter sealed trait", subTypes = Array(classOf[FilterNullableValue], classOf[FilterByValue]))
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+  @JsonSubTypes(
+    Array(
+      new JsonSubTypes.Type(value = classOf[FilterByValue], name = "FilterByValue"),
+      new JsonSubTypes.Type(value = classOf[Generic], name = "FilterNullableValue")
+    ))
+  sealed trait Filter extends NSDbSerializable
+
+  case object Filter {
+    def unapply(arg: Filter): Option[(String, Option[NSDbType], String)] =
+      arg match {
+        case byValue: FilterByValue => Some((byValue.dimension, Some(byValue.value), byValue.operator.toString))
+        case nullableValue: FilterNullableValue =>
+          Some((nullableValue.dimension, None, nullableValue.operator.toString))
+      }
+  }
+
+  @ApiModel(description = "Filter using operator", parent = classOf[Filter])
+  case class FilterByValue(
+      @(ApiModelProperty @field)(value = "dimension on which apply condition") dimension: String,
+      @(ApiModelProperty @field)(value = "value of comparation") value: NSDbType,
+      @(ApiModelProperty @field)(
+        value = "filter comparison operator",
+        dataType = "io.radicalbit.nsdb.web.routes.FilterOperators") operator: FilterOperators.Value
+  ) extends Filter
+
+  @ApiModel(description = "Filter for nullable", parent = classOf[Filter])
+  case class FilterNullableValue(
+      @(ApiModelProperty @field)(value = "dimension on which apply condition") dimension: String,
+      @(ApiModelProperty @field)(
+        value = "filter nullability operator",
+        dataType = "io.radicalbit.nsdb.web.routes.NullableOperators") operator: NullableOperators.Value
+  ) extends Filter
+}

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJson.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJson.scala
@@ -21,6 +21,7 @@ import io.radicalbit.nsdb.actors.RealTimeProtocol.Events._
 import io.radicalbit.nsdb.actors.RealTimeProtocol.RealTimeOutGoingMessage
 import io.radicalbit.nsdb.common._
 import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.web.Filters._
 import io.radicalbit.nsdb.web.actor.StreamActor.RegisterQuery
 import io.radicalbit.nsdb.web.routes._
 import io.radicalbit.nsdb.web.validation.FieldErrorInfo

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/QueryEnriched.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/QueryEnriched.scala
@@ -19,7 +19,7 @@ package io.radicalbit.nsdb.web
 import io.radicalbit.nsdb.common.statement.SelectSQLStatement
 import io.radicalbit.nsdb.sql.parser.StatementParserResult._
 import io.radicalbit.nsdb.sql.parser._
-import io.radicalbit.nsdb.web.routes.Filter
+import io.radicalbit.nsdb.web.Filters.Filter
 
 /**
   * Enriches an input query with:

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/actor/StreamActor.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/actor/StreamActor.scala
@@ -32,9 +32,9 @@ import io.radicalbit.nsdb.security.http.NSDBAuthProvider
 import io.radicalbit.nsdb.security.model.Metric
 import io.radicalbit.nsdb.sql.parser.StatementParserResult._
 import io.radicalbit.nsdb.util.ActorPathLogging
+import io.radicalbit.nsdb.web.Filters.Filter
 import io.radicalbit.nsdb.web.QueryEnriched
 import io.radicalbit.nsdb.web.actor.StreamActor._
-import io.radicalbit.nsdb.web.routes.Filter
 
 import scala.collection.mutable
 

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
@@ -73,13 +73,16 @@ trait QueryApi {
   implicit val timeout: Timeout
 
   @ApiModel(description = "Query Response")
-  case class QueryResponse(
+  case class SelectQueryResponse(
       @(ApiModelProperty @field)(value = "query result as a Seq of Bits") records: Seq[Bit],
       @(ApiModelProperty @field)(value = "json representation of query", required = false, dataType = "SQLStatement") parsed: Option[
         SQLStatement]
   )
 
-  @ApiOperation(value = "Perform query", nickname = "query", httpMethod = "POST", response = classOf[QueryResponse])
+  @ApiOperation(value = "Perform query",
+                nickname = "query",
+                httpMethod = "POST",
+                response = classOf[SelectQueryResponse])
   @ApiImplicitParams(
     Array(
       new ApiImplicitParam(name = "body",
@@ -111,7 +114,7 @@ trait QueryApi {
                   onComplete(readCoordinator ? ExecuteStatement(statement)) {
                     case Success(SelectStatementExecuted(_, values)) =>
                       complete(HttpEntity(ContentTypes.`application/json`,
-                                          write(QueryResponse(values, qb.parsed.map(_ => statement)))))
+                                          write(SelectQueryResponse(values, qb.parsed.map(_ => statement)))))
                     case Success(SelectStatementFailed(_, reason, MetricNotFound(_))) =>
                       complete(HttpResponse(NotFound, entity = reason))
                     case Success(SelectStatementFailed(_, reason, _)) =>

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/QueryApi.scala
@@ -24,15 +24,15 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.pattern.ask
 import akka.util.Timeout
-import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
-import io.radicalbit.nsdb.common.{NSDbLongType, NSDbType}
-import io.radicalbit.nsdb.common.protocol.{Bit, NSDbSerializable}
+import io.radicalbit.nsdb.common.NSDbLongType
+import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement.{SQLStatement, SelectSQLStatement}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.ExecuteStatement
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.security.http.NSDBAuthProvider
 import io.radicalbit.nsdb.security.model.Metric
 import io.radicalbit.nsdb.sql.parser.StatementParserResult._
+import io.radicalbit.nsdb.web.Filters.Filter
 import io.radicalbit.nsdb.web.QueryEnriched
 import io.swagger.annotations._
 import javax.ws.rs.Path
@@ -41,56 +41,6 @@ import org.json4s.jackson.Serialization.write
 
 import scala.annotation.meta.field
 import scala.util.{Failure, Success}
-
-@ApiModel(description = "Filter Operators enumeration with [=, >, >=, <, <=, LIKE]")
-object FilterOperators extends Enumeration {
-  val Equality       = Value("=")
-  val GreaterThan    = Value(">")
-  val GreaterOrEqual = Value(">=")
-  val LessThan       = Value("<")
-  val LessOrEqual    = Value("<=")
-  val Like           = Value("LIKE")
-}
-
-@ApiModel(description = "Filter Nullability Operators enumeration with [ISNULL, ISNOTNULL]")
-object NullableOperators extends Enumeration {
-  val IsNull    = Value("ISNULL")
-  val IsNotNull = Value("ISNOTNULL")
-}
-
-@ApiModel(description = "Filter sealed trait", subTypes = Array(classOf[FilterNullableValue], classOf[FilterByValue]))
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes(
-  Array(
-    new JsonSubTypes.Type(value = classOf[FilterByValue], name = "FilterByValue"),
-    new JsonSubTypes.Type(value = classOf[Generic], name = "FilterNullableValue")
-  ))
-sealed trait Filter extends NSDbSerializable
-
-case object Filter {
-  def unapply(arg: Filter): Option[(String, Option[NSDbType], String)] =
-    arg match {
-      case byValue: FilterByValue             => Some((byValue.dimension, Some(byValue.value), byValue.operator.toString))
-      case nullableValue: FilterNullableValue => Some((nullableValue.dimension, None, nullableValue.operator.toString))
-    }
-}
-
-@ApiModel(description = "Filter using operator", parent = classOf[Filter])
-case class FilterByValue(
-    @(ApiModelProperty @field)(value = "dimension on which apply condition") dimension: String,
-    @(ApiModelProperty @field)(value = "value of comparation") value: NSDbType,
-    @(ApiModelProperty @field)(
-      value = "filter comparison operator",
-      dataType = "io.radicalbit.nsdb.web.routes.FilterOperators") operator: FilterOperators.Value
-) extends Filter
-
-@ApiModel(description = "Filter for nullable", parent = classOf[Filter])
-case class FilterNullableValue(
-    @(ApiModelProperty @field)(value = "dimension on which apply condition") dimension: String,
-    @(ApiModelProperty @field)(
-      value = "filter nullability operator",
-      dataType = "io.radicalbit.nsdb.web.routes.NullableOperators") operator: NullableOperators.Value
-) extends Filter
 
 @ApiModel(description = "Query body")
 case class QueryBody(@(ApiModelProperty @field)(value = "database name") db: String,
@@ -147,7 +97,7 @@ trait QueryApi {
     ))
   def queryApi()(implicit logger: LoggingAdapter, format: Formats): Route = {
     path("query") {
-      post {
+      (post | get) {
         entity(as[QueryBody]) { qb =>
           optionalHeaderValueByName(authenticationProvider.headerName) { header =>
             authenticationProvider.authorizeMetric(ent = qb, header = header, writePermission = false) {

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiSpec.scala
@@ -72,9 +72,39 @@ class QueryApiSpec extends FlatSpec with Matchers with ScalatestRouteTest {
     secureQueryApi.queryApi()(system.log, formats)
   )
 
-  "QueryApi" should "not allow get" in {
-    Get("/query") ~> testRoutes ~> check {
-      status shouldEqual MethodNotAllowed
+  "QueryApi" should "correctly query the db using get verb" in {
+    val q = QueryBody("db", "namespace", "metric", "select * from metric limit 1")
+
+    Get("/query", q) ~> testRoutes ~> check {
+      status shouldBe OK
+      val entity       = entityAs[String]
+      val recordString = pretty(render(parse(entity)))
+
+      recordString shouldBe
+        """{
+          |  "records" : [ {
+          |    "timestamp" : 0,
+          |    "value" : 1,
+          |    "dimensions" : {
+          |      "name" : "name",
+          |      "number" : 2
+          |    },
+          |    "tags" : {
+          |      "country" : "country"
+          |    }
+          |  }, {
+          |    "timestamp" : 2,
+          |    "value" : 3,
+          |    "dimensions" : {
+          |      "name" : "name",
+          |      "number" : 2
+          |    },
+          |    "tags" : {
+          |      "country" : "country"
+          |    }
+          |  } ]
+          |}""".stripMargin
+
     }
   }
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiSpec.scala
@@ -25,6 +25,7 @@ import akka.util.Timeout
 import io.radicalbit.nsdb.actor.FakeReadCoordinator
 import io.radicalbit.nsdb.common.NSDbLongType
 import io.radicalbit.nsdb.security.http.{EmptyAuthorization, NSDBAuthProvider}
+import io.radicalbit.nsdb.web.Filters._
 import io.radicalbit.nsdb.web.NSDbJson._
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes._

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryEnrichmentSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryEnrichmentSpec.scala
@@ -17,7 +17,7 @@
 package io.radicalbit.nsdb.web
 
 import io.radicalbit.nsdb.common.statement._
-import io.radicalbit.nsdb.web.routes._
+import io.radicalbit.nsdb.web.Filters._
 import org.scalatest.{Matchers, WordSpec}
 
 class QueryEnrichmentSpec extends WordSpec with Matchers {


### PR DESCRIPTION
This PR enables a more idiomatic GET rest API for submitting a select query.

Since we are going to add the support for delete statements in rest API, it would be idiomatic to have a GET API for select queries and a POST for delete or update (that we will never support :) )  queries.

Anyway, the existing POST query API is kept for backward compatibility.

Any thought on that is really welcome and appreciated.