### PR TITLE
Introduce Outdated locations

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
@@ -186,30 +186,6 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
         }
       } yield (children, addLocationsResult))
         .onComplete {
-//          case NodeChildActorsGot(metadataCoordinator, writeCoordinator, readCoordinator, publisherActor) =>
-//            val locationsToAdd: Seq[LocationWithCoordinates] = retrieveLocationsToAdd
-//
-//            val locationsGroupedBy: Map[(String, String), Seq[LocationWithCoordinates]] = locationsToAdd.groupBy {
-//              case LocationWithCoordinates(database, namespace, _) => (database, namespace)
-//            }
-//
-//            implicit val scheduler: Scheduler = context.system.scheduler
-//            implicit val _log: LoggingAdapter = log
-//
-//            Future
-//              .sequence {
-//                locationsGroupedBy.map {
-//                  case ((db, namespace), locations) =>
-//                    metadataCoordinator ? AddLocations(db, namespace, locations.map {
-//                      case LocationWithCoordinates(_, _, location) => location
-//                    })
-//                }
-//              }
-//              .map(ErrorManagementUtils.partitionResponses[LocationsAdded, AddLocationsFailed])
-//              .retry(delay, retries) {
-//                case (_, addLocationsFailedList) => addLocationsFailedList.isEmpty
-//              }
-//              .onComplete {
           case Success(
               (NodeChildActorsGot(metadataCoordinator, writeCoordinator, readCoordinator, publisherActor),
                (_, failures))) if failures.isEmpty =>
@@ -221,10 +197,6 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
           case e =>
             onFailureBehaviour(member, e)
         }
-//          case unknownResponse =>
-//            log.error(s"unknown response from nodeActorsGuardian ? GetNodeChildActors $unknownResponse")
-//            context.system.terminate()
-//        }
     case NodeAlive(nodeId, address) =>
       NSDbClusterSnapshot(context.system).addNode(nodeId, address)
     case UnreachableMember(member) =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
@@ -45,7 +45,7 @@ class NodeActorsGuardian(clusterListener: ActorRef, nodeId: String) extends Acto
       log.error(e, "Got the following TimeoutException, resuming the processing")
       Resume
     case e: InvalidLocationsInNode =>
-      log.error(e, "Too many retries on the node")
+      log.error(e, s"Invalid locations ${e.locations} found")
       context.system.terminate()
       Stop
     case t =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
@@ -30,7 +30,7 @@ import io.radicalbit.nsdb.cluster.coordinator._
 import io.radicalbit.nsdb.cluster.createNodeName
 import io.radicalbit.nsdb.cluster.logic.{CapacityWriteNodesSelectionLogic, LocalityReadNodesSelection}
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel._
-import io.radicalbit.nsdb.common.exception.TooManyRetriesException
+import io.radicalbit.nsdb.exception.InvalidLocationsInNode
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 
 import scala.concurrent.duration.FiniteDuration
@@ -44,7 +44,7 @@ class NodeActorsGuardian(clusterListener: ActorRef, nodeId: String) extends Acto
     case e: TimeoutException =>
       log.error(e, "Got the following TimeoutException, resuming the processing")
       Resume
-    case e: TooManyRetriesException =>
+    case e: InvalidLocationsInNode =>
       log.error(e, "Too many retries on the node")
       context.system.terminate()
       Stop

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
@@ -311,6 +311,7 @@ class ReplicatedMetadataCache extends Actor with ActorLogging with WriteConfig {
             log.error(s"error in put location in cache $e")
             AddOutdatedLocationFailed(db, namespace, location)
         }
+        .pipeTo(sender)
     case GetLocationsFromCache(db, namespace, metric) =>
       val key = MetricLocationsCacheKey(db, namespace, metric)
       log.debug("searching for key {} in cache", key)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -551,7 +551,7 @@ class MetadataCoordinator(clusterListener: ActorRef,
             data.foreach {
               case ("coordinates-cache", envelope: DurableStore.DurableDataEnvelope) =>
                 envelope.data.asInstanceOf[ORSet[Coordinates]].elements.foreach {
-                  case c @ Coordinates(db, namespace, metric) =>
+                  case Coordinates(db, namespace, metric) =>
                     metadataCache ! PutCoordinateInCache(db, namespace, metric)
                 }
               case ("all-metric-info-cache", envelope: DurableStore.DurableDataEnvelope) =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -37,14 +37,14 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.deleteStatemen
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.createNodeName
 import io.radicalbit.nsdb.cluster.logic.WriteNodesSelectionLogic
-import io.radicalbit.nsdb.util.ErrorManagementUtils._
+import io.radicalbit.nsdb.util.ErrorManagementUtils.{partitionResponses, _}
 import io.radicalbit.nsdb.commit_log.CommitLogWriterActor._
 import io.radicalbit.nsdb.common.configuration.NSDbConfig
 import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.{Coordinates, NSDbSerializable}
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.index.{DirectorySupport, StorageStrategy}
-import io.radicalbit.nsdb.model.{Location, Schema, TimeContext}
+import io.radicalbit.nsdb.model.{Location, LocationWithCoordinates, Schema, TimeContext}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.statement.TimeRangeManager
@@ -115,6 +115,27 @@ class MetadataCoordinator(clusterListener: ActorRef,
             .flatMap { _ =>
               Future(AddLocationsFailed(db, namespace, errorResponses.map(_.location)))
             }
+        }
+      }
+
+  private def performAddOutdatedLocationIntoCache(
+      locations: Seq[LocationWithCoordinates]): Future[AddOutdatedLocationsResponse] =
+    Future
+      .sequence(locations.map {
+        case LocationWithCoordinates(db, namespace, location) =>
+          (metadataCache ? AddOutdatedLocationInCache(db, namespace, location))
+            .mapTo[AddLocationInCacheResponse]
+      })
+      .flatMap { responses =>
+        val (successResponses: List[OutdatedLocationInCacheAdded], errorResponses: List[AddOutdatedLocationFailed]) =
+          partitionResponses[OutdatedLocationInCacheAdded, AddOutdatedLocationFailed](responses)
+
+        if (successResponses.size == responses.size) {
+          Future(OutdatedLocationsAdded(successResponses.map(res =>
+            LocationWithCoordinates(res.db, res.namespace, res.location))))
+        } else {
+          log.error(s"errors in adding outdated locations in cache $errorResponses")
+          Future(AddOutdatedLocationsFailed(locations))
         }
       }
 
@@ -475,6 +496,16 @@ class MetadataCoordinator(clusterListener: ActorRef,
       }
     case AddLocations(db, namespace, locations) =>
       performAddLocationIntoCache(db, namespace, locations).pipeTo(sender)
+    case AddOutdatedLocations(locations) =>
+      performAddOutdatedLocationIntoCache(locations).pipeTo(sender)
+    case GetOutdatedLocations =>
+      (metadataCache ? GetOutdatedLocationsFromCache)
+        .mapTo[GetOutdatedLocationsFromCache]
+        .map {
+          case OutdatedLocationsFromCacheGot(locations)    => OutdatedLocationsGot(locations.toSeq)
+          case GetOutdatedLocationsFromCacheFailed(reason) => GetOutdatedLocationsFailed(reason)
+        }
+        .pipeTo(sender)
     case GetMetricInfo(db, namespace, metric) =>
       (metadataCache ? GetMetricInfoFromCache(db, namespace, metric))
         .map {
@@ -514,13 +545,13 @@ class MetadataCoordinator(clusterListener: ActorRef,
       (temporaryDurableStoreActor ? LoadAll)
         .map {
           case LoadData(data) =>
-            log.debug(s"restoring $data")
+            log.error(s"restoring $data")
             log.info(s"restoring ${data.size} metadata entries")
 
             data.foreach {
               case ("coordinates-cache", envelope: DurableStore.DurableDataEnvelope) =>
                 envelope.data.asInstanceOf[ORSet[Coordinates]].elements.foreach {
-                  case Coordinates(db, namespace, metric) =>
+                  case c @ Coordinates(db, namespace, metric) =>
                     metadataCache ! PutCoordinateInCache(db, namespace, metric)
                 }
               case ("all-metric-info-cache", envelope: DurableStore.DurableDataEnvelope) =>
@@ -578,6 +609,9 @@ object MetadataCoordinator {
     case class GetWriteLocations(db: String, namespace: String, metric: String, timestamp: Long)
         extends NSDbSerializable
     case class AddLocations(db: String, namespace: String, locations: Seq[Location]) extends NSDbSerializable
+    case class AddOutdatedLocations(locations: Seq[LocationWithCoordinates])         extends NSDbSerializable
+    case object GetOutdatedLocations                                                 extends NSDbSerializable
+
     case class DeleteMetricMetadata(db: String,
                                     namespace: String,
                                     metric: String,
@@ -613,11 +647,6 @@ object MetadataCoordinator {
                                                 retention: Long)
         extends GetWriteLocationsResponse
 
-    case class UpdateLocationFailed(db: String, namespace: String, oldLocation: Location, newOccupation: Long)
-        extends NSDbSerializable
-    case class LocationAdded(db: String, namespace: String, location: Location)     extends NSDbSerializable
-    case class AddLocationFailed(db: String, namespace: String, location: Location) extends NSDbSerializable
-
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
     @JsonSubTypes(
       Array(
@@ -627,6 +656,26 @@ object MetadataCoordinator {
     sealed trait AddLocationsResponse                                                      extends NSDbSerializable
     case class LocationsAdded(db: String, namespace: String, locations: Seq[Location])     extends AddLocationsResponse
     case class AddLocationsFailed(db: String, namespace: String, locations: Seq[Location]) extends AddLocationsResponse
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes(
+      Array(
+        new JsonSubTypes.Type(value = classOf[OutdatedLocationsAdded], name = "OutdatedLocationsAdded"),
+        new JsonSubTypes.Type(value = classOf[AddOutdatedLocationsFailed], name = "AddOutdatedLocationsFailed")
+      ))
+    sealed trait AddOutdatedLocationsResponse                                      extends NSDbSerializable
+    case class OutdatedLocationsAdded(locations: Seq[LocationWithCoordinates])     extends AddOutdatedLocationsResponse
+    case class AddOutdatedLocationsFailed(locations: Seq[LocationWithCoordinates]) extends AddOutdatedLocationsResponse
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes(
+      Array(
+        new JsonSubTypes.Type(value = classOf[OutdatedLocationsAdded], name = "OutdatedLocationsGot"),
+        new JsonSubTypes.Type(value = classOf[AddOutdatedLocationsFailed], name = "GetOutdatedLocationsFailed")
+      ))
+    sealed trait GetOutdatedLocationsResponse                                extends NSDbSerializable
+    case class OutdatedLocationsGot(locations: Seq[LocationWithCoordinates]) extends GetOutdatedLocationsResponse
+    case class GetOutdatedLocationsFailed(reason: String)                    extends GetOutdatedLocationsResponse
 
     case class MetricMetadataDeleted(db: String, namespace: String, metric: String, occurredOn: Long)
         extends NSDbSerializable

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
@@ -24,10 +24,7 @@ import akka.cluster.pubsub.DistributedPubSubMediator.{Publish, Subscribe}
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.NsdbPerfLogger
 import io.radicalbit.nsdb.cluster.PubSubTopics.{COORDINATORS_TOPIC, NODE_GUARDIANS_TOPIC}
-import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.{
-  AddRecordToLocation,
-  ExecuteDeleteStatementInternalInLocations
-}
+import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.{AddRecordToLocation, ExecuteDeleteStatementInternalInLocations}
 import io.radicalbit.nsdb.cluster.actor.SequentialFutureProcessing
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{GetLocations, GetWriteLocations}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
@@ -38,7 +35,7 @@ import io.radicalbit.nsdb.common.configuration.NSDbConfig
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement.DeleteSQLStatement
 import io.radicalbit.nsdb.index.{DirectorySupport, StorageStrategy}
-import io.radicalbit.nsdb.model.{Location, Schema}
+import io.radicalbit.nsdb.model.{Location, Schema, TimeContext}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.util.ActorPathLogging
@@ -132,7 +129,8 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
     * @param bit the bit containing the new schema.
     * @param op code executed in case of success.
     */
-  def updateSchema(db: String, namespace: String, metric: String, bit: Bit)(op: Schema => Future[Any]): Future[Any] =
+  def updateSchema(db: String, namespace: String, metric: String, bit: Bit)(
+      op: Schema => Future[WriteCoordinatorResponse]): Future[WriteCoordinatorResponse] =
     (schemaCoordinator ? UpdateSchemaFromRecord(db, namespace, metric, bit))
       .flatMap {
         case SchemaUpdated(_, _, _, schema) =>
@@ -154,7 +152,7 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
     * @return [[LocationsGot]] if communication with metadata coordinator succeeds, RecordRejected otherwise
     */
   def getWriteLocations(db: String, namespace: String, metric: String, bit: Bit, ts: Long)(
-      op: Seq[Location] => Future[Any]): Future[Any] =
+      op: Seq[Location] => Future[WriteCoordinatorResponse]): Future[WriteCoordinatorResponse] =
     (metadataCoordinator ? GetWriteLocations(db, namespace, metric, ts)).mapTo[GetWriteLocationsResponse].flatMap {
       case WriteLocationsGot(_, _, _, locations) =>
         log.debug(s"received locations for metric $metric, $locations")
@@ -185,8 +183,8 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
     metricsDataActors.get(location.node) match {
       case Some(actor) =>
         (actor ? AddRecordToLocation(db, namespace, bit, location)).map {
-          case msg: RecordAdded    => msg
-          case msg: RecordRejected => msg
+          case msg: RecordAccumulated => msg
+          case msg: RecordRejected    => msg
           case _ =>
             RecordRejected(db,
                            namespace,
@@ -268,8 +266,8 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
                                  bit: Bit,
                                  schema: Schema,
                                  publish: Boolean): Future[WriteCoordinatorResponse] = {
-    val (succeedResponses: List[RecordAdded], _: List[RecordRejected]) =
-      partitionResponses[RecordAdded, RecordRejected](responses)
+    val (succeedResponses: List[RecordAccumulated], _: List[RecordRejected]) =
+      partitionResponses[RecordAccumulated, RecordRejected](responses)
 
     if (succeedResponses.size == responses.size) {
       if (publish)
@@ -412,18 +410,18 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
       log.info(s"unsubscribed publisher actor for node $nodeName")
       sender() ! PublisherUnSubscribed(nodeName)
     case MapInput(ts, db, namespace, metric, bit) =>
-      val startTime = System.currentTimeMillis()
+      val timeContext = TimeContext()
       log.debug("Received a write request for (ts: {}, metric: {}, bit : {})", ts, metric, bit)
 
       val writeOperation = getWriteLocations(db, namespace, metric, bit, bit.timestamp) { locations =>
         updateSchema(db, namespace, metric, bit) { schema =>
-          accumulateOperation(locations, db, namespace, metric, startTime, bit, schema)
+          accumulateOperation(locations, db, namespace, metric, timeContext.currentTime, bit, schema)
         }
       }
 
       val writeOperationEffect: Any => Unit = { _ =>
         if (perfLogger.isDebugEnabled)
-          perfLogger.debug("End write request in {} millis", System.currentTimeMillis() - startTime)
+          perfLogger.debug("End write request in {} millis", System.currentTimeMillis() - timeContext.currentTime)
       }
 
       writeProcessing match {
@@ -446,7 +444,7 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
         commitLogResponses <- Future.sequence {
           locations
             .collect {
-              case location if commitLogCoordinators.get(location.node).isDefined =>
+              case location if commitLogCoordinators.contains(location.node) =>
                 (location, commitLogCoordinators(location.node))
             }
             .map {
@@ -521,7 +519,7 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
         commitLogResponses <- Future.sequence {
           locations
             .collect {
-              case location if commitLogCoordinators.get(location.node).isDefined =>
+              case location if commitLogCoordinators.contains(location.node) =>
                 (location, commitLogCoordinators(location.node))
             }
             .map {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
@@ -24,7 +24,10 @@ import akka.cluster.pubsub.DistributedPubSubMediator.{Publish, Subscribe}
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.NsdbPerfLogger
 import io.radicalbit.nsdb.cluster.PubSubTopics.{COORDINATORS_TOPIC, NODE_GUARDIANS_TOPIC}
-import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.{AddRecordToLocation, ExecuteDeleteStatementInternalInLocations}
+import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.{
+  AddRecordToLocation,
+  ExecuteDeleteStatementInternalInLocations
+}
 import io.radicalbit.nsdb.cluster.actor.SequentialFutureProcessing
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{GetLocations, GetWriteLocations}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._

--- a/nsdb-cluster/src/multi-jvm/resources/application.conf
+++ b/nsdb-cluster/src/multi-jvm/resources/application.conf
@@ -1,0 +1,86 @@
+
+akka.loglevel = ERROR
+akka.actor {
+  provider = "cluster"
+
+  serialization-bindings {
+    "io.radicalbit.nsdb.common.protocol.NSDbSerializable" = jackson-json
+  }
+
+  control-aware-dispatcher {
+    mailbox-type = "akka.dispatch.UnboundedControlAwareMailbox"
+  }
+}
+akka.log-dead-letters-during-shutdown = off
+nsdb {
+
+  retry-policy {
+    delay = 1 second
+    n-retries = 2
+  }
+
+  grpc {
+    interface = "0.0.0.0"
+    port = 7817
+  }
+
+  global.timeout = 30 seconds
+  read-coordinator.timeout = 10 seconds
+  namespace-schema.timeout = 10 seconds
+  namespace-data.timeout = 10 seconds
+  rpc-endpoint.timeout = 30 seconds
+  publisher.timeout = 10 seconds
+  publisher.scheduler.interval = 5 seconds
+  write.scheduler.interval = 15 seconds
+  retention.check.interval = 1 seconds
+
+  cluster {
+    metrics-selector = disk
+    metadata-write-consistency = "all"
+    replication-factor = 2
+  }
+
+  sharding {
+    interval = 1d
+    passivate-after = 1h
+  }
+
+  read {
+    parallelism {
+      initial-size = 1
+      lower-bound= 1
+      upper-bound = 1
+    }
+  }
+
+  write {
+    retry-attempts = 10
+  }
+
+  storage {
+    base-path  = "target/test_index/MetadataTest"
+    index-path = ${nsdb.storage.base-path}"/index"
+    commit-log-path = ${nsdb.storage.base-path}"/commit_log"
+    metadata-path = ${nsdb.storage.base-path}"/metadata"
+  }
+
+  write-coordinator.timeout = 5 seconds
+  metadata-coordinator.timeout = 5 seconds
+  commit-log {
+    serializer = "io.radicalbit.nsdb.commit_log.StandardCommitLogSerializer"
+    writer = "io.radicalbit.nsdb.commit_log.RollingCommitLogFileWriter"
+    directory = "target/commitLog"
+    max-size = 50000
+    passivate-after = 5s
+  }
+
+  heartbeat.interval = 1 second
+
+  websocket {
+    refresh-period = 100
+    retention-size = 10
+  }
+  math {
+    precision = 10
+  }
+}

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/STMultiNodeSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/STMultiNodeSpec.scala
@@ -1,4 +1,4 @@
-package io.radicalbit.rtsae
+package io.radicalbit.nsdb
 
 import akka.cluster.Cluster
 import akka.remote.testconductor.RoleName

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/MetadataRestoreSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/MetadataRestoreSpec.scala
@@ -1,0 +1,205 @@
+package io.radicalbit.nsdb.cluster
+
+import akka.actor.{ActorSelection, Props}
+import akka.cluster.MemberStatus
+import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec}
+import akka.testkit.ImplicitSender
+import com.typesafe.config.ConfigFactory
+import io.radicalbit.nsdb.STMultiNodeSpec
+import io.radicalbit.nsdb.cluster.actor.MetadataSpec.{node1, node2}
+import io.radicalbit.nsdb.cluster.actor.{ClusterListenerTestActor, DatabaseActorsGuardian}
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.ExecuteRestoreMetadata
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.MetadataRestored
+import io.radicalbit.nsdb.common.model.MetricInfo
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.index.{BIGINT, DECIMAL, NumericType}
+import io.radicalbit.nsdb.model.Schema
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
+
+object MetadataRestoreSpec extends MultiNodeConfig {
+  val node1 = role("node-1")
+  val node2 = role("node-2")
+
+  commonConfig(ConfigFactory.parseResources("application.conf"))
+
+  nodeConfig(node1)(ConfigFactory.parseString("akka.remote.artery.canonical.port = 25520"))
+
+  nodeConfig(node2)(ConfigFactory.parseString("akka.remote.artery.canonical.port = 25530"))
+}
+
+
+class MetadataRestoreSpecMultiJvmNode1 extends MetadataRestoreSpec {}
+
+class MetadataRestoreSpecMultiJvmNode2 extends MetadataRestoreSpec {}
+
+class MetadataRestoreSpec extends MultiNodeSpec(MetadataRestoreSpec) with STMultiNodeSpec with ImplicitSender {
+  override def initialParticipants: Int = roles.size
+
+  private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}/metadata-coordinator_${nodeName}_$nodeName"
+  private def schemaCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}/schema-coordinator_${nodeName}_$nodeName"
+
+ system.actorOf(Props[DatabaseActorsGuardian], "guardian")
+
+  system.actorOf(ClusterListenerTestActor.props(), name = "clusterListener")
+
+  "Metadata system" must {
+
+    "join cluster" in {
+      join(node1, node1)
+      join(node2, node1)
+
+      awaitAssert {
+        cluster.state.members.count(_.status == MemberStatus.Up) shouldBe roles.size
+      }
+
+      enterBarrier("joined")
+    }
+
+    "restore values from a metadata dump" in {
+
+      runOn(node1) {
+        val selfMember = cluster.selfMember
+        val nodeName   = s"${selfMember.address.host.getOrElse("noHost")}_${selfMember.address.port.getOrElse(2552)}"
+
+        val metadataCoordinator = system.actorSelection(metadataCoordinatorPath(nodeName))
+
+        val path = getClass.getResource("/dump").getPath
+
+        metadataCoordinator ! ExecuteRestoreMetadata(path)
+
+        awaitAssert {
+          expectMsg(MetadataRestored(path))
+        }
+      }
+
+      enterBarrier("metadata-restored")
+
+      def checkCoordinates(metadataCoordinator: ActorSelection) = {
+        awaitAssert {
+          metadataCoordinator ! GetDbs
+          expectMsg(DbsGot(Set("testDb", "testDbWithInfo")))
+        }
+
+        awaitAssert {
+          metadataCoordinator ! GetNamespaces("testDb")
+          expectMsg(NamespacesGot("testDb", Set("testNamespace", "testNamespace2")))
+        }
+
+        awaitAssert {
+          metadataCoordinator ! GetNamespaces("testDbWithInfo")
+          expectMsg(NamespacesGot("testDbWithInfo", Set("testNamespaceWithInfo")))
+        }
+
+        awaitAssert {
+          metadataCoordinator ! GetMetrics("testDb", "testNamespace")
+          expectMsg(MetricsGot("testDb", "testNamespace", Set("people", "animals")))
+        }
+
+        awaitAssert {
+          metadataCoordinator ! GetMetrics("testDb", "testNamespace2")
+          expectMsg(MetricsGot("testDb", "testNamespace2", Set("animals")))
+        }
+
+        awaitAssert {
+          metadataCoordinator ! GetMetrics("testDbWithInfo", "testNamespaceWithInfo")
+          expectMsg(MetricsGot("testDbWithInfo", "testNamespaceWithInfo", Set("people")))
+        }
+      }
+
+      def checkMetricInfoes(metadataCoordinator: ActorSelection) = {
+        awaitAssert {
+          metadataCoordinator ! GetMetricInfo("testDb", "testNamespace", "people")
+          expectMsg(MetricInfoGot("testDb", "testNamespace", "people", None))
+
+          metadataCoordinator ! GetMetricInfo("testDb", "testNamespace", "animals")
+          expectMsg(MetricInfoGot("testDb", "testNamespace", "animals", None))
+        }
+
+        awaitAssert {
+          metadataCoordinator ! GetMetricInfo("testDb", "testNamespace2", "animals")
+          expectMsg(MetricInfoGot("testDb", "testNamespace2", "animals", None))
+        }
+
+        awaitAssert {
+          metadataCoordinator ! GetMetricInfo("testDbWithInfo", "testNamespaceWithInfo", "people")
+          expectMsg(
+            MetricInfoGot("testDbWithInfo", "testNamespaceWithInfo", "people",
+              Some(MetricInfo("testDbWithInfo", "testNamespaceWithInfo", "people", 172800000, 86400000))))
+        }
+      }
+
+      def checkSchemas(schemaCoordinator: ActorSelection) = {
+
+        def dummyBit(valueType: NumericType[_]): Bit =
+          Bit(0, valueType.zero, Map(
+            "city"             -> "city",
+            "bigDecimalLong"   -> 0L,
+            "bigDecimalDouble" -> 1.1)
+            , Map("gender"           -> "gender"))
+
+        awaitAssert {
+          schemaCoordinator ! GetSchema("testDb", "testNamespace", "people")
+          expectMsg(
+            SchemaGot(
+              "testDb", "testNamespace", "people",
+              Some(Schema("people", dummyBit(DECIMAL())))
+            ))
+
+          schemaCoordinator ! GetSchema("testDb", "testNamespace", "animals")
+          expectMsg(
+            SchemaGot(
+              "testDb", "testNamespace", "animals",
+              Some(Schema("animals", dummyBit(BIGINT())))
+            ))
+        }
+
+        awaitAssert {
+          schemaCoordinator ! GetSchema("testDb", "testNamespace2", "animals")
+          expectMsg(
+            SchemaGot(
+              "testDb", "testNamespace2", "animals",
+              Some(Schema("animals", dummyBit(BIGINT())))
+            ))
+        }
+
+        awaitAssert {
+          schemaCoordinator ! GetSchema("testDbWithInfo", "testNamespaceWithInfo", "people")
+          expectMsg(
+            SchemaGot(
+              "testDbWithInfo", "testNamespaceWithInfo", "people",
+              Some(Schema("people", dummyBit(BIGINT())))
+            ))
+        }
+      }
+
+      runOn(node1) {
+        val selfMember = cluster.selfMember
+        val nodeName   = s"${selfMember.address.host.getOrElse("noHost")}_${selfMember.address.port.getOrElse(2552)}"
+
+        val metadataCoordinator = system.actorSelection(metadataCoordinatorPath(nodeName))
+        val schemaCoordinator   = system.actorSelection(schemaCoordinatorPath(nodeName))
+
+        checkCoordinates(metadataCoordinator)
+        checkMetricInfoes(metadataCoordinator)
+        checkSchemas(schemaCoordinator)
+
+      }
+
+      runOn(node2) {
+        val selfMember = cluster.selfMember
+        val nodeName   = s"${selfMember.address.host.getOrElse("noHost")}_${selfMember.address.port.getOrElse(2552)}"
+
+        val metadataCoordinator = system.actorSelection(metadataCoordinatorPath(nodeName))
+        val schemaCoordinator   = system.actorSelection(schemaCoordinatorPath(nodeName))
+
+        checkCoordinates(metadataCoordinator)
+        checkMetricInfoes(metadataCoordinator)
+        checkSchemas(schemaCoordinator)
+
+      }
+
+    }
+
+  }
+}

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
@@ -10,7 +10,7 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{AddL
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{AddLocationsFailed, LocationsAdded, RemoveNodeMetadataFailed}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{CommitLogCoordinatorUnSubscribed, MetricsDataActorUnSubscribed, PublisherUnSubscribed}
-import io.radicalbit.rtsae.STMultiNodeSpec
+import io.radicalbit.nsdb.STMultiNodeSpec
 
 import scala.concurrent.duration._
 

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
@@ -6,8 +6,8 @@ import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec}
 import akka.testkit.{ImplicitSender, TestProbe}
 import com.typesafe.config.ConfigFactory
 import io.radicalbit.nsdb.cluster.actor.ClusterListenerTestActor.{FailureTest, SuccessTest, TestType}
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{AddLocations, RemoveNodeMetadata}
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{AddLocationsFailed, LocationsAdded, RemoveNodeMetadataFailed}
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{AddLocations, GetOutdatedLocations, RemoveNodeMetadata}
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{AddLocationsFailed, LocationsAdded, OutdatedLocationsGot, RemoveNodeMetadataFailed}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{CommitLogCoordinatorUnSubscribed, MetricsDataActorUnSubscribed, PublisherUnSubscribed}
 import io.radicalbit.nsdb.STMultiNodeSpec
@@ -26,6 +26,7 @@ class MetaDataCoordinatorForTest extends Actor with ActorLogging {
     case UnsubscribeMetricsDataActor(nodeName)     => sender() ! MetricsDataActorUnSubscribed(nodeName)
     case UnSubscribeCommitLogCoordinator(nodeName) => sender() ! CommitLogCoordinatorUnSubscribed(nodeName)
     case RemoveNodeMetadata(nodeName)              => sender() ! RemoveNodeMetadataFailed(nodeName)
+    case GetOutdatedLocations => sender() ! OutdatedLocationsGot(Seq.empty)
     case _ =>
       log.warning("Unhandled message on purpose")
   }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
@@ -26,7 +26,7 @@ class MetaDataCoordinatorForTest extends Actor with ActorLogging {
     case UnsubscribeMetricsDataActor(nodeName)     => sender() ! MetricsDataActorUnSubscribed(nodeName)
     case UnSubscribeCommitLogCoordinator(nodeName) => sender() ! CommitLogCoordinatorUnSubscribed(nodeName)
     case RemoveNodeMetadata(nodeName)              => sender() ! RemoveNodeMetadataFailed(nodeName)
-    case GetOutdatedLocations => sender() ! OutdatedLocationsGot(Seq.empty)
+    case GetOutdatedLocations                      => sender() ! OutdatedLocationsGot(Seq.empty)
     case _ =>
       log.warning("Unhandled message on purpose")
   }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
@@ -29,7 +29,7 @@ abstract class ClusterListenerTestActor
 
   override def retrieveLocationsToAdd(): List[LocationWithCoordinates] = testType match {
     case SuccessTest =>
-      List(LocationWithCoordinates("success", "namespace", Location("metric", "node", 0L, 1L)))
+      List()
     case FailureTest =>
       List(LocationWithCoordinates("failure", "namespace", Location("metric", "node", 0L, 1L)))
   }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
@@ -29,7 +29,7 @@ abstract class ClusterListenerTestActor
 
   override def retrieveLocationsToAdd(): List[LocationWithCoordinates] = testType match {
     case SuccessTest =>
-      List()
+      List.empty
     case FailureTest =>
       List(LocationWithCoordinates("failure", "namespace", Location("metric", "node", 0L, 1L)))
   }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -15,7 +15,7 @@ import io.radicalbit.nsdb.index.{BIGINT, DECIMAL, NumericType}
 import io.radicalbit.nsdb.model.{Location, Schema}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
-import io.radicalbit.rtsae.STMultiNodeSpec
+import io.radicalbit.nsdb.STMultiNodeSpec
 
 import scala.concurrent.Await
 import scala.concurrent.duration._

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -8,8 +8,8 @@ import akka.testkit.ImplicitSender
 import com.typesafe.config.ConfigFactory
 import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache._
 import io.radicalbit.nsdb.common.model.MetricInfo
-import io.radicalbit.nsdb.model.Location
-import io.radicalbit.rtsae.STMultiNodeSpec
+import io.radicalbit.nsdb.model.{Location, LocationWithCoordinates}
+import io.radicalbit.nsdb.STMultiNodeSpec
 
 import scala.concurrent.duration._
 
@@ -496,6 +496,47 @@ class ReplicatedMetadataCacheSpec
       }
 
       enterBarrier("after-node-evict")
+    }
+
+    "manage outdated locations" in {
+
+      replicatedCache ! GetOutdatedLocationsFromCache
+
+      awaitAssert {
+        expectMsgType[OutdatedLocationsFromCacheGot].locations.size shouldBe 0
+      }
+
+      enterBarrier("no-outdated-locations")
+
+      val location = Location("metric", "node1",0,1)
+
+      awaitAssert {
+        replicatedCache ! AddOutdatedLocation("db", "namespace", location)
+        val outdatedLocationAdded = expectMsgType[OutdatedLocationAdded]
+        outdatedLocationAdded.db shouldBe "db"
+        outdatedLocationAdded.namespace shouldBe "namespace"
+        outdatedLocationAdded.location shouldBe location
+      }
+
+      awaitAssert {
+        replicatedCache ! AddOutdatedLocation("db1", "namespace1", location)
+        val outdatedLocationAdded = expectMsgType[OutdatedLocationAdded]
+        outdatedLocationAdded.db shouldBe "db1"
+        outdatedLocationAdded.namespace shouldBe "namespace1"
+        outdatedLocationAdded.location shouldBe location
+      }
+
+      enterBarrier("after-add-outdated-locations")
+
+      awaitAssert {
+        replicatedCache ! GetOutdatedLocationsFromCache
+        val outdatedLocationsFromCacheGot = expectMsgType[OutdatedLocationsFromCacheGot]
+        outdatedLocationsFromCacheGot.locations shouldBe
+          Set(
+            LocationWithCoordinates("db", "namespace", location),
+            LocationWithCoordinates("db1", "namespace1", location),
+          )
+      }
     }
 
   }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -511,16 +511,16 @@ class ReplicatedMetadataCacheSpec
       val location = Location("metric", "node1",0,1)
 
       awaitAssert {
-        replicatedCache ! AddOutdatedLocation("db", "namespace", location)
-        val outdatedLocationAdded = expectMsgType[OutdatedLocationAdded]
+        replicatedCache ! AddOutdatedLocationInCache("db", "namespace", location)
+        val outdatedLocationAdded = expectMsgType[OutdatedLocationInCacheAdded]
         outdatedLocationAdded.db shouldBe "db"
         outdatedLocationAdded.namespace shouldBe "namespace"
         outdatedLocationAdded.location shouldBe location
       }
 
       awaitAssert {
-        replicatedCache ! AddOutdatedLocation("db1", "namespace1", location)
-        val outdatedLocationAdded = expectMsgType[OutdatedLocationAdded]
+        replicatedCache ! AddOutdatedLocationInCache("db1", "namespace1", location)
+        val outdatedLocationAdded = expectMsgType[OutdatedLocationInCacheAdded]
         outdatedLocationAdded.db shouldBe "db1"
         outdatedLocationAdded.namespace shouldBe "namespace1"
         outdatedLocationAdded.location shouldBe location
@@ -533,8 +533,8 @@ class ReplicatedMetadataCacheSpec
         val outdatedLocationsFromCacheGot = expectMsgType[OutdatedLocationsFromCacheGot]
         outdatedLocationsFromCacheGot.locations shouldBe
           Set(
-            LocationWithCoordinates("db", "namespace", location),
             LocationWithCoordinates("db1", "namespace1", location),
+            LocationWithCoordinates("db", "namespace", location)
           )
       }
     }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCacheSpec.scala
@@ -13,7 +13,7 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.{EvictSchema, GetSchemaFromCache, PutSchemaInCache}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.SchemaCached
-import io.radicalbit.rtsae.STMultiNodeSpec
+import io.radicalbit.nsdb.STMultiNodeSpec
 import org.json4s.DefaultFormats
 
 import scala.concurrent.duration._

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedSchemaCacheSpec.scala
@@ -14,6 +14,7 @@ import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.{EvictSchema, GetSchemaFromCache, PutSchemaInCache}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.SchemaCached
 import io.radicalbit.nsdb.STMultiNodeSpec
+import io.radicalbit.nsdb.cluster.actor.MetadataSpec.commonConfig
 import org.json4s.DefaultFormats
 
 import scala.concurrent.duration._
@@ -22,43 +23,8 @@ object ReplicatedSchemaCacheSpec extends MultiNodeConfig {
   val node1 = role("node-1")
   val node2 = role("node-2")
 
-  commonConfig(ConfigFactory.parseString("""
-    |akka.loglevel = INFO
-    |akka.actor {
-    |
-    | serialization-bindings {
-    |   "io.radicalbit.nsdb.common.protocol.NSDbSerializable" = jackson-json
-    | }
-    |
-    | provider = "cluster"
-    | control-aware-dispatcher {
-    |     mailbox-type = "akka.dispatch.UnboundedControlAwareMailbox"
-    |   }
-    |}
-    |akka.log-dead-letters-during-shutdown = off
-    |nsdb {
-    |
-    |  global.timeout = 30 seconds
-    |  read-coordinator.timeout = 10 seconds
-    |  namespace-schema.timeout = 10 seconds
-    |  namespace-data.timeout = 10 seconds
-    |  publisher.timeout = 10 seconds
-    |  publisher.scheduler.interval = 5 seconds
-    |  write.scheduler.interval = 15 seconds
-    |
-    |  cluster.metadata-write-consistency = "all"
-    |
-    |  write-coordinator.timeout = 5 seconds
-    |  metadata-coordinator.timeout = 5 seconds
-    |  commit-log {
-    |   serializer = "io.radicalbit.nsdb.commit_log.StandardCommitLogSerializer"
-    |    writer = "io.radicalbit.nsdb.commit_log.RollingCommitLogFileWriter"
-    |    directory = "target/commitLog"
-    |    max-size = 50000
-    |    passivate-after = 5s
-    |  }
-    |}
-    """.stripMargin))
+  commonConfig(ConfigFactory.parseResources("application.conf"))
+
 }
 
 class ReplicatedSchemaCacheSpecMultiJvmNode1 extends ReplicatedSchemaCacheSpec

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/split_brain/MultiNodeBaseSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/split_brain/MultiNodeBaseSpec.scala
@@ -6,7 +6,7 @@ import akka.remote.testconductor.RoleName
 import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec}
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.testkit.ImplicitSender
-import io.radicalbit.rtsae.STMultiNodeSpec
+import io.radicalbit.nsdb.STMultiNodeSpec
 
 import scala.concurrent.duration.Duration
 

--- a/nsdb-cluster/src/test/resources/application.conf
+++ b/nsdb-cluster/src/test/resources/application.conf
@@ -32,8 +32,6 @@ nsdb {
 
   global.timeout = 30 seconds
 
-  metadata-coordinator.timeout = 10s
-
   write.scheduler.interval = 5 seconds
 
   storage {
@@ -51,7 +49,7 @@ nsdb {
     passivate-after = 5s
   }
 
-  cluster{
+  cluster {
     replication-factor = 1
     metrics-selector = disk
     write-processing = parallel

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
@@ -75,7 +75,7 @@ class MetricsDataActorSpec()
     probe.send(metricsDataActor, AddRecordToLocation(db, namespace, record, location(metric)))
 
     val expectedAdd = awaitAssert {
-      probe.expectMsgType[RecordAdded]
+      probe.expectMsgType[RecordAccumulated]
     }
     expectedAdd.metric shouldBe metric
     expectedAdd.record shouldBe record
@@ -112,7 +112,7 @@ class MetricsDataActorSpec()
     probe.send(metricsDataActor, AddRecordToLocation(db, namespace1, record, location(metric + "2")))
 
     awaitAssert {
-      probe.expectMsgType[RecordAdded]
+      probe.expectMsgType[RecordAccumulated]
     }
 
     expectNoMessage(interval)
@@ -142,7 +142,7 @@ class MetricsDataActorSpec()
     probe.send(metricsDataActor, AddRecordToLocation(db, namespace1, record, location(metric + "2")))
 
     awaitAssert {
-      probe.expectMsgType[RecordAdded]
+      probe.expectMsgType[RecordAccumulated]
     }
 
     expectNoMessage(interval)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/MockedCommitLogCoordinator.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/MockedCommitLogCoordinator.scala
@@ -24,7 +24,7 @@ import io.radicalbit.nsdb.commit_log.CommitLogWriterActor.{
   WriteToCommitLogSucceeded
 }
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.DeleteRecordFromShard
-import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{RecordAdded, RecordRejected}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{RecordAccumulated, RecordRejected}
 
 class MockedCommitLogCoordinator(probe: ActorRef) extends Actor with ActorLogging {
   override def receive: Receive = {
@@ -54,7 +54,7 @@ class MockedMetricsDataActor(probe: ActorRef) extends Actor with ActorLogging {
   override def receive: Receive = {
     case msg @ AddRecordToLocation(db, namespace, bit, location) if location.node == "node1" =>
       probe ! msg
-      sender() ! RecordAdded(db, namespace, location.metric, bit, location, System.currentTimeMillis())
+      sender() ! RecordAccumulated(db, namespace, location.metric, bit, location, System.currentTimeMillis())
     case msg @ AddRecordToLocation(db, namespace, bit, location) if location.node == "node2" =>
       probe ! msg
       sender() ! RecordRejected(db,

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
@@ -198,7 +198,7 @@ class MetricAccumulatorActor(val basePath: String,
       log.debug("received message {}", msg)
       opBufferMap += (UUID.randomUUID().toString -> WriteShardOperation(ns, location, bit))
       val ts = System.currentTimeMillis()
-      sender ! RecordAdded(db, ns, location.metric, bit, location, ts)
+      sender ! RecordAccumulated(db, ns, location.metric, bit, location, ts)
     case DeleteRecordFromShard(_, ns, key, bit) =>
       opBufferMap += (UUID.randomUUID().toString -> DeleteShardRecordOperation(ns, key, bit))
       sender ! RecordDeleted(db, ns, key.metric, bit)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
@@ -24,8 +24,8 @@ import akka.util.Timeout
 import io.radicalbit.nsdb.actors.MetricAccumulatorActor.Refresh
 import io.radicalbit.nsdb.actors.MetricPerformerActor.{PerformRetry, PerformShardWrites, PersistedBit, PersistedBits}
 import io.radicalbit.nsdb.common.configuration.NSDbConfig
-import io.radicalbit.nsdb.common.exception.TooManyRetriesException
 import io.radicalbit.nsdb.common.protocol.{Bit, NSDbSerializable}
+import io.radicalbit.nsdb.exception.InvalidLocationsInNode
 import io.radicalbit.nsdb.index.{AllFacetIndexes, StorageStrategy}
 import io.radicalbit.nsdb.model.{Location, TimeContext}
 import io.radicalbit.nsdb.statement.StatementParser
@@ -151,7 +151,7 @@ class MetricPerformerActor(val basePath: String,
             * the operation has been retried too many times. It's time to mark the node as unavailable
             */
           if (attempt >= maxAttempts) {
-            throw new TooManyRetriesException(op.toString)
+            throw new InvalidLocationsInNode(Seq(op.location))
           }
 
           log.error("retrying operation {} attempt {} ", op, attempt)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/exception/InvalidLocationsInNode.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/exception/InvalidLocationsInNode.scala
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-package io.radicalbit.nsdb.common.exception
+package io.radicalbit.nsdb.exception
 
-import scala.util.control.NoStackTrace
+import io.radicalbit.nsdb.common.exception.NSDbException
+import io.radicalbit.nsdb.model.Location
 
 /**
-  * Trait for NSDb Exceptions. It extends [[NoStackTrace]] for efficiency purpose.
+  * Exception raised in case of write failures.
+  * @param locations locations containing failures.
   */
-trait NSDbException extends RuntimeException with NoStackTrace
-
-class InvalidStatementException(val message: String) extends NSDbException
-class TypeNotSupportedException(val message: String) extends NSDbException
-class NsdbSecurityException(val message: String)     extends NSDbException
-class InvalidNodeIdException(address: String)        extends NSDbException
+class InvalidLocationsInNode(val locations: Seq[Location]) extends NSDbException

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -169,12 +169,12 @@ object MessageProtocol {
     case class InputMapped(db: String, namespace: String, metric: String, record: Bit)
         extends WriteCoordinatorResponse
         with NSDbSerializable
-    case class RecordAdded(db: String,
-                           namespace: String,
-                           metric: String,
-                           record: Bit,
-                           override val location: Location,
-                           override val timestamp: Long)
+    case class RecordAccumulated(db: String,
+                                 namespace: String,
+                                 metric: String,
+                                 record: Bit,
+                                 override val location: Location,
+                                 override val timestamp: Long)
         extends WriteCoordinatorResponse
         with NSDbSerializable
     case class RecordRejected(db: String,

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
@@ -81,7 +81,7 @@ class MetricAccumulatorActorSpec()
 
     probe.send(metricAccumulatorActor, AddRecordToShard(db, namespace, location, bit))
     awaitAssert {
-      val expectedAdd = probe.expectMsgType[RecordAdded]
+      val expectedAdd = probe.expectMsgType[RecordAccumulated]
       expectedAdd.metric shouldBe metric
       expectedAdd.record shouldBe bit
     }
@@ -127,11 +127,11 @@ class MetricAccumulatorActorSpec()
     probe.send(metricAccumulatorActor, AddRecordToShard(db, namespace, key2, bit21))
     probe.send(metricAccumulatorActor, AddRecordToShard(db, namespace, key2, bit22))
     awaitAssert {
-      probe.expectMsgType[RecordAdded]
-      probe.expectMsgType[RecordAdded]
-      probe.expectMsgType[RecordAdded]
-      probe.expectMsgType[RecordAdded]
-      probe.expectMsgType[RecordAdded]
+      probe.expectMsgType[RecordAccumulated]
+      probe.expectMsgType[RecordAccumulated]
+      probe.expectMsgType[RecordAccumulated]
+      probe.expectMsgType[RecordAccumulated]
+      probe.expectMsgType[RecordAccumulated]
     }
 
     expectNoMessage(indexingInterval)
@@ -170,8 +170,8 @@ class MetricAccumulatorActorSpec()
 
     probe.send(metricAccumulatorActor, AddRecordToShard(db, namespace, location, bit1))
     probe.send(metricAccumulatorActor, AddRecordToShard(db, namespace, location, bit2))
-    probe.expectMsgType[RecordAdded]
-    probe.expectMsgType[RecordAdded]
+    probe.expectMsgType[RecordAccumulated]
+    probe.expectMsgType[RecordAccumulated]
 
     expectNoMessage(indexingInterval)
 
@@ -206,8 +206,8 @@ class MetricAccumulatorActorSpec()
 
     probe.send(metricAccumulatorActor, AddRecordToShard(db, namespace, location1, bit1))
     probe.send(metricAccumulatorActor, AddRecordToShard(db, namespace, location2, bit2))
-    probe.expectMsgType[RecordAdded]
-    probe.expectMsgType[RecordAdded]
+    probe.expectMsgType[RecordAccumulated]
+    probe.expectMsgType[RecordAccumulated]
 
     expectNoMessage(indexingInterval)
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricPerformerActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricPerformerActorSpec.scala
@@ -24,8 +24,8 @@ import akka.actor._
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import io.radicalbit.nsdb.actors.MetricAccumulatorActor.Refresh
 import io.radicalbit.nsdb.actors.MetricPerformerActor.PerformShardWrites
-import io.radicalbit.nsdb.common.exception.TooManyRetriesException
 import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.exception.InvalidLocationsInNode
 import io.radicalbit.nsdb.index.BrokenTimeSeriesIndex
 import io.radicalbit.nsdb.model.Location
 import org.apache.lucene.store.MMapDirectory
@@ -36,10 +36,10 @@ import scala.concurrent.duration._
 
 class TestSupervisorActor(probe: ActorRef) extends Actor with ActorLogging {
 
-  val exceptionsCaught: ListBuffer[TooManyRetriesException] = ListBuffer.empty
+  val exceptionsCaught: ListBuffer[InvalidLocationsInNode] = ListBuffer.empty
 
   override val supervisorStrategy: SupervisorStrategy = OneForOneStrategy(maxNrOfRetries = 1) {
-    case e: TooManyRetriesException =>
+    case e: InvalidLocationsInNode =>
       log.error(e, "TooManyRetriesException {}", e.getMessage)
       exceptionsCaught += e
       Resume

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricPerformerActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricPerformerActorSpec.scala
@@ -40,7 +40,7 @@ class TestSupervisorActor(probe: ActorRef) extends Actor with ActorLogging {
 
   override val supervisorStrategy: SupervisorStrategy = OneForOneStrategy(maxNrOfRetries = 1) {
     case e: InvalidLocationsInNode =>
-      log.error(e, "TooManyRetriesException {}", e.getMessage)
+      log.error(e, s"Invalid locations ${e.locations} found")
       exceptionsCaught += e
       Resume
     case t =>


### PR DESCRIPTION
This PR introduces a new metadata entity that is the OutdatedLocations.

OutdatedLocations will be used to store all the locations in which unrecovered write errors occurred.
Having this metadata will be used to improve the shard pick up algorithms