### PR TITLE
[HOTFIX] Restore quid in Websocket protocol

### DIFF
--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/RealTimeProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/RealTimeProtocol.scala
@@ -28,6 +28,7 @@ object RealTimeProtocol {
                                        namespace: String,
                                        metric: String,
                                        queryString: String,
+                                       quid: String,
                                        records: Seq[Bit])
         extends ControlMessage
         with RealTimeOutGoingMessage

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJson.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJson.scala
@@ -122,7 +122,7 @@ object NSDbJson extends DefaultJsonProtocol with SprayJsonSupport {
 
   implicit object RealTimeOutGoingMessageWriter extends JsonWriter[RealTimeOutGoingMessage] {
 
-    implicit val subscribedByQueryStringFormat: RootJsonFormat[SubscribedByQueryString] = jsonFormat5(
+    implicit val subscribedByQueryStringFormat: RootJsonFormat[SubscribedByQueryString] = jsonFormat6(
       SubscribedByQueryString.apply)
     implicit val SubscriptionByQueryStringFailedFormat: RootJsonFormat[SubscriptionByQueryStringFailed] = jsonFormat5(
       SubscriptionByQueryStringFailed.apply)

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/actor/StreamActor.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/actor/StreamActor.scala
@@ -105,8 +105,8 @@ class StreamActor(clientAddress: String,
                                           metric,
                                           inputQueryString,
                                           s"unauthorized ${checkAuthorization.failReason}"))
-    case SubscribedByQueryStringInternal(db, namespace, metric, queryString, _, records) =>
-      wsActor ! OutgoingMessage(SubscribedByQueryString(db, namespace, metric, queryString, records))
+    case SubscribedByQueryStringInternal(db, namespace, metric, queryString, quid, records) =>
+      wsActor ! OutgoingMessage(SubscribedByQueryString(db, namespace, metric, queryString, quid, records))
     case msg: SubscriptionByQueryStringFailed => wsActor ! OutgoingMessage(msg)
     case msg @ RecordsPublished(_, _, _) =>
       buffer += msg


### PR DESCRIPTION
This PR reintroduce the query identifier in the `SubscribedByQueryString` message that is sent to a subscriber as the response for a subscription operation