### PR TITLE
Grace Period for Temporal Queries

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -233,7 +233,7 @@ class ReadCoordinator(metadataCoordinator: ActorRef,
                   internalAggregationReduce(_, schema, aggregation)
                 ).map(limitAndOrder(_, statement, schema, Some(aggregation)))
 
-              case Right(ParsedTemporalAggregatedQuery(_, _, _, rangeLength, aggregation, condition, _, _)) =>
+              case Right(ParsedTemporalAggregatedQuery(_, _, _, rangeLength, aggregation, condition, _, _, _)) =>
                 val sortedLocations = filteredLocations.sortBy(_.from)
 
                 val globalRanges: Seq[TimeRange] =

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/ReadNodesSelection.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/ReadNodesSelection.scala
@@ -16,11 +16,11 @@
 
 package io.radicalbit.nsdb.cluster.logic
 
-import io.radicalbit.nsdb.common.statement.Expression
-import io.radicalbit.nsdb.model.Location
+import io.radicalbit.nsdb.common.statement.{Expression, GracePeriod}
+import io.radicalbit.nsdb.model.{Location, TimeContext}
 import io.radicalbit.nsdb.statement.TimeRangeManager
-import spire.math.Interval
 import spire.implicits._
+import spire.math.Interval
 
 /**
   * contains the method to select distinct locations
@@ -45,6 +45,14 @@ object ReadNodesSelection {
           .map(i => Interval.closed(key.from, key.to).intersect(i) != Interval.empty[Long])
           .foldLeft(false)((x, y) => x || y)
       case _ => true
+    }
+  }
+
+  def filterLocationsThroughGracePeriod(gracePeriod: Long, locations: Seq[Location])(
+      implicit timeContext: TimeContext): Seq[Location] = {
+    val gracePeriodInterval = Interval.above(timeContext.currentTime - gracePeriod)
+    locations.filter { loc =>
+      Interval.closed(loc.from, loc.to).intersect(gracePeriodInterval) != Interval.empty[Long]
     }
   }
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/ReadNodesSelection.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/ReadNodesSelection.scala
@@ -16,7 +16,7 @@
 
 package io.radicalbit.nsdb.cluster.logic
 
-import io.radicalbit.nsdb.common.statement.{Expression, GracePeriod}
+import io.radicalbit.nsdb.common.statement.Expression
 import io.radicalbit.nsdb.model.{Location, TimeContext}
 import io.radicalbit.nsdb.statement.TimeRangeManager
 import spire.implicits._

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
@@ -22,12 +22,11 @@ import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.AddRecordToLocation
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.AddLocations
 import io.radicalbit.nsdb.common.protocol._
 import io.radicalbit.nsdb.common.statement._
-import io.radicalbit.nsdb.model.Location
+import io.radicalbit.nsdb.model.{Location, TimeContext}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 
 import scala.concurrent.Await
-import scala.concurrent.duration._
 
 object TemporalDoubleMetric {
 
@@ -70,7 +69,7 @@ object TemporalLongMetric {
 
 class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordinatorSpec {
 
-  override def beforeAll = {
+  override def beforeAll: Unit = {
     import scala.concurrent.duration._
     implicit val timeout: Timeout = Timeout(5.second)
 
@@ -148,7 +147,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
   "ReadCoordinator" when {
 
     "receive a select containing a temporal group by with count aggregation" should {
-      "execute it successfully when count(*) is used instead of value" in within(5.seconds) {
+      "execute it successfully when count(*) is used instead of value" in {
 
         val expected = awaitAssert {
 
@@ -182,7 +181,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
 
       }
 
-      "execute it successfully when no shard has picked up" in within(5.seconds) {
+      "execute it successfully when no shard has picked up" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -210,7 +209,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
         expected.values.size shouldBe 0
       }
 
-      "execute it successfully when only one shard has picked up" in within(5.seconds) {
+      "execute it successfully when only one shard has picked up" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -243,7 +242,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
         )
       }
 
-      "execute it successfully with limit" in within(5.seconds) {
+      "execute it successfully with limit" in {
 
         val expected = awaitAssert {
 
@@ -273,7 +272,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
         )
       }
 
-      "execute it successfully when time ranges contain more than one value" in within(5.seconds) {
+      "execute it successfully when time ranges contain more than one value" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -306,7 +305,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
     }
 
     "receive a select containing a temporal group by with count aggregation on a double value metric" should {
-      "execute it successfully when count(*) is used instead of value" in within(5.seconds) {
+      "execute it successfully when count(*) is used instead of value" in {
 
         val expected = awaitAssert {
 
@@ -340,7 +339,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
 
       }
 
-      "execute it successfully when time ranges contain more than one value" in within(5.seconds) {
+      "execute it successfully when time ranges contain more than one value" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -373,7 +372,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
     }
 
     "receive a select containing a timestamp where condition and a temporal group by with count aggregation" should {
-      "execute it successfully in case of GTE" in within(5.seconds) {
+      "execute it successfully in case of GTE" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -407,7 +406,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
         )
       }
 
-      "execute it successfully in case of LT" in within(5.seconds) {
+      "execute it successfully in case of LT" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -441,7 +440,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
     }
 
     "receive a select containing a temporal group with count aggregation by with an interval higher than the shard interval" should {
-      "execute it successfully" in within(5.seconds) {
+      "execute it successfully" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -470,7 +469,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
         )
       }
 
-      "execute it successfully in case of a where condition" in within(5.seconds) {
+      "execute it successfully in case of a where condition" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -504,7 +503,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
     }
 
     "receive a select containing a temporal group by with sum aggregation" should {
-      "execute it successfully when sum(*) is used instead of value" in within(5.seconds) {
+      "execute it successfully when sum(*) is used instead of value" in {
 
         val expected = awaitAssert {
 
@@ -538,7 +537,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
 
       }
 
-      "execute it successfully when time ranges contain more than one value" in within(5.seconds) {
+      "execute it successfully when time ranges contain more than one value" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -571,7 +570,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
     }
 
     "receive a select containing a temporal group by with sum aggregation on a double value metric" should {
-      "execute it successfully when sum(*) is used instead of value" in within(5.seconds) {
+      "execute it successfully when sum(*) is used instead of value" in {
 
         val expected = awaitAssert {
 
@@ -605,7 +604,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
 
       }
 
-      "execute it successfully when time ranges contain more than one value" in within(5.seconds) {
+      "execute it successfully when time ranges contain more than one value" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -638,7 +637,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
     }
 
     "receive a select containing a temporal group by with max aggregation" should {
-      "execute it successfully when max(*) is used instead of value" in within(5.seconds) {
+      "execute it successfully when max(*) is used instead of value" in {
 
         val expected = awaitAssert {
 
@@ -672,7 +671,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
 
       }
 
-      "execute it successfully when time ranges contain more than one value" in within(5.seconds) {
+      "execute it successfully when time ranges contain more than one value" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -705,7 +704,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
     }
 
     "receive a select containing a temporal group by with max aggregation on a double metric" should {
-      "execute it successfully when max(*) is used instead of value" in within(5.seconds) {
+      "execute it successfully when max(*) is used instead of value" in {
 
         val expected = awaitAssert {
 
@@ -739,7 +738,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
 
       }
 
-      "execute it successfully when time ranges contain more than one value" in within(5.seconds) {
+      "execute it successfully when time ranges contain more than one value" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -772,7 +771,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
     }
 
     "receive a select containing a temporal group by with min aggregation" should {
-      "execute it successfully when min(*) is used instead of value" in within(5.seconds) {
+      "execute it successfully when min(*) is used instead of value" in {
 
         val expected = awaitAssert {
 
@@ -806,7 +805,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
 
       }
 
-      "execute it successfully when time ranges contain more than one value" in within(5.seconds) {
+      "execute it successfully when time ranges contain more than one value" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -839,7 +838,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
     }
 
     "receive a select containing a temporal group by with min aggregation on a double metric" should {
-      "execute it successfully when min(*) is used instead of value" in within(5.seconds) {
+      "execute it successfully when min(*) is used instead of value" in {
 
         val expected = awaitAssert {
 
@@ -873,7 +872,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
 
       }
 
-      "execute it successfully when time ranges contain more than one value" in within(5.seconds) {
+      "execute it successfully when time ranges contain more than one value" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -905,7 +904,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
     }
 
     "receive a select containing a temporal group by with avg aggregation" should {
-      "execute it successfully when avg(*) is used instead of value" in within(5.seconds) {
+      "execute it successfully when avg(*) is used instead of value" in {
 
         val expected = awaitAssert {
 
@@ -939,7 +938,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
 
       }
 
-      "execute it successfully when time ranges contain more than one value" in within(5.seconds) {
+      "execute it successfully when time ranges contain more than one value" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -972,7 +971,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
     }
 
     "receive a select containing a temporal group by with avg aggregation on a double value metric" should {
-      "execute it successfully when avg(*) is used instead of value" in within(5.seconds) {
+      "execute it successfully when avg(*) is used instead of value" in {
 
         val expected = awaitAssert {
 
@@ -1006,7 +1005,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
 
       }
 
-      "execute it successfully when time ranges contain more than one value" in within(5.seconds) {
+      "execute it successfully when time ranges contain more than one value" in {
         val expected = awaitAssert {
 
           probe.send(
@@ -1038,5 +1037,130 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractReadCoordi
 
     }
 
+    "receive a select containing a temporal group by with a grace period" should {
+      "execute it successfully with a count aggregation" in {
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalLongMetric.name,
+                distinct = false,
+                fields = ListFields(List(Field("*", Some(CountAggregation)))),
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
+                gracePeriod = Some(GracePeriod("s", 50L))
+              ),
+              timeContext = Some(TimeContext(currentTime = 160000L))
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values shouldBe Seq(
+          Bit(110000, 1L, Map("lowerBound" -> 110000L, "upperBound" -> 130000L), Map()),
+          Bit(130000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
+        )
+      }
+
+      "execute it successfully with sum aggregation" in {
+
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalLongMetric.name,
+                distinct = false,
+                fields = ListFields(List(Field("*", Some(SumAggregation)))),
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
+                gracePeriod = Some(GracePeriod("s", 80L))
+              ),
+              timeContext = Some(TimeContext(currentTime = 160000L))
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values shouldBe Seq(
+          Bit(80000, 5L, Map("lowerBound"  -> 80000L, "upperBound"  -> 100000L), Map()),
+          Bit(100000, 3L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
+          Bit(130000, 2L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
+        )
+
+      }
+
+      "execute it successfully with avg aggregation" in {
+
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalLongMetric.name,
+                distinct = false,
+                fields = ListFields(List(Field("*", Some(AvgAggregation)))),
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
+                gracePeriod = Some(GracePeriod("s", 80L))
+              ),
+              timeContext = Some(TimeContext(currentTime = 160000L))
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values shouldBe Seq(
+          Bit(80000, 5.0, Map("lowerBound"  -> 80000L, "upperBound"  -> 100000L), Map()),
+          Bit(100000, 3.0, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
+          Bit(130000, 2.0, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
+        )
+
+      }
+
+      "execute it successfully with count aggregation and a condition" in {
+
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalLongMetric.name,
+                distinct = false,
+                fields = ListFields(List(Field("*", Some(CountAggregation)))),
+                condition = Some(
+                  Condition(ComparisonExpression(dimension = "timestamp",
+                                                 comparison = LessOrEqualToOperator,
+                                                 value = AbsoluteComparisonValue(100000L)))),
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
+                gracePeriod = Some(GracePeriod("s", 80L))
+              ),
+              timeContext = Some(TimeContext(currentTime = 160000L))
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values shouldBe Seq(
+          Bit(80000, 1L, Map("lowerBound" -> 80000L, "upperBound" -> 100000L), Map())
+        )
+
+      }
+
+    }
   }
 }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -50,7 +50,7 @@ class TestSubscriber extends Actor {
 
 class FakeReadCoordinatorActor extends Actor {
   def receive: Receive = {
-    case ExecuteStatement(statement) =>
+    case ExecuteStatement(statement, _) =>
       sender() ! SelectStatementExecuted(statement, values = Seq.empty)
   }
 }

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -318,10 +318,13 @@ object SQLStatement {
   final val plus  = "+"
   final val minus = "-"
 
-  final val day    = Set("d", "day")
-  final val hour   = Set("h", "hour")
-  final val minute = Set("min", "minute")
-  final val second = Set("s", "sec", "second")
+  // The order of this sequences is essential, because those are picked up by the parser and used to create an alternative composition rule
+  // like "day" | "d" | "hour|
+  // if a shorter label is before a longer one that has the same prefix, the parser will match the first rule and fail otherwise.
+  final val day    = Seq("day", "d")
+  final val hour   = Seq("hour", "h")
+  final val minute = Seq("minute", "min")
+  final val second = Set("second", "sec", "s")
 }
 
 /**

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -212,6 +212,12 @@ final case class DescOrderOperator(override val dimension: String) extends Order
 final case class LimitOperator(value: Int) extends NSDbSerializable
 
 /**
+  * Time interval to consider to limit the size of a query.
+  * @param interval Time interval in milliseconds
+  */
+final case class GracePeriod(interval: Long)
+
+/**
   * Comparison value to wrap values for tracking relative and absolute (mainly for relative timestamp)
   */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -321,6 +327,7 @@ object SQLStatement {
   * @param condition the where condition. See [[Condition]].
   * @param groupBy present if the query includes a group by clause.
   * @param order present if the query includes a order clause. See [[OrderOperator]].
+  * @param gracePeriod present if the query includes a grace period clause. See [[GracePeriod]].
   * @param limit present if the query includes a limit clause. See [[LimitOperator]].
   */
 final case class SelectSQLStatement(override val db: String,
@@ -331,6 +338,7 @@ final case class SelectSQLStatement(override val db: String,
                                     condition: Option[Condition] = None,
                                     groupBy: Option[GroupByAggregation] = None,
                                     order: Option[OrderOperator] = None,
+                                    gracePeriod: Option[GracePeriod] = None,
                                     limit: Option[LimitOperator] = None)
     extends SQLStatement
     with LazyLogging

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -214,8 +214,10 @@ final case class LimitOperator(value: Int) extends NSDbSerializable
 /**
   * Time interval to consider to limit the size of a query.
   * @param interval Time interval in milliseconds
+  * @param timeMeasure a single character that express the chosen time measure.
+  * @param quantity the absolute quantity provided in the query string.
   */
-final case class GracePeriod(interval: Long)
+final case class GracePeriod(interval: Long, timeMeasure: String, quantity: Long)
 
 /**
   * Comparison value to wrap values for tracking relative and absolute (mainly for relative timestamp)

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -213,11 +213,16 @@ final case class LimitOperator(value: Int) extends NSDbSerializable
 
 /**
   * Time interval to consider to limit the size of a query.
-  * @param interval Time interval in milliseconds
   * @param timeMeasure a single character that express the chosen time measure.
   * @param quantity the absolute quantity provided in the query string.
   */
-final case class GracePeriod(interval: Long, timeMeasure: String, quantity: Long)
+final case class GracePeriod(timeMeasure: String, quantity: Long) {
+
+  /**
+    * Time interval in milliseconds.
+    */
+  lazy val interval = Duration(s"$quantity${timeMeasure.toLowerCase}").toMillis
+}
 
 /**
   * Comparison value to wrap values for tracking relative and absolute (mainly for relative timestamp)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
@@ -268,7 +268,7 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
     case msg @ ExecuteSelectStatement(statement, schema, locations, _, timeContext, isSingleNode) =>
       log.debug("executing statement in metric reader actor {}", statement)
       StatementParser.parseStatement(statement, schema)(timeContext) match {
-        case Right(parsedStatement @ ParsedSimpleQuery(_, _, _, false, limit, fields, _)) =>
+        case Right(parsedStatement @ ParsedSimpleQuery(_, _, _, false, _, _, _)) =>
           retrieveAndOrderPlainResults(actorsForLocations(locations), parsedStatement, msg)
             .map {
               case SelectStatementExecuted(_, seq) =>
@@ -310,7 +310,7 @@ class MetricReaderActor(val basePath: String, nodeName: String, val db: String, 
               internalAggregationReduce(_, schema, aggregation, isSingleNode))
 
           shardResults.pipeTo(sender)
-        case Right(ParsedTemporalAggregatedQuery(_, _, _, _, aggregationType, _, _, _)) =>
+        case Right(ParsedTemporalAggregatedQuery(_, _, _, _, aggregationType, _, _, _, _)) =>
           val actors =
             actorsForLocations(locations)
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -188,7 +188,8 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
           handleNoIndexResults(Try(index.getMaxGroupBy(q, schema, groupField)))
         case Right(ParsedAggregatedQuery(_, _, q, InternalStandardAggregation(groupField, MinAggregation), _, _)) =>
           handleNoIndexResults(Try(index.getMinGroupBy(q, schema, groupField)))
-        case Right(ParsedTemporalAggregatedQuery(_, _, q, _, InternalTemporalAggregation(CountAggregation), _, _, _)) =>
+        case Right(
+            ParsedTemporalAggregatedQuery(_, _, q, _, InternalTemporalAggregation(CountAggregation), _, _, _, _)) =>
           handleNoIndexResults(
             Try(
               facetIndexes
@@ -199,7 +200,7 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
                                    "value",
                                    None,
                                    globalRanges.filter(_.intersect(location)))))
-        case Right(ParsedTemporalAggregatedQuery(_, _, q, _, aggregationType, _, _, _)) =>
+        case Right(ParsedTemporalAggregatedQuery(_, _, q, _, aggregationType, _, _, _, _)) =>
           val valueFieldType: IndexType[_] = schema.value.indexType
           handleNoIndexResults(
             Try(

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -19,18 +19,7 @@ import java.math.MathContext
 
 import io.radicalbit.nsdb.common.{NSDbNumericType, NSDbType}
 import io.radicalbit.nsdb.common.protocol.Bit
-import io.radicalbit.nsdb.common.statement.{
-  Aggregation,
-  AvgAggregation,
-  CountAggregation,
-  DescOrderOperator,
-  FirstAggregation,
-  LastAggregation,
-  MaxAggregation,
-  MinAggregation,
-  SelectSQLStatement,
-  SumAggregation
-}
+import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.index.{BIGINT, NumericType}
 import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -44,8 +44,10 @@ object MessageProtocol {
     case class GetSchemaFromCache(db: String, namespace: String, metric: String)               extends NSDbSerializable
     case class EvictSchema(db: String, namespace: String, metric: String)                      extends NSDbSerializable
 
-    case class ValidateStatement(selectStatement: SelectSQLStatement) extends NSDbSerializable
-    case class ExecuteStatement(selectStatement: SelectSQLStatement)  extends NSDbSerializable
+    case class ValidateStatement(selectStatement: SelectSQLStatement, timeContext: Option[TimeContext] = None)
+        extends NSDbSerializable
+    case class ExecuteStatement(selectStatement: SelectSQLStatement, timeContext: Option[TimeContext] = None)
+        extends NSDbSerializable
     case class ExecuteSelectStatement(selectStatement: SelectSQLStatement,
                                       schema: Schema,
                                       locations: Seq[Location],

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/ExpressionParser.scala
@@ -90,17 +90,17 @@ object ExpressionParser {
         Try(IntPoint.newExactQuery(field, t.cast(value.rawValue))) match {
           case Success(q) => Right(q)
           case _ =>
-            Left(StatementParserErrors.uncompatibleOperator("equality", "INT"))
+            Left(StatementParserErrors.nonCompatibleOperator("equality", "INT"))
         }
       case Some(SchemaField(_, _, t: BIGINT)) =>
         Try(LongPoint.newExactQuery(field, t.cast(value.rawValue))) match {
           case Success(q) => Right(q)
-          case _          => Left(StatementParserErrors.uncompatibleOperator("equality", "BIGINT"))
+          case _          => Left(StatementParserErrors.nonCompatibleOperator("equality", "BIGINT"))
         }
       case Some(SchemaField(_, _, t: DECIMAL)) =>
         Try(DoublePoint.newExactQuery(field, t.cast(value.rawValue))) match {
           case Success(q) => Right(q)
-          case _          => Left(StatementParserErrors.uncompatibleOperator("equality", "DECIMAL"))
+          case _          => Left(StatementParserErrors.nonCompatibleOperator("equality", "DECIMAL"))
         }
       case Some(SchemaField(_, _, _: VARCHAR)) => Right(new TermQuery(new Term(field, value.rawValue.toString)))
       case None                                => Left(StatementParserErrors.notExistingDimension(field))
@@ -114,7 +114,7 @@ object ExpressionParser {
       case Some(SchemaField(_, _, _: VARCHAR)) =>
         Right(new WildcardQuery(new Term(field, value.rawValue.toString.replaceAll("\\$", "*"))))
       case Some(_) =>
-        Left(StatementParserErrors.uncompatibleOperator("Like", "VARCHAR"))
+        Left(StatementParserErrors.nonCompatibleOperator("Like", "VARCHAR"))
       case None => Left(StatementParserErrors.notExistingDimension(field))
     }
   }
@@ -141,14 +141,14 @@ object ExpressionParser {
         Try(t.cast(v)).map(v =>
           buildRangeQuery[Int](IntPoint.newRangeQuery, v + 1, v - 1, Int.MinValue, Int.MaxValue, v)) match {
           case Success(q) => Right(q)
-          case _          => Left(StatementParserErrors.uncompatibleOperator("range", "INT"))
+          case _          => Left(StatementParserErrors.nonCompatibleOperator("range", "INT"))
         }
       case (Some(SchemaField(_, _, t: BIGINT)), v) =>
         Try(t.cast(v)).map(v =>
           buildRangeQuery[Long](LongPoint.newRangeQuery, v + 1, v - 1, Long.MinValue, Long.MaxValue, v)) match {
           case Success(q) => Right(q)
           case _ =>
-            Left(StatementParserErrors.uncompatibleOperator("range", "BIGINT"))
+            Left(StatementParserErrors.nonCompatibleOperator("range", "BIGINT"))
         }
       case (Some(SchemaField(_, _, t: DECIMAL)), v) =>
         Try(t.cast(v)).map(
@@ -160,10 +160,10 @@ object ExpressionParser {
                                     Double.MaxValue,
                                     v)) match {
           case Success(q) => Right(q)
-          case _          => Left(StatementParserErrors.uncompatibleOperator("range", "DECIMAL"))
+          case _          => Left(StatementParserErrors.nonCompatibleOperator("range", "DECIMAL"))
         }
       case (Some(_), _) =>
-        Left(StatementParserErrors.uncompatibleOperator("comparison", "numerical"))
+        Left(StatementParserErrors.nonCompatibleOperator("comparison", "numerical"))
       case (None, _) => Left(StatementParserErrors.notExistingDimension(field))
     }
   }
@@ -179,14 +179,14 @@ object ExpressionParser {
         } match {
           case Success(q) => Right(q)
           case _ =>
-            Left(StatementParserErrors.uncompatibleOperator("range", "BIGINT"))
+            Left(StatementParserErrors.nonCompatibleOperator("range", "BIGINT"))
         }
       case (Some(SchemaField(_, _, t: INT)), v1, v2) =>
         Try((t.cast(v1), t.cast(v2))).map {
           case (l, h) => IntPoint.newRangeQuery(field, l, h)
         } match {
           case Success(q) => Right(q)
-          case _          => Left(StatementParserErrors.uncompatibleOperator("range", "INT"))
+          case _          => Left(StatementParserErrors.nonCompatibleOperator("range", "INT"))
         }
       case (Some(SchemaField(_, _, t: DECIMAL)), v1, v2) =>
         Try((t.cast(v1), t.cast(v2))).map {
@@ -194,10 +194,10 @@ object ExpressionParser {
         } match {
           case Success(q) => Right(q)
           case _ =>
-            Left(StatementParserErrors.uncompatibleOperator("range", "DECIMAL"))
+            Left(StatementParserErrors.nonCompatibleOperator("range", "DECIMAL"))
         }
       case (Some(SchemaField(_, _, _: VARCHAR)), _, _) =>
-        Left(StatementParserErrors.uncompatibleOperator("range", "numerical"))
+        Left(StatementParserErrors.nonCompatibleOperator("range", "numerical"))
       case (None, _, _) => Left(StatementParserErrors.notExistingDimension(field))
     }
   }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
@@ -60,9 +60,10 @@ object StatementParser {
 
     val limitOpt = statement.limit.map(_.value)
 
-    expParsed flatMap { exp =>
-      FieldsParser.parseFieldList(statement.fields, schema).flatMap { parsedFieldsList =>
-        //switch on group by
+    for {
+      exp              <- expParsed
+      parsedFieldsList <- FieldsParser.parseFieldList(statement.fields, schema)
+      pardedQuery <- {
         (statement.groupBy, parsedFieldsList.list) match {
           case (Some(group), _)
               if sortOpt
@@ -135,7 +136,7 @@ object StatementParser {
               ))
         }
       }
-    }
+    } yield pardedQuery
   }
 
   /**

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParserErrors.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParserErrors.scala
@@ -35,7 +35,9 @@ object StatementParserErrors {
     "cannot sort group by query result by a field not in group by clause"
   def notExistingDimension(dim: String)       = s"field $dim does not exist"
   def notExistingDimensions(dim: Seq[String]) = s"field [${dim.mkString(",")}] does not exist"
-  def uncompatibleOperator(operator: String, dimTypeAllowed: String) =
+  def nonCompatibleOperator(operator: String, dimTypeAllowed: String) =
     s"cannot use $operator operator on dimension different from $dimTypeAllowed"
+  def nonCompatibleClauses(clause1: String, clause2: String) =
+    s"The clause $clause1 and $clause2 are not compatible and cannot be used together"
 
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParserErrors.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParserErrors.scala
@@ -33,11 +33,10 @@ object StatementParserErrors {
     "cannot execute an aggregation on a field different than value"
   lazy val SORT_DIMENSION_NOT_IN_GROUP =
     "cannot sort group by query result by a field not in group by clause"
+  lazy val GRACE_PERIOD_NOT_ALLOWED           = "grace period clause is allowed only in temporal group by queries"
   def notExistingDimension(dim: String)       = s"field $dim does not exist"
   def notExistingDimensions(dim: Seq[String]) = s"field [${dim.mkString(",")}] does not exist"
   def nonCompatibleOperator(operator: String, dimTypeAllowed: String) =
     s"cannot use $operator operator on dimension different from $dimTypeAllowed"
-  def nonCompatibleClauses(clause1: String, clause2: String) =
-    s"The clause $clause1 and $clause2 are not compatible and cannot be used together"
 
 }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -32,7 +32,7 @@ import scala.concurrent.duration._
 
 class EmptyReadCoordinator extends Actor {
   def receive: Receive = {
-    case ExecuteStatement(statement) =>
+    case ExecuteStatement(statement, _) =>
       sender() ! SelectStatementExecuted(statement, values = Seq.empty)
   }
 }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
@@ -276,7 +276,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             limit = Some(LimitOperator(4))
           ),
           schema
-        ) shouldBe Left(StatementParserErrors.uncompatibleOperator("equality", "BIGINT"))
+        ) shouldBe Left(StatementParserErrors.nonCompatibleOperator("equality", "BIGINT"))
       }
       "parse it successfully on a number vs a string" in {
         StatementParser.parseStatement(
@@ -374,7 +374,7 @@ class StatementParserSpec extends WordSpec with Matchers {
             limit = Some(LimitOperator(4))
           ),
           schema
-        ) shouldBe Left(StatementParserErrors.uncompatibleOperator("equality", "BIGINT"))
+        ) shouldBe Left(StatementParserErrors.nonCompatibleOperator("equality", "BIGINT"))
       }
     }
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
@@ -377,7 +377,7 @@ class TimeRangeManagerSpec extends WordSpec with Matchers {
 
         res shouldBe Seq(
           TimeRange(84, 89, false, true),
-          TimeRange(79, 84, true, true)
+          TimeRange(80, 84, true, true)
         )
       }
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/actor/EmptyReadCoordinator.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/actor/EmptyReadCoordinator.scala
@@ -22,7 +22,7 @@ import io.radicalbit.nsdb.protocol.MessageProtocol.Events.SelectStatementExecute
 
 class EmptyReadCoordinator extends Actor {
   def receive: Receive = {
-    case ExecuteStatement(statement) =>
+    case ExecuteStatement(statement, _) =>
       sender() ! SelectStatementExecuted(statement, values = Seq.empty)
   }
 }

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/actor/FakeReadCoordinator.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/actor/FakeReadCoordinator.scala
@@ -36,7 +36,7 @@ class FakeReadCoordinator extends Actor {
       sender ! MetricsGot(db, namespace, metrics)
     case GetSchema(db, namespace, metric) =>
       sender() ! SchemaGot(db, namespace, metric, schemas.get(metric))
-    case ValidateStatement(statement) =>
+    case ValidateStatement(statement, _) =>
       implicit val timeContext: TimeContext = TimeContext()
       schemas.get(statement.metric) match {
         case Some(schema) =>
@@ -49,7 +49,7 @@ class FakeReadCoordinator extends Actor {
                                                    s"metric ${statement.metric} does not exist",
                                                    MetricNotFound(statement.metric))
       }
-    case ExecuteStatement(statement)
+    case ExecuteStatement(statement, _)
         if statement.condition.isDefined && statement.condition.get.expression.isInstanceOf[RangeExpression] =>
       implicit val timeContext: TimeContext = TimeContext()
       StatementParser.parseStatement(statement, Schema(statement.metric, bits.head)) match {
@@ -60,7 +60,7 @@ class FakeReadCoordinator extends Actor {
           sender ! SelectStatementExecuted(statement, filteredBits)
         case Left(errorMessage) => sender ! SelectStatementFailed(statement, errorMessage)
       }
-    case ExecuteStatement(statement) =>
+    case ExecuteStatement(statement, _) =>
       implicit val timeContext: TimeContext = TimeContext()
       StatementParser.parseStatement(statement, Schema(statement.metric, bits.head)) match {
         case Right(_) =>

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryEnrichmentSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryEnrichmentSpec.scala
@@ -27,137 +27,147 @@ class QueryEnrichmentSpec extends WordSpec with Matchers {
     "Query with a single filter over a dimension of Long type" should {
       "be correctly converted with equal operator" in {
         val filters = Seq(FilterByValue("age", 1L, FilterOperators.Equality))
-        val originalStatement = SelectSQLStatement("db",
-                                                   "namespace",
-                                                   "people",
-                                                   false,
-                                                   ListFields(List(Field("name", None))),
-                                                   None,
-                                                   None,
-                                                   None,
-                                                   Some(LimitOperator(1)))
+        val originalStatement = SelectSQLStatement(
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
+          condition = None,
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
+        )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(Condition(EqualityExpression("age", AbsoluteComparisonValue(1L)))),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
       "be correctly converted with GT operator" in {
         val filters = Seq(FilterByValue("age", 1L, FilterOperators.GreaterThan))
-        val originalStatement = SelectSQLStatement("db",
-                                                   "namespace",
-                                                   "people",
-                                                   false,
-                                                   ListFields(List(Field("name", None))),
-                                                   None,
-                                                   None,
-                                                   None,
-                                                   Some(LimitOperator(1)))
+        val originalStatement = SelectSQLStatement(
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
+          condition = None,
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
+        )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(Condition(ComparisonExpression("age", GreaterThanOperator, AbsoluteComparisonValue(1L)))),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
       "be correctly converted with GTE operator" in {
         val filters = Seq(FilterByValue("age", 1L, FilterOperators.GreaterOrEqual))
-        val originalStatement = SelectSQLStatement("db",
-                                                   "namespace",
-                                                   "people",
-                                                   false,
-                                                   ListFields(List(Field("name", None))),
-                                                   None,
-                                                   None,
-                                                   None,
-                                                   Some(LimitOperator(1)))
+        val originalStatement = SelectSQLStatement(
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
+          condition = None,
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
+        )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(Condition(ComparisonExpression("age", GreaterOrEqualToOperator, AbsoluteComparisonValue(1L)))),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
       "be correctly converted with LT operator" in {
         val filters = Seq(FilterByValue("age", 1L, FilterOperators.LessThan))
-        val originalStatement = SelectSQLStatement("db",
-                                                   "namespace",
-                                                   "people",
-                                                   false,
-                                                   ListFields(List(Field("name", None))),
-                                                   None,
-                                                   None,
-                                                   None,
-                                                   Some(LimitOperator(1)))
+        val originalStatement = SelectSQLStatement(
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
+          condition = None,
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
+        )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(Condition(ComparisonExpression("age", LessThanOperator, AbsoluteComparisonValue(1L)))),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
       "be correctly converted with LTE operator" in {
         val filters = Seq(FilterByValue("age", 1L, FilterOperators.LessOrEqual))
-        val originalStatement = SelectSQLStatement("db",
-                                                   "namespace",
-                                                   "people",
-                                                   false,
-                                                   ListFields(List(Field("name", None))),
-                                                   None,
-                                                   None,
-                                                   None,
-                                                   Some(LimitOperator(1)))
+        val originalStatement = SelectSQLStatement(
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
+          condition = None,
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
+        )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(Condition(ComparisonExpression("age", LessOrEqualToOperator, AbsoluteComparisonValue(1L)))),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
     }
@@ -165,56 +175,60 @@ class QueryEnrichmentSpec extends WordSpec with Matchers {
     "Query with a single filter over a dimension of String type" should {
       "be correctly converted with equal operator" in {
         val filters = Seq(FilterByValue("surname", "Poe", FilterOperators.Equality))
-        val originalStatement = SelectSQLStatement("db",
-                                                   "namespace",
-                                                   "people",
-                                                   false,
-                                                   ListFields(List(Field("name", None))),
-                                                   None,
-                                                   None,
-                                                   None,
-                                                   Some(LimitOperator(1)))
+        val originalStatement = SelectSQLStatement(
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
+          condition = None,
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
+        )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(Condition(EqualityExpression("surname", AbsoluteComparisonValue("Poe")))),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
       "be correctly converted with LIKE operator" in {
         val filters = Seq(FilterByValue("surname", "Poe", FilterOperators.Like))
-        val originalStatement = SelectSQLStatement("db",
-                                                   "namespace",
-                                                   "people",
-                                                   false,
-                                                   ListFields(List(Field("name", None))),
-                                                   None,
-                                                   None,
-                                                   None,
-                                                   Some(LimitOperator(1)))
+        val originalStatement = SelectSQLStatement(
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
+          condition = None,
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
+        )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(Condition(LikeExpression("surname", "Poe"))),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
     }
@@ -223,59 +237,61 @@ class QueryEnrichmentSpec extends WordSpec with Matchers {
       "be correctly converted with equal operators" in {
         val filters = Seq(FilterByValue("age", 1L, FilterOperators.Equality),
                           FilterByValue("height", 100L, FilterOperators.Equality))
-        val originalStatement = SelectSQLStatement("db",
-                                                   "namespace",
-                                                   "people",
-                                                   false,
-                                                   ListFields(List(Field("name", None))),
-                                                   None,
-                                                   None,
-                                                   None,
-                                                   Some(LimitOperator(1)))
-
-        val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
-
-        enrichedStatement shouldEqual
-          SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
-            Some(
-              Condition(
-                TupledLogicalExpression(EqualityExpression("age", AbsoluteComparisonValue(1L)),
-                                        AndOperator,
-                                        EqualityExpression("height", AbsoluteComparisonValue(100L))))),
-            None,
-            None,
-            Some(LimitOperator(1))
-          )
-      }
-      "be correctly converted with equal operators and existing Condition" in {
-        val filters = Seq(FilterByValue("age", 1L, FilterOperators.Equality),
-                          FilterByValue("height", 100L, FilterOperators.Equality))
         val originalStatement = SelectSQLStatement(
-          "db",
-          "namespace",
-          "people",
-          false,
-          ListFields(List(Field("name", None))),
-          Some(Condition(EqualityExpression("surname", AbsoluteComparisonValue("poe")))),
-          None,
-          None,
-          Some(LimitOperator(1))
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
+          condition = None,
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
         )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
+            Some(
+              Condition(
+                TupledLogicalExpression(EqualityExpression("age", AbsoluteComparisonValue(1L)),
+                                        AndOperator,
+                                        EqualityExpression("height", AbsoluteComparisonValue(100L))))),
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
+          )
+      }
+      "be correctly converted with equal operators and existing Condition" in {
+        val filters = Seq(FilterByValue("age", 1L, FilterOperators.Equality),
+                          FilterByValue("height", 100L, FilterOperators.Equality))
+        val originalStatement = SelectSQLStatement(
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
+          Some(Condition(EqualityExpression("surname", AbsoluteComparisonValue("poe")))),
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
+        )
+
+        val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
+
+        enrichedStatement shouldEqual
+          SelectSQLStatement(
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(
               Condition(
                 TupledLogicalExpression(
@@ -288,9 +304,9 @@ class QueryEnrichmentSpec extends WordSpec with Matchers {
                   )
                 )
               )),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
       "be correctly converted with different operators and existing Condition" in {
@@ -298,26 +314,26 @@ class QueryEnrichmentSpec extends WordSpec with Matchers {
           Seq(FilterByValue("age", 1L, FilterOperators.GreaterThan),
               FilterByValue("height", 100L, FilterOperators.LessOrEqual))
         val originalStatement = SelectSQLStatement(
-          "db",
-          "namespace",
-          "people",
-          false,
-          ListFields(List(Field("name", None))),
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
           Some(Condition(LikeExpression("surname", "poe"))),
-          None,
-          None,
-          Some(LimitOperator(1))
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
         )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(
               Condition(
                 TupledLogicalExpression(
@@ -330,9 +346,9 @@ class QueryEnrichmentSpec extends WordSpec with Matchers {
                   )
                 )
               )),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
       "be correctly converted with different operators and existing Conditions" in {
@@ -340,30 +356,30 @@ class QueryEnrichmentSpec extends WordSpec with Matchers {
           Seq(FilterByValue("age", 1L, FilterOperators.GreaterThan),
               FilterByValue("height", 100L, FilterOperators.LessOrEqual))
         val originalStatement = SelectSQLStatement(
-          "db",
-          "namespace",
-          "people",
-          false,
-          ListFields(List(Field("name", None))),
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
           Some(
             Condition(
               TupledLogicalExpression(LikeExpression("surname", "poe"),
                                       OrOperator,
                                       EqualityExpression("number", AbsoluteComparisonValue(1.0))))),
-          None,
-          None,
-          Some(LimitOperator(1))
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
         )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(
               Condition(
                 TupledLogicalExpression(
@@ -378,9 +394,9 @@ class QueryEnrichmentSpec extends WordSpec with Matchers {
                   )
                 )
               )),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
       "be correctly converted with different operators (also Not) and existing Conditions" in {
@@ -388,30 +404,30 @@ class QueryEnrichmentSpec extends WordSpec with Matchers {
           Seq(FilterByValue("age", 1L, FilterOperators.GreaterThan),
               FilterByValue("height", 100L, FilterOperators.LessOrEqual))
         val originalStatement = SelectSQLStatement(
-          "db",
-          "namespace",
-          "people",
-          false,
-          ListFields(List(Field("name", None))),
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
           Some(
             Condition(
               TupledLogicalExpression(LikeExpression("surname", "poe"),
                                       OrOperator,
                                       NotExpression(EqualityExpression("number", AbsoluteComparisonValue(1.0)))))),
-          None,
-          None,
-          Some(LimitOperator(1))
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
         )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(
               Condition(
                 TupledLogicalExpression(
@@ -426,9 +442,9 @@ class QueryEnrichmentSpec extends WordSpec with Matchers {
                   )
                 )
               )),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
     }
@@ -436,90 +452,96 @@ class QueryEnrichmentSpec extends WordSpec with Matchers {
     "Query with a single filter of nullable conditions" should {
       "be correctly converted with is null" in {
         val filters = Seq(FilterNullableValue("age", NullableOperators.IsNull))
-        val originalStatement = SelectSQLStatement("db",
-                                                   "namespace",
-                                                   "people",
-                                                   false,
-                                                   ListFields(List(Field("name", None))),
-                                                   None,
-                                                   None,
-                                                   None,
-                                                   Some(LimitOperator(1)))
+        val originalStatement = SelectSQLStatement(
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
+          condition = None,
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
+        )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(Condition(NullableExpression("age"))),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
 
       "be correctly converted with is not null" in {
         val filters = Seq(FilterNullableValue("age", NullableOperators.IsNotNull))
-        val originalStatement = SelectSQLStatement("db",
-                                                   "namespace",
-                                                   "people",
-                                                   false,
-                                                   ListFields(List(Field("name", None))),
-                                                   None,
-                                                   None,
-                                                   None,
-                                                   Some(LimitOperator(1)))
+        val originalStatement = SelectSQLStatement(
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
+          condition = None,
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
+        )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(Condition(NotExpression(NullableExpression("age")))),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
 
       "be correctly converted with is null and is not null" in {
         val filters = Seq(FilterNullableValue("age", NullableOperators.IsNull),
                           FilterNullableValue("height", NullableOperators.IsNotNull))
-        val originalStatement = SelectSQLStatement("db",
-                                                   "namespace",
-                                                   "people",
-                                                   false,
-                                                   ListFields(List(Field("name", None))),
-                                                   None,
-                                                   None,
-                                                   None,
-                                                   Some(LimitOperator(1)))
+        val originalStatement = SelectSQLStatement(
+          db = "db",
+          namespace = "namespace",
+          metric = "people",
+          distinct = false,
+          fields = ListFields(List(Field("name", None))),
+          condition = None,
+          groupBy = None,
+          order = None,
+          limit = Some(LimitOperator(1))
+        )
 
         val enrichedStatement = originalStatement.addConditions(filters.map(Filter.unapply(_).get))
 
         enrichedStatement shouldEqual
           SelectSQLStatement(
-            "db",
-            "namespace",
-            "people",
-            false,
-            ListFields(List(Field("name", None))),
+            db = "db",
+            namespace = "namespace",
+            metric = "people",
+            distinct = false,
+            fields = ListFields(List(Field("name", None))),
             Some(
               Condition(
                 TupledLogicalExpression(NullableExpression("age"),
                                         AndOperator,
                                         NotExpression(NullableExpression("height"))))),
-            None,
-            None,
-            Some(LimitOperator(1))
+            groupBy = None,
+            order = None,
+            limit = Some(LimitOperator(1))
           )
       }
     }

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -265,8 +265,8 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
   lazy val limit: PackratParser[LimitOperator] = (Limit ~> intValue) ^^ (value => LimitOperator(value))
 
   lazy val gracePeriod: PackratParser[GracePeriod] = (since ~> longValue ~ timeMeasure) ^^ {
-    case quantity ~ ((timeMeasure, unit)) =>
-      GracePeriod(unit * quantity, timeMeasure, quantity)
+    case timeMeasure ~ quantity =>
+      GracePeriod(quantity, timeMeasure)
   }
 
   private def selectQuery(db: String, namespace: String) =

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -138,6 +138,8 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
     case strings: List[String] => strings.mkString(" ")
   }
 
+  // The lists to be folded must be ordered by string length ascending.
+  // If a shorter string is before a longer one that has the same prefix, the parser will match the first rule and fail otherwise.
   private val timeMeasure = day.foldLeft(day.head.ignoreCase)((d1, d2) => d1 | d2.ignoreCase) |
     hour.foldLeft(hour.head.ignoreCase)((d1, d2) => d1 | d2.ignoreCase) |
     minute.foldLeft(minute.head.ignoreCase)((d1, d2) => d1 | d2.ignoreCase) |

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -265,7 +265,8 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
   lazy val limit: PackratParser[LimitOperator] = (Limit ~> intValue) ^^ (value => LimitOperator(value))
 
   lazy val gracePeriod: PackratParser[GracePeriod] = (since ~> longValue ~ timeMeasure) ^^ {
-    case unit ~ ((_, quantity)) => GracePeriod(unit * quantity)
+    case quantity ~ ((timeMeasure, unit)) =>
+      GracePeriod(unit * quantity, timeMeasure, quantity)
   }
 
   private def selectQuery(db: String, namespace: String) =

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/GracePeriodStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/GracePeriodStatementSpec.scala
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.sql.parser
+
+import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.sql.parser.StatementParserResult._
+import org.scalatest.Inside._
+import org.scalatest.{Matchers, WordSpec}
+
+class GracePeriodStatementSpec extends WordSpec with Matchers {
+
+  private val parser = new SQLStatementParser
+
+  private val seconds = 1000L
+  private val minutes = 60 * seconds
+  private val hours   = 60 * minutes
+  private val days    = 24 * hours
+
+  "A SQL parser instance" when {
+
+    "receive a select with a grace period" should {
+
+      "parse it successfully for an hours size period" in {
+        inside(
+          parser.parse(db = "db", namespace = "namespace", input = "SELECT * FROM people since 6h")
+        ) {
+          case success: SqlStatementParserSuccess =>
+            inside(success.statement) {
+              case selectSQLStatement: SelectSQLStatement =>
+                selectSQLStatement shouldBe
+                  SelectSQLStatement(
+                    db = "db",
+                    namespace = "namespace",
+                    metric = "people",
+                    distinct = false,
+                    fields = AllFields(),
+                    gracePeriod = Some(GracePeriod(6 * hours, "h", 6))
+                  )
+            }
+        }
+      }
+
+      "parse it successfully for a seconds size period" in {
+        inside(
+          parser.parse(db = "db", namespace = "namespace", input = "SELECT * FROM people since 6s")
+        ) {
+          case success: SqlStatementParserSuccess =>
+            inside(success.statement) {
+              case selectSQLStatement: SelectSQLStatement =>
+                selectSQLStatement shouldBe
+                  SelectSQLStatement(
+                    db = "db",
+                    namespace = "namespace",
+                    metric = "people",
+                    distinct = false,
+                    fields = AllFields(),
+                    gracePeriod = Some(GracePeriod(6 * seconds, "s", 6))
+                  )
+            }
+        }
+      }
+
+      "parse it successfully for a minutes size period" in {
+        inside(
+          parser.parse(db = "db", namespace = "namespace", input = "SELECT * FROM people since 6m")
+        ) {
+          case success: SqlStatementParserSuccess =>
+            inside(success.statement) {
+              case selectSQLStatement: SelectSQLStatement =>
+                selectSQLStatement shouldBe
+                  SelectSQLStatement(
+                    db = "db",
+                    namespace = "namespace",
+                    metric = "people",
+                    distinct = false,
+                    fields = AllFields(),
+                    gracePeriod = Some(GracePeriod(6 * minutes, "m", 6))
+                  )
+            }
+        }
+      }
+
+      "parse it successfully for a days size period" in {
+        inside(
+          parser.parse(db = "db", namespace = "namespace", input = "SELECT * FROM people since 6d")
+        ) {
+          case success: SqlStatementParserSuccess =>
+            inside(success.statement) {
+              case selectSQLStatement: SelectSQLStatement =>
+                selectSQLStatement shouldBe
+                  SelectSQLStatement(
+                    db = "db",
+                    namespace = "namespace",
+                    metric = "people",
+                    distinct = false,
+                    fields = AllFields(),
+                    gracePeriod = Some(GracePeriod(6 * days, "d", 6))
+                  )
+            }
+        }
+      }
+
+      "fail if other time measures are provided" in {
+        parser.parse(db = "db", namespace = "namespace", input = "SELECT * FROM people since 6y") shouldBe a[
+          SqlStatementParserFailure]
+      }
+    }
+
+    "receive a select with a where condition and a grace period" should {
+      "parse it successfully relative time in complex condition with brackets" in {
+        inside(
+          parser.parse(
+            db = "db",
+            namespace = "namespace",
+            "SELECT name FROM people WHERE (name like $an$ and surname = pippo) and timestamp IN (2,4)  since 6h")
+        ) {
+          case success: SqlStatementParserSuccess =>
+            inside(success.statement) {
+              case selectSQLStatement: SelectSQLStatement =>
+                selectSQLStatement shouldBe
+                  SelectSQLStatement(
+                    db = "db",
+                    namespace = "namespace",
+                    metric = "people",
+                    distinct = false,
+                    fields = ListFields(List(Field("name", None))),
+                    condition = Some(Condition(TupledLogicalExpression(
+                      expression1 = TupledLogicalExpression(
+                        expression1 = LikeExpression("name", "$an$"),
+                        operator = AndOperator,
+                        expression2 =
+                          EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo"))
+                      ),
+                      operator = AndOperator,
+                      expression2 = RangeExpression(dimension = "timestamp",
+                                                    value1 = AbsoluteComparisonValue(2L),
+                                                    value2 = AbsoluteComparisonValue(4L))
+                    ))),
+                    gracePeriod = Some(GracePeriod(6 * hours, "h", 6))
+                  )
+            }
+        }
+      }
+    }
+
+    "receive a select with a where condition an order and a limit" should {
+      "parse it successfully relative time in complex condition with brackets" in {
+        inside(
+          parser.parse(db = "db",
+                       namespace = "namespace",
+                       "SELECT name FROM people WHERE surname = pippo order by name desc since 6h limit 5")
+        ) {
+          case success: SqlStatementParserSuccess =>
+            inside(success.statement) {
+              case selectSQLStatement: SelectSQLStatement =>
+                selectSQLStatement shouldBe
+                  SelectSQLStatement(
+                    db = "db",
+                    namespace = "namespace",
+                    metric = "people",
+                    distinct = false,
+                    fields = ListFields(List(Field("name", None))),
+                    condition = Some(
+                      Condition(EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo")))),
+                    order = Some(DescOrderOperator(dimension = "name")),
+                    limit = Some(LimitOperator(5)),
+                    gracePeriod = Some(GracePeriod(6 * hours, "h", 6))
+                  )
+            }
+        }
+      }
+
+      "fail if grace period is provided after the limit" in {
+        parser.parse(db = "db",
+                     namespace = "namespace",
+                     "SELECT name FROM people WHERE surname = pippo order by name desc limit 5 since 6h") shouldBe a[
+          SqlStatementParserFailure]
+      }
+    }
+
+  }
+
+}

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/GracePeriodStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/GracePeriodStatementSpec.scala
@@ -190,7 +190,8 @@ class GracePeriodStatementSpec extends WordSpec with Matchers {
     "receive a select with a where condition, a group by, an order and a limit" should {
       "parse it successfully for a standard group by" in {
         inside(
-          parser.parse(db = "db",
+          parser.parse(
+            db = "db",
             namespace = "namespace",
             "SELECT name FROM people WHERE surname = pippo group by name order by name desc since 6h limit 5")
         ) {
@@ -217,7 +218,8 @@ class GracePeriodStatementSpec extends WordSpec with Matchers {
 
       "parse it successfully for a temporal group by" in {
         inside(
-          parser.parse(db = "db",
+          parser.parse(
+            db = "db",
             namespace = "namespace",
             "SELECT name FROM people WHERE surname = pippo group by interval 30s order by name desc since 6h limit 5")
         ) {
@@ -243,7 +245,6 @@ class GracePeriodStatementSpec extends WordSpec with Matchers {
       }
 
     }
-
 
   }
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/GracePeriodStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/GracePeriodStatementSpec.scala
@@ -25,11 +25,6 @@ class GracePeriodStatementSpec extends WordSpec with Matchers {
 
   private val parser = new SQLStatementParser
 
-  private val seconds = 1000L
-  private val minutes = 60 * seconds
-  private val hours   = 60 * minutes
-  private val days    = 24 * hours
-
   "A SQL parser instance" when {
 
     "receive a select with a grace period" should {
@@ -48,7 +43,7 @@ class GracePeriodStatementSpec extends WordSpec with Matchers {
                     metric = "people",
                     distinct = false,
                     fields = AllFields(),
-                    gracePeriod = Some(GracePeriod(6 * hours, "h", 6))
+                    gracePeriod = Some(GracePeriod("H", 6))
                   )
             }
         }
@@ -68,7 +63,7 @@ class GracePeriodStatementSpec extends WordSpec with Matchers {
                     metric = "people",
                     distinct = false,
                     fields = AllFields(),
-                    gracePeriod = Some(GracePeriod(6 * seconds, "s", 6))
+                    gracePeriod = Some(GracePeriod("S", 6))
                   )
             }
         }
@@ -76,7 +71,7 @@ class GracePeriodStatementSpec extends WordSpec with Matchers {
 
       "parse it successfully for a minutes size period" in {
         inside(
-          parser.parse(db = "db", namespace = "namespace", input = "SELECT * FROM people since 6m")
+          parser.parse(db = "db", namespace = "namespace", input = "SELECT * FROM people since 6min")
         ) {
           case success: SqlStatementParserSuccess =>
             inside(success.statement) {
@@ -88,7 +83,7 @@ class GracePeriodStatementSpec extends WordSpec with Matchers {
                     metric = "people",
                     distinct = false,
                     fields = AllFields(),
-                    gracePeriod = Some(GracePeriod(6 * minutes, "m", 6))
+                    gracePeriod = Some(GracePeriod("MIN", 6))
                   )
             }
         }
@@ -108,7 +103,7 @@ class GracePeriodStatementSpec extends WordSpec with Matchers {
                     metric = "people",
                     distinct = false,
                     fields = AllFields(),
-                    gracePeriod = Some(GracePeriod(6 * days, "d", 6))
+                    gracePeriod = Some(GracePeriod("D", 6))
                   )
             }
         }
@@ -150,7 +145,7 @@ class GracePeriodStatementSpec extends WordSpec with Matchers {
                                                     value1 = AbsoluteComparisonValue(2L),
                                                     value2 = AbsoluteComparisonValue(4L))
                     ))),
-                    gracePeriod = Some(GracePeriod(6 * hours, "h", 6))
+                    gracePeriod = Some(GracePeriod("H", 6))
                   )
             }
         }
@@ -178,7 +173,7 @@ class GracePeriodStatementSpec extends WordSpec with Matchers {
                       Condition(EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("pippo")))),
                     order = Some(DescOrderOperator(dimension = "name")),
                     limit = Some(LimitOperator(5)),
-                    gracePeriod = Some(GracePeriod(6 * hours, "h", 6))
+                    gracePeriod = Some(GracePeriod("H", 6))
                   )
             }
         }

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
@@ -47,12 +47,12 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         inside(
           parser.parse(db = "db",
                        namespace = "registry",
-                       input = "SELECT name FROM people WHERE timestamp >= now - 10s")
+                       input = "SELECT name FROM people WHERE timestamp >= now - 10 sec")
         ) {
           case SqlStatementParserSuccess(_, selectSQLStatement: SelectSQLStatement) =>
             inside(selectSQLStatement.condition.value.expression) {
               case ComparisonExpression(_, _, comparisonValue) =>
-                comparisonValue shouldBe RelativeComparisonValue(minus, 10, "S")
+                comparisonValue shouldBe RelativeComparisonValue(minus, 10, "SEC")
             }
         }
       }
@@ -91,7 +91,8 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
           parser.parse(
             db = "db",
             namespace = "registry",
-            input = "SELECT name FROM people WHERE timestamp < now and timestamp > now - 2h OR timestamp = now + 4min")
+            input =
+              "SELECT name FROM people WHERE timestamp < now and timestamp > now - 2 hour OR timestamp = now + 4min")
         ) {
           case SqlStatementParserSuccess(_, selectSQLStatement: SelectSQLStatement) =>
             inside(selectSQLStatement.condition.value.expression) {
@@ -103,7 +104,7 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
                                                                    OrOperator,
                                                                    EqualityExpression(_, thirdTimestampComparison))) =>
                 firstTimestampComparison shouldBe RelativeComparisonValue(plus, 0L, "S")
-                secondTimestampComparison shouldBe RelativeComparisonValue(minus, 2L, "H")
+                secondTimestampComparison shouldBe RelativeComparisonValue(minus, 2L, "HOUR")
                 thirdTimestampComparison shouldBe RelativeComparisonValue(plus, 4L, "MIN")
             }
         }
@@ -115,7 +116,7 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
             db = "db",
             namespace = "registry",
             input =
-              "SELECT name FROM people WHERE (timestamp < now + 30d and timestamp > now - 2h) or timestamp = now + 4d")
+              "SELECT name FROM people WHERE (timestamp < now + 30 day and timestamp > now - 2h) or timestamp = now + 4d")
         ) {
           case SqlStatementParserSuccess(_, selectSQLStatement: SelectSQLStatement) =>
             inside(selectSQLStatement.condition.value.expression) {
@@ -126,7 +127,7 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
                                                                                         secondTimestampComparison)),
                                            OrOperator,
                                            EqualityExpression(_, thirdTimestampComparison)) =>
-                firstTimestampComparison shouldBe RelativeComparisonValue(plus, 30L, "D")
+                firstTimestampComparison shouldBe RelativeComparisonValue(plus, 30L, "DAY")
                 secondTimestampComparison shouldBe RelativeComparisonValue(minus, 2L, "H")
                 thirdTimestampComparison shouldBe RelativeComparisonValue(plus, 4L, "D")
             }
@@ -137,7 +138,7 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
         inside(
           parser.parse(db = "db",
                        namespace = "registry",
-                       input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, now + 4 s)")
+                       input = "SELECT name FROM people WHERE timestamp IN (now - 2 s, now + 4 second)")
         ) {
           case SqlStatementParserSuccess(_, selectSQLStatement: SelectSQLStatement) =>
             inside(selectSQLStatement.condition.value.expression) {
@@ -145,7 +146,7 @@ class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
                                    firstAggregation: RelativeComparisonValue,
                                    secondAggregation: RelativeComparisonValue) =>
                 firstAggregation shouldBe RelativeComparisonValue(minus, 2L, "S")
-                secondAggregation shouldBe RelativeComparisonValue(plus, 4L, "S")
+                secondAggregation shouldBe RelativeComparisonValue(plus, 4L, "SECOND")
             }
         }
       }


### PR DESCRIPTION
This PR introduces the concept of grace period:

In the SQL parser the `since` clause has been enabled. It will be possible to specify it at the end of a SQL query in order to set the amount of time backwards that must consider.

e.g. `select count(*) from metric group by  interval 10s since 6h` will return all the time buckets from 6h ago  

The `since` clause is allowed only on temporal group by queries. It will be rejected otherwise