### PR TITLE
In Memory Management for Temporal Queries Streaming

### DIFF
--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
@@ -214,6 +214,7 @@ class PublisherActor(readCoordinator: ActorRef) extends ActorPathLogging {
                 subscribedActorsByQueryId
                   .get(quid)
                   .foreach(e => e.foreach(_ ! RecordsPublished(quid, schema.metric, Seq(record))))
+                temporalBuckets -= quid
               case None => //do nothing
             }
           case _ =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
@@ -267,6 +267,7 @@ class PublisherActor(readCoordinator: ActorRef) extends ActorPathLogging {
 
   override def postStop(): Unit = {
     Option(aggregatedPushTask).foreach(_.cancel())
+    temporalAggregatedTasks.foreach { case (_, task) => task.cancel() }
   }
 
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -38,6 +38,11 @@ package object post_proc {
   final val `count(*)` = "count(*)"
   final val `sum(*)`   = "sum(*)"
   final val `avg(*)`   = "avg(*)"
+  final val `min(*)`   = "min(*)"
+  final val `max(*)`   = "max(*)"
+
+  final val lowerBoundField = "lowerBound"
+  final val upperBoundField = "upperBound"
 
   /**
     * Applies, if needed, ordering and limiting to a sequence of chained partial results.
@@ -189,6 +194,65 @@ package object post_proc {
     if (finalStep)
       applyOrderingWithLimit(chainedResult, statement, schema, Some(temporalAggregation))
     else chainedResult
+  }
+
+  /**
+    *
+    * @param schema
+    * @param statement
+    * @param temporalAggregation
+    * @param mathContext
+    * @return
+    */
+  def reduceSingleTemporalBucket(
+      schema: Schema,
+      statement: SelectSQLStatement,
+      temporalAggregation: InternalTemporalAggregation)(implicit mathContext: MathContext): Seq[Bit] => Option[Bit] = {
+    res =>
+      val v                              = schema.value.indexType.asInstanceOf[NumericType[_]]
+      implicit val numeric: Numeric[Any] = v.numeric
+
+      res.sortBy(_.timestamp) match {
+        case Nil => None
+        case head :: Nil =>
+          Some(
+            Bit(head.timestamp,
+                head.value,
+                Map(upperBoundField -> head.timestamp, lowerBoundField -> head.timestamp),
+                Map.empty)
+          )
+        case bits =>
+          val head = bits.head
+          val last = bits.last
+          val dimensions =
+            Map(upperBoundField -> NSDbNumericType(last.timestamp), lowerBoundField -> NSDbNumericType(head.timestamp))
+          Some(
+            temporalAggregation.aggregation match {
+              case CountAggregation =>
+                val count = NSDbNumericType(bits.size)
+                Bit(last.timestamp, NSDbNumericType(count), dimensions, Map(`count(*)` -> count))
+              case SumAggregation =>
+                val sum = NSDbNumericType(bits.map(_.value.rawValue).sum)
+                Bit(last.timestamp, sum, dimensions, Map(`sum(*)` -> sum))
+              case MaxAggregation =>
+                val max = NSDbNumericType(bits.map(_.value.rawValue).max)
+                Bit(head.timestamp, max, dimensions, Map(`max(*)` -> max))
+              case MinAggregation =>
+                val min = NSDbNumericType(bits.map(_.value.rawValue).min)
+                Bit(last.timestamp, min, dimensions, Map(`min(*)` -> min))
+              case AvgAggregation =>
+                val sum   = NSDbNumericType(bits.map(_.value.rawValue).sum)
+                val count = NSDbNumericType(bits.size)
+                val avg   = if (count.rawValue == 0) NSDbNumericType(0.0) else NSDbNumericType(sum / count)
+                Bit(
+                  last.timestamp,
+                  avg,
+                  dimensions,
+                  Map(`avg(*)` -> avg)
+                )
+            }
+          )
+      }
   }
 
   /**

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -17,7 +17,7 @@
 package io.radicalbit.nsdb
 import java.math.MathContext
 
-import io.radicalbit.nsdb.common.{NSDbNumericType, NSDbType}
+import io.radicalbit.nsdb.common.{NSDbLongType, NSDbNumericType, NSDbType}
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.index.{BIGINT, NumericType}
@@ -229,14 +229,14 @@ package object post_proc {
           Some(
             temporalAggregation.aggregation match {
               case CountAggregation =>
-                val count = NSDbNumericType(bits.size)
-                Bit(last.timestamp, NSDbNumericType(count), dimensions, Map(`count(*)` -> count))
+                val count = NSDbLongType(bits.size)
+                Bit(last.timestamp, count, dimensions, Map(`count(*)` -> count))
               case SumAggregation =>
                 val sum = NSDbNumericType(bits.map(_.value.rawValue).sum)
                 Bit(last.timestamp, sum, dimensions, Map(`sum(*)` -> sum))
               case MaxAggregation =>
                 val max = NSDbNumericType(bits.map(_.value.rawValue).max)
-                Bit(head.timestamp, max, dimensions, Map(`max(*)` -> max))
+                Bit(last.timestamp, max, dimensions, Map(`max(*)` -> max))
               case MinAggregation =>
                 val min = NSDbNumericType(bits.map(_.value.rawValue).min)
                 Bit(last.timestamp, min, dimensions, Map(`min(*)` -> min))

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
@@ -217,7 +217,7 @@ object StatementParser {
   case class ParsedTemporalAggregatedQuery(namespace: String,
                                            metric: String,
                                            q: Query,
-                                           rangeLength: Long,
+                                           interval: Long,
                                            aggregation: InternalTemporalAggregation,
                                            condition: Option[Condition],
                                            sort: Option[Sort] = None,

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/EmptyReadCoordinator.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/EmptyReadCoordinator.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.actors
+
+import akka.actor.{Actor, Props}
+import io.radicalbit.nsdb.model.Schema
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.ExecuteStatement
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.SelectStatementExecuted
+
+class EmptyReadCoordinator(schema: Schema) extends Actor {
+  def receive: Receive = {
+    case ExecuteStatement(statement, _) =>
+      sender() ! SelectStatementExecuted(statement, values = Seq.empty, schema)
+  }
+}
+
+object EmptyReadCoordinator {
+  def props(schema: Schema) = Props(new EmptyReadCoordinator(schema))
+}


### PR DESCRIPTION
This PR has the purpose to introduce the in-memory management for temporal query streaming.

When a subscriber provides a temporal query, all the records the comes are stored into in-memory buckets.
Also. a scheduler is created with the interval specified by the query itself, e.g. a `group by interval 30s`  query generate a scheduler of 30s.
Aim of these schedulers is to trigger the operation of bucket aggregation and publish.

In this PR, the grace period is not taken into consideration. 
Managing it is the scope of a future PR.