### PR TITLE
Time context And Standard Durations

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
@@ -121,7 +121,7 @@ class MetricsDataActor(val basePath: String, val nodeName: String, commitLogCoor
       getOrCreateAccumulator(db, namespace) forward msg
     case msg @ GetCountWithLocations(db, namespace, _, _) =>
       getOrCreateReader(db, namespace) forward msg
-    case msg @ ExecuteSelectStatement(statement, _, _, _, _) =>
+    case msg @ ExecuteSelectStatement(statement, _, _, _, _, _) =>
       log.debug("executing statement in metric data actor {}", statement)
       getOrCreateReader(statement.db, statement.namespace) forward msg
     case AddRecordToLocation(db, namespace, bit, location) =>

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -219,31 +219,43 @@ final case class LimitOperator(value: Int) extends NSDbSerializable
     new JsonSubTypes.Type(value = classOf[RelativeComparisonValue], name = "RelativeComparisonValue")
   ))
 sealed trait ComparisonValue {
+  def absoluteValue(currentTime: Long): NSDbType = value
   def value: NSDbType
 }
 
 object ComparisonValue {
-  def unapply(cv: ComparisonValue): Option[NSDbType] = Some(cv.value)
+
+  /**
+    * Extract the value of a [[ComparisonValue]]
+    * @return a tuple containing the value and a boolean that is true whether the comparison is relative.
+    */
+  def unapply(comparisonValue: ComparisonValue): Option[NSDbType] =
+    Some(comparisonValue.value)
+
 }
 
 /**
   * Class that represent an absolute comparison value
   * @param value the absolute value
   */
-final case class AbsoluteComparisonValue(override val value: NSDbType) extends ComparisonValue
+final case class AbsoluteComparisonValue(value: NSDbType) extends ComparisonValue
 
 /**
   * Class that represent a relative comparison value.
-  * @param value the absolute value
-  * @param operator the operator of the now (plus or minus)
-  * @param quantity the quantity of the relative time
-  * @param unitMeasure the unit measure of the relative time (s, m, h, d)
+  * @param value the time interval in milliseconds.
+  * @param operator the operator of the now (plus or minus).
+  * @param quantity the quantity of the relative time.
+  * @param unitMeasure the unit measure of the relative time (s, m, h, d).
   */
 final case class RelativeComparisonValue(override val value: NSDbType,
                                          operator: String,
                                          quantity: Long,
                                          unitMeasure: String)
-    extends ComparisonValue
+    extends ComparisonValue {
+
+  override def absoluteValue(currentTime: Long): NSDbType = ???
+
+}
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
@@ -28,7 +28,7 @@ import io.radicalbit.nsdb.actors.MetricPerformerActor.PerformShardWrites
 import io.radicalbit.nsdb.common.configuration.NSDbConfig
 import io.radicalbit.nsdb.common.protocol.NSDbSerializable
 import io.radicalbit.nsdb.index.StorageStrategy
-import io.radicalbit.nsdb.model.Location
+import io.radicalbit.nsdb.model.{Location, TimeContext}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.statement.StatementParser
@@ -203,6 +203,7 @@ class MetricAccumulatorActor(val basePath: String,
       opBufferMap += (UUID.randomUUID().toString -> DeleteShardRecordOperation(ns, key, bit))
       sender ! RecordDeleted(db, ns, key.metric, bit)
     case ExecuteDeleteStatementInShards(statement, schema, keys) =>
+      implicit val timeContext: TimeContext = TimeContext()
       StatementParser.parseStatement(statement, schema) match {
         case Right(ParsedDeleteQuery(ns, metric, q)) =>
           keys.foreach { key =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
@@ -27,7 +27,7 @@ import io.radicalbit.nsdb.common.configuration.NSDbConfig
 import io.radicalbit.nsdb.common.exception.TooManyRetriesException
 import io.radicalbit.nsdb.common.protocol.{Bit, NSDbSerializable}
 import io.radicalbit.nsdb.index.{AllFacetIndexes, StorageStrategy}
-import io.radicalbit.nsdb.model.Location
+import io.radicalbit.nsdb.model.{Location, TimeContext}
 import io.radicalbit.nsdb.statement.StatementParser
 import io.radicalbit.nsdb.util.ActorPathLogging
 import org.apache.lucene.index.IndexWriter
@@ -112,6 +112,7 @@ class MetricPerformerActor(val basePath: String,
               }
             //FIXME add compensation logic here as well
             case DeleteShardQueryOperation(_, _, statement, schema) =>
+              implicit val timeContext: TimeContext = TimeContext()
               StatementParser.parseStatement(statement, schema) match {
                 case Right(parsedQuery) =>
                   (for {

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
@@ -29,7 +29,7 @@ import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.{globalTimeo
 import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType, ValueFieldType}
 import io.radicalbit.nsdb.common.statement.{DescOrderOperator, SelectSQLStatement}
 import io.radicalbit.nsdb.common.{NSDbLongType, NSDbType}
-import io.radicalbit.nsdb.model.{Location, TimeContext}
+import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.post_proc._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
@@ -29,7 +29,7 @@ import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.{globalTimeo
 import io.radicalbit.nsdb.common.protocol.{Bit, DimensionFieldType, ValueFieldType}
 import io.radicalbit.nsdb.common.statement.{DescOrderOperator, SelectSQLStatement}
 import io.radicalbit.nsdb.common.{NSDbLongType, NSDbType}
-import io.radicalbit.nsdb.model.Location
+import io.radicalbit.nsdb.model.{Location, TimeContext}
 import io.radicalbit.nsdb.post_proc._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
@@ -265,9 +265,9 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
         })
         .map(s => CountGot(db, ns, metric, s.sum))
         .pipeTo(sender)
-    case msg @ ExecuteSelectStatement(statement, schema, locations, _, isSingleNode) =>
+    case msg @ ExecuteSelectStatement(statement, schema, locations, _, timeContext, isSingleNode) =>
       log.debug("executing statement in metric reader actor {}", statement)
-      StatementParser.parseStatement(statement, schema) match {
+      StatementParser.parseStatement(statement, schema)(timeContext) match {
         case Right(parsedStatement @ ParsedSimpleQuery(_, _, _, false, limit, fields, _)) =>
           retrieveAndOrderPlainResults(actorsForLocations(locations), parsedStatement, msg)
             .map {

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
@@ -29,6 +29,7 @@ import io.radicalbit.nsdb.actors.RealTimeProtocol.Events.{RecordsPublished, Subs
 import io.radicalbit.nsdb.common.protocol.{Bit, NSDbSerializable}
 import io.radicalbit.nsdb.common.statement.{SelectSQLStatement, SimpleGroupByAggregation, TemporalGroupByAggregation}
 import io.radicalbit.nsdb.index.TemporaryIndex
+import io.radicalbit.nsdb.model.TimeContext
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.statement.StatementParser
@@ -134,7 +135,8 @@ class PublisherActor(readCoordinator: ActorRef) extends ActorPathLogging {
       queries.foreach {
         case (id, nsdbQuery)
             if !nsdbQuery.aggregated && nsdbQuery.query.metric == metric && subscribedActorsByQueryId.contains(id) =>
-          val luceneQuery = StatementParser.parseStatement(nsdbQuery.query, schema)
+          implicit val timeContext: TimeContext = TimeContext()
+          val luceneQuery                       = StatementParser.parseStatement(nsdbQuery.query, schema)
           luceneQuery match {
             case Right(parsedQuery: ParsedSimpleQuery) =>
               val temporaryIndex: TemporaryIndex = new TemporaryIndex()

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -127,9 +127,9 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
       sender ! CountGot(db, namespace, metric, count)
     case ReceiveTimeout =>
       self ! PoisonPill
-    case ExecuteSelectStatement(statement, schema, _, globalRanges, _) =>
+    case ExecuteSelectStatement(statement, schema, _, globalRanges, timeContext, _) =>
       log.debug("executing statement in metric shard reader actor {}", statement)
-      val results: Try[Seq[Bit]] = StatementParser.parseStatement(statement, schema) match {
+      val results: Try[Seq[Bit]] = StatementParser.parseStatement(statement, schema)(timeContext) match {
         case Right(ParsedSimpleQuery(_, _, q, false, limit, fields, sort)) =>
           statement.getTimeOrdering match {
             case Some(_) =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
@@ -82,6 +82,8 @@ class Schema private (val metric: String, val fieldsMap: Map[String, SchemaField
       (otherSchema.metric == this.metric) && (otherSchema.fieldsMap.size == this.fieldsMap.size) && (otherSchema.fieldsMap == this.fieldsMap)
     } else false
   }
+
+  override def toString = s"Schema($metric, $fieldsMap)"
 }
 
 object Schema extends TypeSupport {

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/TimeContext.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/TimeContext.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.model
+
+import java.util.TimeZone
+
+/**
+  * Context in which a read or a write request is executed.
+  * @param currentTime The reference timestamp to be used as wall clock time.
+  * @param timezone the timezone to be used.
+  */
+case class TimeContext(currentTime: Long = System.currentTimeMillis(), timezone: TimeZone = TimeZone.getDefault)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.{Bit, NSDbSerializable}
 import io.radicalbit.nsdb.common.statement.{DeleteSQLStatement, SelectSQLStatement}
-import io.radicalbit.nsdb.model.{Location, Schema, TimeRange}
+import io.radicalbit.nsdb.model.{Location, Schema, TimeContext, TimeRange}
 
 /**
   * common messages exchanged among all the nsdb actors.
@@ -50,6 +50,7 @@ object MessageProtocol {
                                       schema: Schema,
                                       locations: Seq[Location],
                                       ranges: Seq[TimeRange] = Seq.empty,
+                                      timeContext: TimeContext,
                                       isSingleNode: Boolean)
         extends NSDbSerializable
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
@@ -122,7 +122,7 @@ object ExpressionParser {
   private def comparisonExpression[T](schema: Map[String, SchemaField],
                                       field: String,
                                       operator: ComparisonOperator,
-                                      value: Any): Either[String, Query] = {
+                                      value: NSDbType): Either[String, Query] = {
     def buildRangeQuery[T](fieldTypeRangeQuery: (String, T, T) => Query,
                            greaterF: T,
                            lessThan: T,
@@ -136,7 +136,7 @@ object ExpressionParser {
         case LessOrEqualToOperator    => fieldTypeRangeQuery(field, min, v)
       }
 
-    (schema.get(field), value) match {
+    (schema.get(field), value.rawValue) match {
       case (Some(SchemaField(_, _, t: INT)), v) =>
         Try(t.cast(v)).map(v =>
           buildRangeQuery[Int](IntPoint.newRangeQuery, v + 1, v - 1, Int.MinValue, Int.MaxValue, v)) match {
@@ -170,9 +170,9 @@ object ExpressionParser {
 
   private def rangeExpression(schema: Map[String, SchemaField],
                               field: String,
-                              p1: Any,
-                              p2: Any): Either[String, Query] = {
-    (schema.get(field), p1, p2) match {
+                              p1: NSDbType,
+                              p2: NSDbType): Either[String, Query] = {
+    (schema.get(field), p1.rawValue, p2.rawValue) match {
       case (Some(SchemaField(_, _, t: BIGINT)), v1, v2) =>
         Try((t.cast(v1), t.cast(v2))).map {
           case (l, h) => LongPoint.newRangeQuery(field, l, h)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
@@ -17,7 +17,7 @@
 package io.radicalbit.nsdb.statement
 
 import io.radicalbit.nsdb.common.statement._
-import io.radicalbit.nsdb.model.Schema
+import io.radicalbit.nsdb.model.{Schema, TimeContext}
 import io.radicalbit.nsdb.statement.FieldsParser.SimpleField
 import org.apache.lucene.search._
 
@@ -30,10 +30,11 @@ object StatementParser {
     * Parses a [[DeleteSQLStatement]] into a [[ParsedQuery]].
     *
     * @param statement the statement to be parsed.
-    * @param schema    metric'groupFieldType schema.
+    * @param schema    metric groupFieldType schema.
     * @return a Try of [[ParsedQuery]] to handle errors.
     */
-  def parseStatement(statement: DeleteSQLStatement, schema: Schema): Either[String, ParsedQuery] = {
+  def parseStatement(statement: DeleteSQLStatement, schema: Schema)(
+      implicit timeContext: TimeContext): Either[String, ParsedQuery] = {
     val expParsed = ExpressionParser.parseExpression(Some(statement.condition.expression), schema.fieldsMap)
     expParsed.map(exp => ParsedDeleteQuery(statement.namespace, statement.metric, exp.q))
   }
@@ -45,7 +46,8 @@ object StatementParser {
     * @param schema    metric's schema.
     * @return a Try of [[ParsedQuery]] to handle errors.
     */
-  def parseStatement(statement: SelectSQLStatement, schema: Schema): Either[String, ParsedQuery] = {
+  def parseStatement(statement: SelectSQLStatement, schema: Schema)(
+      implicit timeContext: TimeContext): Either[String, ParsedQuery] = {
     val sortOpt = statement.order.map(order => {
       val sortType = schema.fieldsMap.get(order.dimension).map(_.indexType.sortType).getOrElse(SortField.Type.DOC)
       new Sort(new SortField(order.dimension, sortType, order.isInstanceOf[DescOrderOperator]))

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserAggregationsSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserAggregationsSpec.scala
@@ -18,7 +18,7 @@ package io.radicalbit.nsdb.statement
 
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement.{SumAggregation => SqlSumAggregation, _}
-import io.radicalbit.nsdb.model.Schema
+import io.radicalbit.nsdb.model.{Schema, TimeContext}
 import io.radicalbit.nsdb.statement.FieldsParser.SimpleField
 import io.radicalbit.nsdb.statement.StatementParser._
 import org.apache.lucene.document.LongPoint
@@ -26,6 +26,8 @@ import org.apache.lucene.search._
 import org.scalatest.{Matchers, WordSpec}
 
 class StatementParserAggregationsSpec extends WordSpec with Matchers {
+
+  implicit val timeContext: TimeContext = TimeContext()
 
   private val schema = Schema(
     "people",

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserRelativeTimeSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserRelativeTimeSpec.scala
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.statement
+
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.common.statement.SQLStatement._
+import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.model.{Schema, TimeContext}
+import io.radicalbit.nsdb.statement.FieldsParser.SimpleField
+import io.radicalbit.nsdb.statement.StatementParser._
+import org.apache.lucene.document.LongPoint
+import org.apache.lucene.search._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.concurrent.duration.Duration
+
+class StatementParserRelativeTimeSpec extends WordSpec with Matchers {
+
+  implicit val timeContext: TimeContext = TimeContext()
+
+  private val schema = Schema(
+    "people",
+    Bit(0,
+        1.1,
+        dimensions = Map("name" -> "name", "surname" -> "surname", "creationDate" -> 0L),
+        tags = Map("amount"     -> 1.1, "city"       -> "city", "country"         -> "country", "age" -> 0))
+  )
+
+  "A statement parser instance" when {
+
+    "receive a select containing a range selection" should {
+      "parse it successfully with both absolute and relative comparisons" in {
+        StatementParser.parseStatement(
+          SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(
+              Condition(
+                RangeExpression(dimension = "timestamp",
+                                value1 = AbsoluteComparisonValue(2L),
+                                value2 = RelativeComparisonValue(plus, 4L, "min")))),
+            limit = Some(LimitOperator(4))
+          ),
+          schema
+        ) should be(
+          Right(
+            ParsedSimpleQuery(
+              "registry",
+              "people",
+              LongPoint.newRangeQuery("timestamp", 2, timeContext.currentTime + Duration("4 min").toMillis),
+              false,
+              4,
+              List("name").map(SimpleField(_))
+            ))
+        )
+      }
+      "parse it successfully with relative comparisons" in {
+        StatementParser.parseStatement(
+          SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(
+              Condition(
+                RangeExpression(dimension = "timestamp",
+                                value1 = RelativeComparisonValue(minus, 4L, "s"),
+                                value2 = RelativeComparisonValue(plus, 4L, "min")))),
+            limit = Some(LimitOperator(4))
+          ),
+          schema
+        ) should be(
+          Right(
+            ParsedSimpleQuery(
+              "registry",
+              "people",
+              LongPoint.newRangeQuery("timestamp",
+                                      timeContext.currentTime - Duration("4 s").toMillis,
+                                      timeContext.currentTime + Duration("4 min").toMillis),
+              false,
+              4,
+              List("name").map(SimpleField(_))
+            ))
+        )
+      }
+    }
+
+    "receive a select containing a GTE selection" should {
+      "parse it successfully in case of relative comparison" in {
+        StatementParser.parseStatement(
+          SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(
+              Condition(
+                ComparisonExpression(dimension = "timestamp",
+                                     comparison = GreaterOrEqualToOperator,
+                                     value = RelativeComparisonValue(minus, 10L, "second")))),
+            limit = Some(LimitOperator(4))
+          ),
+          schema
+        ) should be(
+          Right(
+            ParsedSimpleQuery(
+              "registry",
+              "people",
+              LongPoint.newRangeQuery("timestamp", timeContext.currentTime - Duration("10 s").toMillis, Long.MaxValue),
+              false,
+              4,
+              List("name").map(SimpleField(_))
+            ))
+        )
+      }
+    }
+
+    "receive a select containing a GT AND a LTE selection" should {
+      "parse it successfully in case of relative comparisons" in {
+        StatementParser.parseStatement(
+          SelectSQLStatement(
+            db = "db",
+            namespace = "registry",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            condition = Some(Condition(TupledLogicalExpression(
+              expression1 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterThanOperator,
+                                                 value = RelativeComparisonValue(minus, 4L, "s")),
+              operator = AndOperator,
+              expression2 = ComparisonExpression(dimension = "timestamp",
+                                                 comparison = LessOrEqualToOperator,
+                                                 value = RelativeComparisonValue(plus, 4L, "hour"))
+            ))),
+            limit = Some(LimitOperator(4))
+          ),
+          schema
+        ) should be(
+          Right(
+            ParsedSimpleQuery(
+              "registry",
+              "people",
+              new BooleanQuery.Builder()
+                .add(LongPoint.newRangeQuery("timestamp",
+                                             timeContext.currentTime - Duration("4 s").toMillis + 1L,
+                                             Long.MaxValue),
+                     BooleanClause.Occur.MUST)
+                .add(LongPoint.newRangeQuery("timestamp",
+                                             Long.MinValue,
+                                             timeContext.currentTime + Duration("4 h").toMillis),
+                     BooleanClause.Occur.MUST)
+                .build(),
+              false,
+              4,
+              List("name").map(SimpleField(_))
+            )
+          ))
+      }
+    }
+  }
+}

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
@@ -18,7 +18,7 @@ package io.radicalbit.nsdb.statement
 
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement._
-import io.radicalbit.nsdb.model.Schema
+import io.radicalbit.nsdb.model.{Schema, TimeContext}
 import io.radicalbit.nsdb.statement.FieldsParser.SimpleField
 import io.radicalbit.nsdb.statement.StatementParser._
 import org.apache.lucene.document.{DoublePoint, LongPoint}
@@ -27,6 +27,8 @@ import org.apache.lucene.search._
 import org.scalatest.{Matchers, WordSpec}
 
 class StatementParserSpec extends WordSpec with Matchers {
+
+  implicit val timeContext: TimeContext = TimeContext()
 
   private val schema = Schema(
     "people",

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/CustomSerializers.scala
@@ -166,8 +166,7 @@ object CustomSerializers {
               List(JField("dimension", JString(dimension)),
                    JField("comparison", JString("=")),
                    JField("value", JDouble(value))))
-          case EqualityExpression(dimension,
-                                  RelativeComparisonValue(NSDbLongType(value), operator, quantity, unitMeasure)) =>
+          case EqualityExpression(dimension, RelativeComparisonValue(operator, quantity, unitMeasure)) =>
             JObject(
               List(
                 JField("dimension", JString(dimension)),
@@ -175,8 +174,7 @@ object CustomSerializers {
                 JField(
                   "value",
                   JObject(
-                    List(JField("value", JLong(value)),
-                         JField("operator", JString(operator)),
+                    List(JField("operator", JString(operator)),
                          JField("quantity", JLong(quantity)),
                          JField("unitMeasure", JString(unitMeasure)))
                   )

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CustomSerializerForTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CustomSerializerForTest.scala
@@ -28,9 +28,9 @@ case object CustomSerializerForTest
                  JField("operator", JString(operator)),
                  JField("quantity", JInt(quantity)),
                  JField("unitMeasure", JString(unitMeasure)))) =>
-          RelativeComparisonValue(0L, operator, quantity.intValue, unitMeasure)
+          RelativeComparisonValue(operator, quantity.intValue, unitMeasure)
       }, {
-        case RelativeComparisonValue(_, operator, quantity: Long, unitMeasure) =>
+        case RelativeComparisonValue(operator, quantity: Long, unitMeasure) =>
           JObject(
             List(JField("value", JLong(0L)),
                  JField("operator", JString(operator)),

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryParserApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryParserApiSpec.scala
@@ -977,7 +977,7 @@ class QueryParserApiSpec extends WordSpec with Matchers with ScalatestRouteTest 
           |          "value" : 0,
           |          "operator" : "-",
           |          "quantity" : 2,
-          |          "unitMeasure" : "d"
+          |          "unitMeasure" : "D"
           |        }
           |      }
           |    }
@@ -1048,7 +1048,7 @@ class QueryParserApiSpec extends WordSpec with Matchers with ScalatestRouteTest 
           |            "value" : 0,
           |            "operator" : "-",
           |            "quantity" : 2,
-          |            "unitMeasure" : "d"
+          |            "unitMeasure" : "D"
           |          }
           |        },
           |        "operator" : "or",
@@ -1145,7 +1145,7 @@ class QueryParserApiSpec extends WordSpec with Matchers with ScalatestRouteTest 
           |              "value" : 0,
           |              "operator" : "-",
           |              "quantity" : 2,
-          |              "unitMeasure" : "h"
+          |              "unitMeasure" : "H"
           |            },
           |            "value2" : {
           |              "value" : 7
@@ -1160,7 +1160,7 @@ class QueryParserApiSpec extends WordSpec with Matchers with ScalatestRouteTest 
           |                "value" : 0,
           |                "operator" : "-",
           |                "quantity" : 2,
-          |                "unitMeasure" : "d"
+          |                "unitMeasure" : "D"
           |              }
           |            },
           |            "operator" : "or",
@@ -1263,7 +1263,7 @@ class QueryParserApiSpec extends WordSpec with Matchers with ScalatestRouteTest 
           |              "value" : 0,
           |              "operator" : "-",
           |              "quantity" : 2,
-          |              "unitMeasure" : "h"
+          |              "unitMeasure" : "H"
           |            },
           |            "value2" : {
           |              "value" : 7
@@ -1278,7 +1278,7 @@ class QueryParserApiSpec extends WordSpec with Matchers with ScalatestRouteTest 
           |                "value" : 0,
           |                "operator" : "-",
           |                "quantity" : 2,
-          |                "unitMeasure" : "d"
+          |                "unitMeasure" : "D"
           |              }
           |            },
           |            "operator" : "or",
@@ -1297,7 +1297,7 @@ class QueryParserApiSpec extends WordSpec with Matchers with ScalatestRouteTest 
           |                    "value" : 0,
           |                    "operator" : "-",
           |                    "quantity" : 1,
-          |                    "unitMeasure" : "s"
+          |                    "unitMeasure" : "S"
           |                  }
           |                },
           |                "operator" : "and",

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
@@ -17,7 +17,6 @@
 package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
-import io.radicalbit.nsdb.sql.parser.SQLStatementParser._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult.{SqlStatementParserFailure, SqlStatementParserSuccess}
 import org.scalatest.{Matchers, WordSpec}
 
@@ -354,7 +353,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               fields = ListFields(List(Field("value", Some(CountAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(3000, 3, second))
+              groupBy = Some(TemporalGroupByAggregation(3000, 3, "S"))
             )
           ))
       }
@@ -362,7 +361,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
 
     "receive a select with a temporal group by without measure in minutes" should {
       "parse it successfully" in {
-        val query = "SELECT count(value) FROM people group by interval m"
+        val query = "SELECT count(value) FROM people group by interval min"
         parser.parse(db = "db", namespace = "registry", input = query) should be(
           SqlStatementParserSuccess(
             query,
@@ -372,7 +371,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               fields = ListFields(List(Field("value", Some(CountAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(60000, 1, minute))
+              groupBy = Some(TemporalGroupByAggregation(60000, 1, "MIN"))
             )
           ))
       }
@@ -389,7 +388,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("value", Some(CountAggregation)))),
-            groupBy = Some(TemporalGroupByAggregation(86400000, 1, day)),
+            groupBy = Some(TemporalGroupByAggregation(86400000, 1, "D")),
             limit = Some(LimitOperator(1))
           )
         ))
@@ -416,7 +415,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(CountAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, day))
+              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, "D"))
             )
           ))
       }
@@ -441,7 +440,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(CountAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, day))
+              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, "D"))
             )
           ))
       }
@@ -466,7 +465,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(SumAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, day))
+              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, "D"))
             )
           ))
       }
@@ -491,7 +490,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(AvgAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(4 * 24 * 3600 * 1000, 4, day))
+              groupBy = Some(TemporalGroupByAggregation(4 * 24 * 3600 * 1000, 4, "D"))
             )
           ))
       }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
@@ -17,6 +17,7 @@
 package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.sql.parser.SQLStatementParser._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult.{SqlStatementParserFailure, SqlStatementParserSuccess}
 import org.scalatest.{Matchers, WordSpec}
 
@@ -353,7 +354,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               fields = ListFields(List(Field("value", Some(CountAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(3000, 3, "s"))
+              groupBy = Some(TemporalGroupByAggregation(3000, 3, second))
             )
           ))
       }
@@ -371,7 +372,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
               metric = "people",
               distinct = false,
               fields = ListFields(List(Field("value", Some(CountAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(60000, 1, "m"))
+              groupBy = Some(TemporalGroupByAggregation(60000, 1, minute))
             )
           ))
       }
@@ -388,7 +389,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
             metric = "people",
             distinct = false,
             fields = ListFields(List(Field("value", Some(CountAggregation)))),
-            groupBy = Some(TemporalGroupByAggregation(86400000, 1, "d")),
+            groupBy = Some(TemporalGroupByAggregation(86400000, 1, day)),
             limit = Some(LimitOperator(1))
           )
         ))
@@ -415,7 +416,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(CountAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, "d"))
+              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, day))
             )
           ))
       }
@@ -440,7 +441,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(CountAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, "d"))
+              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, day))
             )
           ))
       }
@@ -465,7 +466,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(SumAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, "d"))
+              groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, day))
             )
           ))
       }
@@ -490,7 +491,7 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
                 operator = AndOperator
               ))),
               fields = ListFields(List(Field("*", Some(AvgAggregation)))),
-              groupBy = Some(TemporalGroupByAggregation(4 * 24 * 3600 * 1000, 4, "d"))
+              groupBy = Some(TemporalGroupByAggregation(4 * 24 * 3600 * 1000, 4, day))
             )
           ))
       }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
@@ -16,9 +16,10 @@
 
 package io.radicalbit.nsdb.sql.parser
 
-import io.radicalbit.nsdb.common.NSDbLongType
 import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.sql.parser.SQLStatementParser._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult._
+import org.scalatest.Inside._
 import org.scalatest.OptionValues._
 import org.scalatest.{Matchers, WordSpec}
 
@@ -29,342 +30,163 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
   private val seconds = 1000L
   private val minutes = 60 * seconds
   private val hours   = 60 * minutes
-  private val days    = 24 * hours
-
-  private val timestampTolerance = 100L
+  24 * hours
 
   "A SQL parser instance" when {
 
     "receive a select with a relative timestamp value" should {
 
       "parse it successfully using relative time in simple where equality condition" in {
-        val result =
+        inside(
           parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp = now - 10s")
-        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
-        statement.isInstanceOf[SelectSQLStatement] shouldBe true
-        val now = System.currentTimeMillis()
-
-        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
-        val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[EqualityExpression]
-
-        val firstTimestamp = expression.value.asInstanceOf[RelativeComparisonValue]
-
-        firstTimestamp.value shouldBe a[NSDbLongType]
-        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 10 * seconds +- timestampTolerance
-        firstTimestamp.operator shouldBe "-"
-        firstTimestamp.quantity shouldBe 10
-        firstTimestamp.unitMeasure shouldBe "s"
+        ) {
+          case SqlStatementParserSuccess(_, selectSQLStatement: SelectSQLStatement) =>
+            inside(selectSQLStatement.condition.value.expression) {
+              case EqualityExpression(_, comparisonValue) =>
+                comparisonValue shouldBe RelativeComparisonValue(10000L, minus, 10, second)
+            }
+        }
       }
 
       "parse it successfully relative time in simple where comparison condition" in {
-        val result =
+        inside(
           parser.parse(db = "db",
                        namespace = "registry",
                        input = "SELECT name FROM people WHERE timestamp >= now - 10s")
-
-        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
-        statement.isInstanceOf[SelectSQLStatement] shouldBe true
-        val now = System.currentTimeMillis()
-
-        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
-        val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[ComparisonExpression]
-
-        val firstTimestamp = expression.value.asInstanceOf[RelativeComparisonValue]
-
-        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 10 * seconds +- timestampTolerance
-        firstTimestamp.operator shouldBe "-"
-        firstTimestamp.quantity shouldBe 10
-        firstTimestamp.unitMeasure shouldBe "s"
+        ) {
+          case SqlStatementParserSuccess(_, selectSQLStatement: SelectSQLStatement) =>
+            inside(selectSQLStatement.condition.value.expression) {
+              case ComparisonExpression(_, _, comparisonValue) =>
+                comparisonValue shouldBe RelativeComparisonValue(10000L, minus, 10, second)
+            }
+        }
       }
 
       "parse it successfully relative time in simple where comparison condition (now)" in {
-        val result =
+        inside(
           parser.parse(db = "db", namespace = "registry", input = "SELECT name FROM people WHERE timestamp < now")
-
-        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
-        statement.isInstanceOf[SelectSQLStatement] shouldBe true
-        val now = System.currentTimeMillis()
-
-        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
-        val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[ComparisonExpression]
-
-        val firstTimestamp = expression.value.asInstanceOf[AbsoluteComparisonValue]
-
-        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now +- timestampTolerance
+        ) {
+          case SqlStatementParserSuccess(_, selectSQLStatement: SelectSQLStatement) =>
+            inside(selectSQLStatement.condition.value.expression) {
+              case ComparisonExpression(_, _, comparisonValue) =>
+                comparisonValue shouldBe RelativeComparisonValue(0L, plus, 0L, second)
+            }
+        }
       }
 
       "parse it successfully relative time with double comparison condition (AND)" in {
-        val result =
+        inside(
           parser.parse(db = "db",
                        namespace = "registry",
                        input = "SELECT name FROM people WHERE timestamp < now AND age >= 18")
-
-        val now = System.currentTimeMillis()
-        result shouldBe a[SqlStatementParserSuccess]
-        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
-        statement shouldBe a[SelectSQLStatement]
-
-        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
-        val condition =
-          selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
-
-        val timestampExpression = condition.expression1.asInstanceOf[ComparisonExpression]
-        val ageExpression       = condition.expression2.asInstanceOf[ComparisonExpression]
-
-        val timestampComparison = timestampExpression.value.asInstanceOf[AbsoluteComparisonValue]
-        val ageComparison       = ageExpression.value.asInstanceOf[AbsoluteComparisonValue]
-
-        timestampComparison.value.asInstanceOf[NSDbLongType].rawValue shouldBe now +- timestampTolerance
-        timestampExpression.comparison shouldBe LessThanOperator
-
-        ageComparison.value.rawValue shouldBe 18
-        ageExpression.comparison shouldBe GreaterOrEqualToOperator
-
+        ) {
+          case SqlStatementParserSuccess(_, selectSQLStatement: SelectSQLStatement) =>
+            inside(selectSQLStatement.condition.value.expression) {
+              case TupledLogicalExpression(ComparisonExpression(_, _, timestampComparison),
+                                           AndOperator,
+                                           ComparisonExpression(_, _, ageComparison)) =>
+                timestampComparison shouldBe RelativeComparisonValue(0L, plus, 0L, second)
+                ageComparison shouldBe AbsoluteComparisonValue(18L)
+            }
+        }
       }
 
       "parse it successfully relative time in complex comparison condition (AND/OR)" in {
-        val result =
+        inside(
           parser.parse(
             db = "db",
             namespace = "registry",
             input = "SELECT name FROM people WHERE timestamp < now and timestamp > now - 2h OR timestamp = now + 4m")
-        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
-        statement.isInstanceOf[SelectSQLStatement] shouldBe true
-        val now = System.currentTimeMillis()
-
-        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
-        val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
-
-        val firstTimestamp =
-          expression.expression1.asInstanceOf[ComparisonExpression].value.asInstanceOf[AbsoluteComparisonValue]
-        val secondExpression = expression.expression2.asInstanceOf[TupledLogicalExpression]
-        val secondTimestamp =
-          secondExpression.expression1
-            .asInstanceOf[ComparisonExpression]
-            .value
-            .asInstanceOf[RelativeComparisonValue]
-        val thirdTimestamp = secondExpression.expression2
-          .asInstanceOf[EqualityExpression]
-          .value
-          .asInstanceOf[RelativeComparisonValue]
-
-        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now +- timestampTolerance
-
-        secondTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 2 * hours +- timestampTolerance
-        secondTimestamp.operator shouldBe "-"
-        secondTimestamp.quantity shouldBe 2
-        secondTimestamp.unitMeasure shouldBe "h"
-
-        thirdTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 4 * minutes +- timestampTolerance
-        thirdTimestamp.operator shouldBe "+"
-        thirdTimestamp.quantity shouldBe 4
-        thirdTimestamp.unitMeasure shouldBe "m"
-
+        ) {
+          case SqlStatementParserSuccess(_, selectSQLStatement: SelectSQLStatement) =>
+            inside(selectSQLStatement.condition.value.expression) {
+              case TupledLogicalExpression(ComparisonExpression(_, _, firstTimestampComparison),
+                                           AndOperator,
+                                           TupledLogicalExpression(ComparisonExpression(_,
+                                                                                        _,
+                                                                                        secondTimestampComparison),
+                                                                   OrOperator,
+                                                                   EqualityExpression(_, thirdTimestampComparison))) =>
+                firstTimestampComparison shouldBe RelativeComparisonValue(0L, plus, 0L, second)
+                secondTimestampComparison shouldBe RelativeComparisonValue(7200000L, minus, 2L, hour)
+                thirdTimestampComparison shouldBe RelativeComparisonValue(240000L, plus, 4L, minute)
+            }
+        }
       }
 
-      "parse it successfully using relative time in complex where condition" in {
-
-        val result = parser.parse(db = "db",
-                                  namespace = "registry",
-                                  input = "SELECT name FROM people WHERE timestamp < now + 5s and timestamp > now - 8d")
-        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
-        statement.isInstanceOf[SelectSQLStatement] shouldBe true
-        val now = System.currentTimeMillis()
-
-        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
-        val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
-
-        val firstTimestamp =
-          expression.expression1.asInstanceOf[ComparisonExpression].value.asInstanceOf[RelativeComparisonValue]
-        val secondTimestamp =
-          expression.expression2.asInstanceOf[ComparisonExpression].value.asInstanceOf[RelativeComparisonValue]
-
-        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 5 * seconds +- timestampTolerance
-        firstTimestamp.operator shouldBe "+"
-        firstTimestamp.quantity shouldBe 5
-        firstTimestamp.unitMeasure shouldBe "s"
-
-        secondTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 8 * days +- timestampTolerance
-        secondTimestamp.operator shouldBe "-"
-        secondTimestamp.quantity shouldBe 8
-        secondTimestamp.unitMeasure shouldBe "d"
-      }
-
-      "parse it successfully using relative time in very complex where condition" in {
-
-        val result = parser.parse(
-          db = "db",
-          namespace = "registry",
-          input =
-            "SELECT name FROM people WHERE timestamp < now + 30d and timestamp > now - 2h AND timestamp = now + 4m")
-        result shouldBe a[SqlStatementParserSuccess]
-        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
-        statement shouldBe a[SelectSQLStatement]
-        val now = System.currentTimeMillis()
-
-        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
-        val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
-
-        val firstTimestamp =
-          expression.expression1.asInstanceOf[ComparisonExpression].value.asInstanceOf[RelativeComparisonValue]
-        val secondExpression = expression.expression2.asInstanceOf[TupledLogicalExpression]
-        val secondTimestamp =
-          secondExpression.expression1
-            .asInstanceOf[ComparisonExpression]
-            .value
-            .asInstanceOf[RelativeComparisonValue]
-        val thirdTimestamp = secondExpression.expression2
-          .asInstanceOf[EqualityExpression]
-          .value
-          .asInstanceOf[RelativeComparisonValue]
-
-        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 30 * days +- timestampTolerance
-        firstTimestamp.operator shouldBe "+"
-        firstTimestamp.quantity shouldBe 30
-        firstTimestamp.unitMeasure shouldBe "d"
-
-        secondTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 2 * hours +- timestampTolerance
-        secondTimestamp.operator shouldBe "-"
-        secondTimestamp.quantity shouldBe 2
-        secondTimestamp.unitMeasure shouldBe "h"
-
-        thirdTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 4 * minutes +- timestampTolerance
-        thirdTimestamp.operator shouldBe "+"
-        thirdTimestamp.quantity shouldBe 4
-        thirdTimestamp.unitMeasure shouldBe "m"
-      }
-
-      "parse it successfully using relative time in very complex where condition with brackets" in {
-
-        val result = parser.parse(
-          db = "db",
-          namespace = "registry",
-          input =
-            "SELECT name FROM people WHERE (timestamp < now + 30d and timestamp > now - 2h) or timestamp = now + 4m")
-        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
-        statement.isInstanceOf[SelectSQLStatement] shouldBe true
-        val now = System.currentTimeMillis()
-
-        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
-        val expression         = selectSQLStatement.condition.value.expression.asInstanceOf[TupledLogicalExpression]
-
-        val thirdTimestamp =
-          expression.expression2.asInstanceOf[EqualityExpression].value.asInstanceOf[RelativeComparisonValue]
-
-        val secondExpression = expression.expression1.asInstanceOf[TupledLogicalExpression]
-        val firstTimestamp =
-          secondExpression.expression1
-            .asInstanceOf[ComparisonExpression]
-            .value
-            .asInstanceOf[RelativeComparisonValue]
-        val secondTimestamp =
-          secondExpression.expression2
-            .asInstanceOf[ComparisonExpression]
-            .value
-            .asInstanceOf[RelativeComparisonValue]
-
-        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 30 * days +- timestampTolerance
-        firstTimestamp.operator shouldBe "+"
-        firstTimestamp.quantity shouldBe 30
-        firstTimestamp.unitMeasure shouldBe "d"
-
-        secondTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 2 * hours +- timestampTolerance
-        secondTimestamp.operator shouldBe "-"
-        secondTimestamp.quantity shouldBe 2
-        secondTimestamp.unitMeasure shouldBe "h"
-
-        thirdTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 4 * minutes +- timestampTolerance
-        thirdTimestamp.operator shouldBe "+"
-        thirdTimestamp.quantity shouldBe 4
-        thirdTimestamp.unitMeasure shouldBe "m"
+      "parse it successfully using relative time in a complex where condition with brackets" in {
+        inside(
+          parser.parse(
+            db = "db",
+            namespace = "registry",
+            input =
+              "SELECT name FROM people WHERE (timestamp < now + 30d and timestamp > now - 2h) or timestamp = now + 4d")
+        ) {
+          case SqlStatementParserSuccess(_, selectSQLStatement: SelectSQLStatement) =>
+            inside(selectSQLStatement.condition.value.expression) {
+              case TupledLogicalExpression(TupledLogicalExpression(ComparisonExpression(_, _, firstTimestampComparison),
+                                                                   AndOperator,
+                                                                   ComparisonExpression(_,
+                                                                                        _,
+                                                                                        secondTimestampComparison)),
+                                           OrOperator,
+                                           EqualityExpression(_, thirdTimestampComparison)) =>
+                firstTimestampComparison shouldBe RelativeComparisonValue(2592000000L, plus, 30L, day)
+                secondTimestampComparison shouldBe RelativeComparisonValue(7200000L, minus, 2L, hour)
+                thirdTimestampComparison shouldBe RelativeComparisonValue(345600000L, plus, 4L, day)
+            }
+        }
       }
 
       "parse it successfully with a relative timestamp range condition" in {
-        val result = parser.parse(db = "db",
-                                  namespace = "registry",
-                                  input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, now + 4 s)")
-
-        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
-        statement.isInstanceOf[SelectSQLStatement] shouldBe true
-        val now = System.currentTimeMillis()
-
-        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
-        val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression]
-
-        val firstTimestamp  = expression.value1.asInstanceOf[RelativeComparisonValue]
-        val secondTimestamp = expression.value2.asInstanceOf[RelativeComparisonValue]
-
-        expression.dimension shouldBe "timestamp"
-        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 2 * seconds +- timestampTolerance
-        firstTimestamp.operator shouldBe "-"
-        firstTimestamp.quantity shouldBe 2
-        firstTimestamp.unitMeasure shouldBe "s"
-        secondTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 4 * seconds +- timestampTolerance
-        secondTimestamp.operator shouldBe "+"
-        secondTimestamp.quantity shouldBe 4
-        secondTimestamp.unitMeasure shouldBe "s"
+        inside(
+          parser.parse(db = "db",
+                       namespace = "registry",
+                       input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, now + 4 s)")
+        ) {
+          case SqlStatementParserSuccess(_, selectSQLStatement: SelectSQLStatement) =>
+            inside(selectSQLStatement.condition.value.expression) {
+              case RangeExpression(_,
+                                   firstAggregation: RelativeComparisonValue,
+                                   secondAggregation: RelativeComparisonValue) =>
+                firstAggregation shouldBe RelativeComparisonValue(2000L, minus, 2L, second)
+                secondAggregation shouldBe RelativeComparisonValue(4000L, plus, 4L, second)
+            }
+        }
       }
 
       "parse it successfully with a relative timestamp range condition with unnecessary brackets" in {
-        val result = parser.parse(db = "db",
-                                  namespace = "registry",
-                                  input = "SELECT name FROM people WHERE (timestamp IN (now - 2 s, now + 4 s))")
-
-        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
-        statement.isInstanceOf[SelectSQLStatement] shouldBe true
-        val now = System.currentTimeMillis()
-
-        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
-        val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression]
-
-        val firstTimestamp  = expression.value1.asInstanceOf[RelativeComparisonValue]
-        val secondTimestamp = expression.value2.asInstanceOf[RelativeComparisonValue]
-
-        expression.dimension shouldBe "timestamp"
-        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 2 * seconds +- timestampTolerance
-        firstTimestamp.operator shouldBe "-"
-        firstTimestamp.quantity shouldBe 2
-        firstTimestamp.unitMeasure shouldBe "s"
-        secondTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now + 4 * seconds +- timestampTolerance
-        secondTimestamp.operator shouldBe "+"
-        secondTimestamp.quantity shouldBe 4
-        secondTimestamp.unitMeasure shouldBe "s"
+        inside(
+          parser.parse(db = "db",
+                       namespace = "registry",
+                       input = "SELECT name FROM people WHERE (timestamp IN (now - 2 s, now + 4 s))")
+        ) {
+          case SqlStatementParserSuccess(_, selectSQLStatement: SelectSQLStatement) =>
+            inside(selectSQLStatement.condition.value.expression) {
+              case RangeExpression(_,
+                                   firstAggregation: RelativeComparisonValue,
+                                   secondAggregation: RelativeComparisonValue) =>
+                firstAggregation shouldBe RelativeComparisonValue(2000L, minus, 2L, second)
+                secondAggregation shouldBe RelativeComparisonValue(4000L, plus, 4L, second)
+            }
+        }
       }
 
       "parse it successfully with a mixed relative/absolute timestamp range condition" in {
-        val result = parser.parse(db = "db",
-                                  namespace = "registry",
-                                  input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, 5)")
-
-        result.isInstanceOf[SqlStatementParserSuccess] shouldBe true
-        val statement = result.asInstanceOf[SqlStatementParserSuccess].statement
-        statement.isInstanceOf[SelectSQLStatement] shouldBe true
-        val now = System.currentTimeMillis()
-
-        val selectSQLStatement = statement.asInstanceOf[SelectSQLStatement]
-        val expression =
-          selectSQLStatement.condition.value.expression.asInstanceOf[RangeExpression]
-
-        val firstTimestamp = expression.value1.asInstanceOf[RelativeComparisonValue]
-        expression.dimension shouldBe "timestamp"
-        firstTimestamp.value.asInstanceOf[NSDbLongType].rawValue shouldBe now - 2 * seconds +- timestampTolerance
-        firstTimestamp.operator shouldBe "-"
-        firstTimestamp.quantity shouldBe 2
-        firstTimestamp.unitMeasure shouldBe "s"
-        expression.value2 shouldBe AbsoluteComparisonValue(5L)
+        inside(
+          parser.parse(db = "db",
+                       namespace = "registry",
+                       input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, 5)")
+        ) {
+          case SqlStatementParserSuccess(_, selectSQLStatement: SelectSQLStatement) =>
+            inside(selectSQLStatement.condition.value.expression) {
+              case RangeExpression(_,
+                                   firstAggregation: RelativeComparisonValue,
+                                   secondAggregation: AbsoluteComparisonValue) =>
+                firstAggregation shouldBe RelativeComparisonValue(2000L, minus, 2L, second)
+                secondAggregation shouldBe AbsoluteComparisonValue(5L)
+            }
+        }
       }
 
     }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
@@ -156,7 +156,7 @@ class SQLStatementBracketsSpec extends WordSpec with Matchers {
           db = "db",
           namespace = "registry",
           input =
-            "SELECT name FROM people WHERE timestamp < now + 30d and (timestamp > now - 2h) AND (timestamp = now + 4m)")
+            "SELECT name FROM people WHERE timestamp < now + 30d and (timestamp > now - 2h) AND (timestamp = now + 4 min)")
         statement.isInstanceOf[SqlStatementParserSuccess] shouldBe true
       }
     }


### PR DESCRIPTION
This PR introduces one new feature and consolidates an existing one
- a TimeContext has been introduced. 
By now, it will include the current time and the timezone. 
The object is centrally initialized inside coordinators and used to calculate relative time expression throughout all the shards.
- Duration labels are now compliant with the Java and Scala nomenclature:
allowed values are now 
```
d, day, 
h, hour
min minute
s, sec, second
```
