### PR TITLE
Manage late events in temporal query streaming

### DIFF
--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -22,8 +22,7 @@ import akka.actor.{Actor, Props}
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import io.radicalbit.nsdb.actors.PublisherActor
 import io.radicalbit.nsdb.actors.PublisherActor.Commands.SubscribeBySqlStatement
-import io.radicalbit.nsdb.actors.PublisherActor.Events.SubscribedByQueryStringInternal
-import io.radicalbit.nsdb.actors.RealTimeProtocol.Events.RecordsPublished
+import io.radicalbit.nsdb.actors.RealTimeProtocol.Events.{RecordsPublished, SubscribedByQueryString}
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.GetLocations
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.LocationsGot
@@ -139,7 +138,7 @@ trait WriteCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers 
 
       probe.send(publisherActor,
                  SubscribeBySqlStatement(subscriber, db, namespace, "testMetric", "testQueryString", testSqlStatement))
-      probe.expectMsgType[SubscribedByQueryStringInternal]
+      probe.expectMsgType[SubscribedByQueryString]
       publisherActor.underlyingActor.subscribedActorsByQueryId.keys.size shouldBe 1
       publisherActor.underlyingActor.plainQueries.keys.size shouldBe 1
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -305,13 +305,16 @@ class PublisherActorSpec
       )
       probe.expectMsgType[SubscribedByQueryString]
 
-      secondProbe.send(publisherActor,
-                       SubscribeBySqlStatement(secondProbe.ref,
-                                               "db",
-                                               "namespace",
-                                               "metric",
-                                               "queryString",
-                                               testTemporalAggregatedSqlStatement(CountAggregation), Some(testTimeContext)))
+      secondProbe.send(
+        publisherActor,
+        SubscribeBySqlStatement(secondProbe.ref,
+                                "db",
+                                "namespace",
+                                "metric",
+                                "queryString",
+                                testTemporalAggregatedSqlStatement(CountAggregation),
+                                Some(testTimeContext))
+      )
       secondProbe.expectMsgType[SubscribedByQueryString]
 
       (1 to 10).foreach { i =>
@@ -334,45 +337,60 @@ class PublisherActorSpec
 
     "send a message to all its subscribers when multiple matching event comes for a multiple count query with different aggregations" in {
 
-      probe.send(publisherActor,
-                 SubscribeBySqlStatement(probeActor,
-                                         "db",
-                                         "namespace",
-                                         "metric",
-                                         "queryString",
-                                         testTemporalAggregatedSqlStatement(CountAggregation),Some(testTimeContext)))
+      probe.send(
+        publisherActor,
+        SubscribeBySqlStatement(probeActor,
+                                "db",
+                                "namespace",
+                                "metric",
+                                "queryString",
+                                testTemporalAggregatedSqlStatement(CountAggregation),
+                                Some(testTimeContext))
+      )
       probe.expectMsgType[SubscribedByQueryString]
-      probe.send(publisherActor,
-                 SubscribeBySqlStatement(probeActor,
-                                         "db",
-                                         "namespace",
-                                         "metric",
-                                         "queryString",
-                                         testTemporalAggregatedSqlStatement(SumAggregation),Some(testTimeContext)))
+      probe.send(
+        publisherActor,
+        SubscribeBySqlStatement(probeActor,
+                                "db",
+                                "namespace",
+                                "metric",
+                                "queryString",
+                                testTemporalAggregatedSqlStatement(SumAggregation),
+                                Some(testTimeContext))
+      )
       probe.expectMsgType[SubscribedByQueryString]
-      probe.send(publisherActor,
-                 SubscribeBySqlStatement(probeActor,
-                                         "db",
-                                         "namespace",
-                                         "metric",
-                                         "queryString",
-                                         testTemporalAggregatedSqlStatement(AvgAggregation),Some(testTimeContext)))
+      probe.send(
+        publisherActor,
+        SubscribeBySqlStatement(probeActor,
+                                "db",
+                                "namespace",
+                                "metric",
+                                "queryString",
+                                testTemporalAggregatedSqlStatement(AvgAggregation),
+                                Some(testTimeContext))
+      )
       probe.expectMsgType[SubscribedByQueryString]
-      probe.send(publisherActor,
-                 SubscribeBySqlStatement(probeActor,
-                                         "db",
-                                         "namespace",
-                                         "metric",
-                                         "queryString",
-                                         testTemporalAggregatedSqlStatement(MinAggregation),Some(testTimeContext)))
+      probe.send(
+        publisherActor,
+        SubscribeBySqlStatement(probeActor,
+                                "db",
+                                "namespace",
+                                "metric",
+                                "queryString",
+                                testTemporalAggregatedSqlStatement(MinAggregation),
+                                Some(testTimeContext))
+      )
       probe.expectMsgType[SubscribedByQueryString]
-      probe.send(publisherActor,
-                 SubscribeBySqlStatement(probeActor,
-                                         "db",
-                                         "namespace",
-                                         "metric",
-                                         "queryString",
-                                         testTemporalAggregatedSqlStatement(MaxAggregation),Some(testTimeContext)))
+      probe.send(
+        publisherActor,
+        SubscribeBySqlStatement(probeActor,
+                                "db",
+                                "namespace",
+                                "metric",
+                                "queryString",
+                                testTemporalAggregatedSqlStatement(MaxAggregation),
+                                Some(testTimeContext))
+      )
       probe.expectMsgType[SubscribedByQueryString]
 
       (1 to 10).foreach { i =>

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/actor/StreamActor.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/actor/StreamActor.scala
@@ -22,7 +22,6 @@ import akka.actor.{ActorRef, PoisonPill, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 import io.radicalbit.nsdb.actors.PublisherActor.Commands._
-import io.radicalbit.nsdb.actors.PublisherActor.Events.SubscribedByQueryStringInternal
 import io.radicalbit.nsdb.actors.RealTimeProtocol.Events._
 import io.radicalbit.nsdb.actors.RealTimeProtocol.RealTimeOutGoingMessage
 import io.radicalbit.nsdb.common.NSDbLongType
@@ -105,8 +104,8 @@ class StreamActor(clientAddress: String,
                                           metric,
                                           inputQueryString,
                                           s"unauthorized ${checkAuthorization.failReason}"))
-    case SubscribedByQueryStringInternal(db, namespace, metric, queryString, quid, records) =>
-      wsActor ! OutgoingMessage(SubscribedByQueryString(db, namespace, metric, queryString, quid, records))
+    case msg: SubscribedByQueryString =>
+      wsActor ! OutgoingMessage(msg)
     case msg: SubscriptionByQueryStringFailed => wsActor ! OutgoingMessage(msg)
     case msg @ RecordsPublished(_, _, _) =>
       buffer += msg


### PR DESCRIPTION
This PR adds the management of late events in real-time streaming.

The `since` clause in temporal queries is used to determine a grace period for pushing records that come in the past (late events). 
Every pushed time bucket will be store for the grace period and whenever a late event comes, it will be aggregated  with the related bucket ad pushed again.
