### PR TITLE
Precision

### DIFF
--- a/nsdb-cluster/src/main/resources/nsdb.conf
+++ b/nsdb-cluster/src/main/resources/nsdb.conf
@@ -165,7 +165,7 @@ nsdb {
   }
 
   math {
-    max-precision = 10
-    max-precision = ${?MATH_MAX_PRECISION}
+    precision = 10
+    precision = ${?MATH_PRECISION}
   }
 }

--- a/nsdb-cluster/src/main/resources/nsdb.conf
+++ b/nsdb-cluster/src/main/resources/nsdb.conf
@@ -163,4 +163,9 @@ nsdb {
     n-retries = 2
     n-retries = ${?RETRY_POLICY_N_RETRIES}
   }
+
+  math {
+    max-precision = 10
+    max-precision = ${?MATH_MAX_PRECISION}
+  }
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
@@ -26,7 +26,6 @@ import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.actor._
-import io.radicalbit.nsdb.common.configuration.NSDbConfig
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.globalTimeout
 
 /**

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
@@ -26,6 +26,8 @@ import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.actor._
+import io.radicalbit.nsdb.common.configuration.NSDbConfig
+import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.globalTimeout
 
 /**
   * Creates the top level actor [[DatabaseActorsGuardian]] and grpc endpoint [[io.radicalbit.nsdb.cluster.endpoint.GrpcEndpoint]] based on coordinators
@@ -35,7 +37,7 @@ trait NSDbActors {
   implicit def system: ActorSystem
 
   implicit lazy val timeout: Timeout =
-    Timeout(system.settings.config.getDuration("nsdb.global.timeout", TimeUnit.SECONDS), TimeUnit.SECONDS)
+    Timeout(system.settings.config.getDuration(globalTimeout, TimeUnit.SECONDS), TimeUnit.SECONDS)
 
   def initTopLevelActors(): Unit = {
     AkkaManagement(system).start()

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -16,6 +16,7 @@
 
 package io.radicalbit.nsdb.cluster.coordinator
 
+import java.math.{MathContext, RoundingMode}
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorRef, Props}
@@ -28,6 +29,7 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.GetLo
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.LocationsGot
 import io.radicalbit.nsdb.cluster.logic.ReadNodesSelection
 import io.radicalbit.nsdb.common.NSDbNumericType
+import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.maxPrecision
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement.SelectSQLStatement
 import io.radicalbit.nsdb.model.{Location, Schema, TimeRange}
@@ -58,6 +60,9 @@ class ReadCoordinator(metadataCoordinator: ActorRef,
   implicit val timeout: Timeout = Timeout(
     context.system.settings.config.getDuration("nsdb.read-coordinator.timeout", TimeUnit.SECONDS),
     TimeUnit.SECONDS)
+
+  implicit val mathContext: MathContext =
+    new MathContext(context.system.settings.config.getInt(maxPrecision), RoundingMode.HALF_UP)
 
   import context.dispatcher
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -29,7 +29,7 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.GetLo
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.LocationsGot
 import io.radicalbit.nsdb.cluster.logic.ReadNodesSelection
 import io.radicalbit.nsdb.common.NSDbNumericType
-import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.maxPrecision
+import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.precision
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement.SelectSQLStatement
 import io.radicalbit.nsdb.model.{Location, Schema, TimeRange}
@@ -62,7 +62,7 @@ class ReadCoordinator(metadataCoordinator: ActorRef,
     TimeUnit.SECONDS)
 
   implicit val mathContext: MathContext =
-    new MathContext(context.system.settings.config.getInt(maxPrecision), RoundingMode.HALF_UP)
+    new MathContext(context.system.settings.config.getInt(precision), RoundingMode.HALF_UP)
 
   import context.dispatcher
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/WriteConfig.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/WriteConfig.scala
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit
 
 import akka.actor.Actor
 import akka.cluster.ddata.Replicator.{WriteAll, WriteConsistency, WriteLocal, WriteMajority}
+import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.globalTimeout
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -27,7 +28,7 @@ trait WriteConfig { this: Actor =>
   private val config = context.system.settings.config
 
   private lazy val timeout: FiniteDuration =
-    FiniteDuration(config.getDuration("nsdb.global.timeout", TimeUnit.SECONDS), TimeUnit.SECONDS)
+    FiniteDuration(config.getDuration(globalTimeout, TimeUnit.SECONDS), TimeUnit.SECONDS)
 
   /**
     * Provides a Write Consistency policy from a config value.

--- a/nsdb-cluster/src/test/resources/application.conf
+++ b/nsdb-cluster/src/test/resources/application.conf
@@ -80,7 +80,7 @@ nsdb {
   }
 
   math {
-    max-precision = 10
+    precision = 10
   }
 
   read-coordinator.timeout = 30 seconds

--- a/nsdb-cluster/src/test/resources/application.conf
+++ b/nsdb-cluster/src/test/resources/application.conf
@@ -79,6 +79,10 @@ nsdb {
     n-retries = 2
   }
 
+  math {
+    max-precision = 10
+  }
+
   read-coordinator.timeout = 30 seconds
   metadata-coordinator.timeout = 30 seconds
   write-coordinator.timeout = 30 seconds

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/configuration/NSDbConfig.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/configuration/NSDbConfig.scala
@@ -51,7 +51,7 @@ object NSDbConfig {
 
     final val globalTimeout = "nsdb.global.timeout"
 
-    final val maxPrecision = "nsdb.math.max-precision"
+    final val precision = "nsdb.math.precision"
   }
 
   object LowLevel {

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/configuration/NSDbConfig.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/configuration/NSDbConfig.scala
@@ -48,6 +48,10 @@ object NSDbConfig {
 
     final val retryPolicyDelay    = "nsdb.retry-policy.delay"
     final val retryPolicyNRetries = "nsdb.retry-policy.n-retries"
+
+    final val globalTimeout = "nsdb.global.timeout"
+
+    final val maxPrecision = "nsdb.math.max-precision"
   }
 
   object LowLevel {

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/package.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/package.scala
@@ -16,6 +16,8 @@
 
 package io.radicalbit.nsdb
 
+import java.math.MathContext
+
 import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 
 /**
@@ -101,9 +103,9 @@ package object common {
     def <(other: NSDbNumericType): Boolean  = compare(other) == -1
     def <=(other: NSDbNumericType): Boolean = compare(other) == -1 || compare(other) == 0
 
-    def /(other: NSDbNumericType) = Double.box {
+    def /(other: NSDbNumericType)(implicit context: MathContext) = Double.box {
       new java.math.BigDecimal(this.rawValue.toString)
-        .divide(new java.math.BigDecimal(other.rawValue.toString))
+        .divide(new java.math.BigDecimal(other.rawValue.toString), context)
         .doubleValue()
     }
   }

--- a/nsdb-common/src/test/resources/nsdb-test.conf
+++ b/nsdb-common/src/test/resources/nsdb-test.conf
@@ -116,6 +116,6 @@ nsdb {
   }
 
   math {
-    max-precision = 10
+    precision = 10
   }
 }

--- a/nsdb-common/src/test/resources/nsdb-test.conf
+++ b/nsdb-common/src/test/resources/nsdb-test.conf
@@ -114,4 +114,8 @@ nsdb {
     //Websocket retention size
     retention-size = 10
   }
+
+  math {
+    max-precision = 10
+  }
 }

--- a/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbConfigProviderSpec.scala
+++ b/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbConfigProviderSpec.scala
@@ -17,42 +17,45 @@
 package io.radicalbit.nsdb.common.configuration
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
-import NSDbConfig.LowLevel._
-import NSDbConfig.HighLevel._
+import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel._
+import io.radicalbit.nsdb.common.configuration.NSDbConfig.LowLevel._
+import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
 
-class NSDbConfigProviderSpec extends FlatSpec with Matchers with OneInstancePerTest with NSDbConfigProvider {
+class NSDbConfigProviderSpec extends WordSpec with Matchers with OneInstancePerTest with NSDbConfigProvider {
 
   override def userDefinedConfig: Config      = ConfigFactory.parseResources("nsdb-test.conf").resolve()
   override def lowLevelTemplateConfig: Config = ConfigFactory.parseResources("application-test.conf")
 
-  "NSDbConfigProvider" should "properly merge configuration files" in {
+  "NSDbConfigProvider" should {
+    "properly merge configuration files" in {
 
-    val c1 = ConfigFactory.parseString("""
+      val c1 = ConfigFactory.parseString(
+        """
           |p1 = "a"
           |p2 = "b"
           |""".stripMargin)
 
-    val c2 = ConfigFactory.parseString(
-      """
+      val c2 = ConfigFactory.parseString(
+        """
           |p2= "b"
           |p3 = "d"
           |""".stripMargin
-    )
+      )
 
-    val mergedConf = mergeConf(c1, c2)
-    mergedConf.getString("p1") shouldBe "a"
-    mergedConf.getString("p2") shouldBe "b"
-    mergedConf.getString("p3") shouldBe "d"
-  }
+      val mergedConf = mergeConf(c1, c2)
+      mergedConf.getString("p1") shouldBe "a"
+      mergedConf.getString("p2") shouldBe "b"
+      mergedConf.getString("p3") shouldBe "d"
+    }
 
-  "NSDbConfigProvider" should "properly populate a low level conf" in {
-    config.getValue(AkkaArteryHostName) shouldBe userDefinedConfig.getValue(NSDbNodeHostName)
-    config.getValue(AkkaArteryPort) shouldBe userDefinedConfig.getValue(NSDbNodePort)
-    config.getValue(AkkaDDPersistenceDir) shouldBe userDefinedConfig.getValue(NSDBMetadataPath)
-    config.getValue(AkkaDiscoveryNSDbEndpoints) shouldBe userDefinedConfig.getValue(NSDbClusterEndpoints)
+    "properly populate a low level conf" in {
+      config.getValue(AkkaArteryHostName) shouldBe userDefinedConfig.getValue(NSDbNodeHostName)
+      config.getValue(AkkaArteryPort) shouldBe userDefinedConfig.getValue(NSDbNodePort)
+      config.getValue(AkkaDDPersistenceDir) shouldBe userDefinedConfig.getValue(NSDBMetadataPath)
+      config.getValue(AkkaDiscoveryNSDbEndpoints) shouldBe userDefinedConfig.getValue(NSDbClusterEndpoints)
 
-    config.hasPath(AkkaManagementContactPointNr) shouldBe false
+      config.hasPath(AkkaManagementContactPointNr) shouldBe false
+    }
   }
 
 }

--- a/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbConfigProviderSpec.scala
+++ b/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbConfigProviderSpec.scala
@@ -29,8 +29,7 @@ class NSDbConfigProviderSpec extends WordSpec with Matchers with OneInstancePerT
   "NSDbConfigProvider" should {
     "properly merge configuration files" in {
 
-      val c1 = ConfigFactory.parseString(
-        """
+      val c1 = ConfigFactory.parseString("""
           |p1 = "a"
           |p2 = "b"
           |""".stripMargin)

--- a/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbNumericTypeSpec.scala
+++ b/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbNumericTypeSpec.scala
@@ -37,6 +37,8 @@ class NSDbNumericTypeSpec extends WordSpec with Matchers{
 
     "use at most the digits set by the math context " in {
       NSDbNumericType(2) / NSDbNumericType(3) shouldBe 0.6666666667
+
+      NSDbNumericType(200) / NSDbNumericType(3) shouldBe 66.66666667
     }
 
   }

--- a/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbNumericTypeSpec.scala
+++ b/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbNumericTypeSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.common.configuration
+
+import java.math.{MathContext, RoundingMode}
+
+import io.radicalbit.nsdb.common.NSDbNumericType
+import org.scalatest.{Matchers, WordSpec}
+
+class NSDbNumericTypeSpec extends WordSpec with Matchers{
+
+  implicit val mathContext: MathContext = new MathContext(10, RoundingMode.HALF_UP)
+
+  "NSDbNumericType" should {
+
+    "support division among integers and doubles" in {
+
+      NSDbNumericType(2) / NSDbNumericType(2.5) shouldBe 0.8
+
+      NSDbNumericType(2.5) / NSDbNumericType(2) shouldBe 1.25
+
+    }
+
+    "use at most the digits set by the math context " in {
+      NSDbNumericType(2) / NSDbNumericType(3) shouldBe 0.6666666667
+    }
+
+  }
+
+}

--- a/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbNumericTypeSpec.scala
+++ b/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbNumericTypeSpec.scala
@@ -21,7 +21,7 @@ import java.math.{MathContext, RoundingMode}
 import io.radicalbit.nsdb.common.NSDbNumericType
 import org.scalatest.{Matchers, WordSpec}
 
-class NSDbNumericTypeSpec extends WordSpec with Matchers{
+class NSDbNumericTypeSpec extends WordSpec with Matchers {
 
   implicit val mathContext: MathContext = new MathContext(10, RoundingMode.HALF_UP)
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
@@ -25,7 +25,7 @@ import akka.pattern.{ask, pipe}
 import akka.util.Timeout
 import io.radicalbit.nsdb.actors.MetricAccumulatorActor.Refresh
 import io.radicalbit.nsdb.actors.ShardReaderActor.RefreshShard
-import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.{globalTimeout, maxPrecision}
+import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.{globalTimeout, precision}
 import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType, ValueFieldType}
 import io.radicalbit.nsdb.common.statement.{DescOrderOperator, SelectSQLStatement}
 import io.radicalbit.nsdb.common.{NSDbLongType, NSDbNumericType, NSDbType}
@@ -59,7 +59,7 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
     Timeout(context.system.settings.config.getDuration(globalTimeout, TimeUnit.SECONDS), TimeUnit.SECONDS)
 
   implicit val mathContext: MathContext =
-    new MathContext(context.system.settings.config.getInt(maxPrecision), RoundingMode.HALF_UP)
+    new MathContext(context.system.settings.config.getInt(precision), RoundingMode.HALF_UP)
 
   private val actors: mutable.Map[Location, ActorRef] = mutable.Map.empty
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -15,6 +15,8 @@
  */
 
 package io.radicalbit.nsdb
+import java.math.MathContext
+
 import io.radicalbit.nsdb.common.{NSDbNumericType, NSDbType}
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement.{DescOrderOperator, SelectSQLStatement}
@@ -39,11 +41,10 @@ package object post_proc {
     * @param aggregationType aggregation type (temporal, count, sum etc.)
     * @return the final result obtained from the manipulation of the partials.
     */
-  def applyOrderingWithLimit(
-      chainedResults: Seq[Bit],
-      statement: SelectSQLStatement,
-      schema: Schema,
-      aggregationType: Option[InternalAggregation] = None)(implicit ec: ExecutionContext): Seq[Bit] = {
+  def applyOrderingWithLimit(chainedResults: Seq[Bit],
+                             statement: SelectSQLStatement,
+                             schema: Schema,
+                             aggregationType: Option[InternalAggregation] = None): Seq[Bit] = {
     val sortedResults = aggregationType match {
       case Some(_: InternalTemporalAggregation) =>
         val temporalSortedResults = chainedResults.sortBy(_.timestamp)
@@ -126,7 +127,7 @@ package object post_proc {
       schema: Schema,
       statement: SelectSQLStatement,
       aggregation: InternalTemporalAggregation,
-      finalStep: Boolean = true)(implicit ec: ExecutionContext): Seq[Bit] => Seq[Bit] = { res =>
+      finalStep: Boolean = true)(implicit mathContext: MathContext): Seq[Bit] => Seq[Bit] = { res =>
     val v                              = schema.value.indexType.asInstanceOf[NumericType[_]]
     implicit val numeric: Numeric[Any] = v.numeric
     val chainedResult =
@@ -194,7 +195,7 @@ package object post_proc {
   def internalAggregationReduce(bits: Seq[Bit],
                                 schema: Schema,
                                 aggregation: InternalStandardAggregation,
-                                finalStep: Boolean = true): Bit = {
+                                finalStep: Boolean = true)(implicit mathContext: MathContext): Bit = {
     val v                              = schema.value.indexType.asInstanceOf[NumericType[_]]
     implicit val numeric: Numeric[Any] = v.numeric
     aggregation match {

--- a/nsdb-core/src/test/resources/application.conf
+++ b/nsdb-core/src/test/resources/application.conf
@@ -81,4 +81,8 @@ nsdb{
     retry-attempts = 3
   }
 
+  math {
+    max-precision = 10
+  }
+
 }

--- a/nsdb-core/src/test/resources/application.conf
+++ b/nsdb-core/src/test/resources/application.conf
@@ -82,7 +82,7 @@ nsdb{
   }
 
   math {
-    max-precision = 10
+    precision = 10
   }
 
 }

--- a/nsdb-it/src/main/resources/nsdb-minicluster.conf
+++ b/nsdb-it/src/main/resources/nsdb-minicluster.conf
@@ -141,4 +141,8 @@ nsdb {
     n-retries = 2
     n-retries = ${?RETRY_POLICY_N_RETRIES}
   }
+
+  math {
+    max-precision = 10
+  }
 }

--- a/nsdb-it/src/main/resources/nsdb-minicluster.conf
+++ b/nsdb-it/src/main/resources/nsdb-minicluster.conf
@@ -143,6 +143,6 @@ nsdb {
   }
 
   math {
-    max-precision = 10
+    precision = 10
   }
 }


### PR DESCRIPTION
This PR introduces the configuration parameter 

`nsdb.math.precision` 

configurable also by setting the env variable 

`MATH_PRECISION`

Aim of this parameter is to set the total number of digits allowed for a double value

some redundant code in `ReadCoordinator` has been removed as well