### PR TITLE
Use Unique NodeId for Locations

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
@@ -27,7 +27,8 @@ import org.json4s.{DefaultFormats, Formats}
 /**
   * Class responsible to instantiate all the node endpoints (e.g. grpc, http and ws).
   */
-class NsdbNodeEndpoint(readCoordinator: ActorRef,
+class NsdbNodeEndpoint(nodeId: String,
+                       readCoordinator: ActorRef,
                        writeCoordinator: ActorRef,
                        metadataCoordinator: ActorRef,
                        publisher: ActorRef)(override implicit val system: ActorSystem)
@@ -38,12 +39,13 @@ class NsdbNodeEndpoint(readCoordinator: ActorRef,
 
   override implicit val logger: LoggingAdapter = Logging.getLogger(system, this)
 
-  new GrpcEndpoint(readCoordinator = readCoordinator,
+  new GrpcEndpoint(nodeId = nodeId,
+                   readCoordinator = readCoordinator,
                    writeCoordinator = writeCoordinator,
                    metadataCoordinator = metadataCoordinator)
 
   implicit val formats: Formats = DefaultFormats ++ CustomSerializers.customSerializers + BitSerializer
 
-  initWebEndpoint(writeCoordinator, readCoordinator, metadataCoordinator, publisher)
+  initWebEndpoint(nodeId, writeCoordinator, readCoordinator, metadataCoordinator, publisher)
 
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
@@ -27,7 +27,7 @@ final class ClusterListener extends AbstractClusterListener {
                                    writeCoordinator: ActorRef,
                                    metadataCoordinator: ActorRef,
                                    publisherActor: ActorRef): Unit =
-    new NsdbNodeEndpoint(readCoordinator, writeCoordinator, metadataCoordinator, publisherActor)(context.system)
+    new NsdbNodeEndpoint(nodeId, readCoordinator, writeCoordinator, metadataCoordinator, publisherActor)(context.system)
 
   protected def onFailureBehaviour(member: Member, error: Any): Unit = {
     log.error("received wrong response {}", error)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActor.scala
@@ -124,12 +124,8 @@ class MetricsDataActor(val basePath: String, val nodeName: String, commitLogCoor
     case msg @ ExecuteSelectStatement(statement, _, _, _, _, _) =>
       log.debug("executing statement in metric data actor {}", statement)
       getOrCreateReader(statement.db, statement.namespace) forward msg
-    case AddRecordToLocation(db, namespace, bit, location) =>
-      getOrCreateAccumulator(db, namespace) forward AddRecordToShard(
-        db,
-        namespace,
-        Location(location.metric, nodeName, location.from, location.to),
-        bit)
+    case msg @ AddRecordToShard(db, namespace, _, _) =>
+      getOrCreateAccumulator(db, namespace) forward msg
     case DeleteRecordFromLocation(db, namespace, bit, location) =>
       getOrCreateAccumulator(db, namespace) forward DeleteRecordFromShard(
         db,
@@ -171,7 +167,6 @@ object MetricsDataActor {
   def props(basePath: String, nodeName: String, commitLogCoordinator: ActorRef): Props =
     Props(new MetricsDataActor(basePath, nodeName, commitLogCoordinator))
 
-  case class AddRecordToLocation(db: String, namespace: String, bit: Bit, location: Location) extends NSDbSerializable
   case class DeleteRecordFromLocation(db: String, namespace: String, bit: Bit, location: Location)
       extends NSDbSerializable
   case class ExecuteDeleteStatementInternalInLocations(statement: DeleteSQLStatement,

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
@@ -135,11 +135,11 @@ object ReplicatedMetadataCache {
       extends AddLocationInCacheResponse
   final case class AddOutdatedLocationFailed(db: String, namespace: String, location: Location)
       extends AddLocationInCacheResponse
-  final case object GetOutdatedLocationsFromCache extends NSDbSerializable
-  sealed trait GetOutdatedLocationsFromCache      extends NSDbSerializable
+  final case object GetOutdatedLocationsFromCache    extends NSDbSerializable
+  sealed trait GetOutdatedLocationsFromCacheResponse extends NSDbSerializable
   final case class OutdatedLocationsFromCacheGot(locations: Set[LocationWithCoordinates])
-      extends GetOutdatedLocationsFromCache
-  final case class GetOutdatedLocationsFromCacheFailed(reason: String) extends GetOutdatedLocationsFromCache
+      extends GetOutdatedLocationsFromCacheResponse
+  final case class GetOutdatedLocationsFromCacheFailed(reason: String) extends GetOutdatedLocationsFromCacheResponse
 }
 
 /**

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -28,6 +28,7 @@ import akka.util.Timeout
 import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 import com.typesafe.config.ConfigFactory
 import io.radicalbit.nsdb.cluster.PubSubTopics.{COORDINATORS_TOPIC, NODE_GUARDIANS_TOPIC}
+import io.radicalbit.nsdb.cluster.`extension`.NSDbClusterSnapshot
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.ExecuteDeleteStatementInternalInLocations
 import io.radicalbit.nsdb.cluster.actor.NSDbMetricsEvents._
 import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache._
@@ -68,6 +69,8 @@ class MetadataCoordinator(clusterListener: ActorRef,
     extends ActorPathLogging
     with DirectorySupport {
   private val cluster = Cluster(context.system)
+
+  private val nsdbClusterSnapshot = NSDbClusterSnapshot(context.system)
 
   private val config = context.system.settings.config
 
@@ -385,27 +388,27 @@ class MetadataCoordinator(clusterListener: ActorRef,
                 }
             }
       }
-    case SubscribeMetricsDataActor(actor: ActorRef, nodeName) =>
-      if (!metricsDataActors.get(nodeName).contains(actor)) {
-        metricsDataActors += (nodeName -> actor)
-        log.info(s"subscribed data actor for node $nodeName")
+    case SubscribeMetricsDataActor(actor: ActorRef, nodeId) =>
+      if (!metricsDataActors.get(nodeId).contains(actor)) {
+        metricsDataActors += (nodeId -> actor)
+        log.info(s"subscribed data actor for node $nodeId")
       }
-      sender() ! MetricsDataActorSubscribed(actor, nodeName)
-    case SubscribeCommitLogCoordinator(actor: ActorRef, nodeName) =>
-      if (!commitLogCoordinators.get(nodeName).contains(actor)) {
-        commitLogCoordinators += (nodeName -> actor)
-        log.info(s"subscribed commit log actor for node $nodeName")
+      sender() ! MetricsDataActorSubscribed(actor, nodeId)
+    case SubscribeCommitLogCoordinator(actor: ActorRef, nodeId) =>
+      if (!commitLogCoordinators.get(nodeId).contains(actor)) {
+        commitLogCoordinators += (nodeId -> actor)
+        log.info(s"subscribed commit log actor for node $nodeId")
       }
-      sender() ! CommitLogCoordinatorSubscribed(actor, nodeName)
+      sender() ! CommitLogCoordinatorSubscribed(actor, nodeId)
 
-    case UnsubscribeMetricsDataActor(nodeName) =>
-      metricsDataActors -= nodeName
-      log.info(s"metric data actor removed for node $nodeName")
-      sender() ! MetricsDataActorUnSubscribed(nodeName)
-    case UnSubscribeCommitLogCoordinator(nodeName) =>
-      commitLogCoordinators -= nodeName
-      log.info(s"unsubscribed commit log actor for node $nodeName")
-      sender() ! CommitLogCoordinatorUnSubscribed(nodeName)
+    case UnsubscribeMetricsDataActor(nodeId) =>
+      metricsDataActors -= nodeId
+      log.info(s"metric data actor removed for node $nodeId")
+      sender() ! MetricsDataActorUnSubscribed(nodeId)
+    case UnSubscribeCommitLogCoordinator(nodeId) =>
+      commitLogCoordinators -= nodeId
+      log.info(s"unsubscribed commit log actor for node $nodeId")
+      sender() ! CommitLogCoordinatorUnSubscribed(nodeId)
     case GetDbs =>
       (metadataCache ? GetDbsFromCache)
         .mapTo[DbsFromCacheGot]
@@ -474,7 +477,9 @@ class MetadataCoordinator(clusterListener: ActorRef,
                               Random.shuffle(clusterAliveMembers.toSeq).take(replicationFactor).map(createNodeName)
                             }
 
-                          val locations = nodes.map(Location(metric, _, start, end))
+                          val nodesWithId = nodes.map(address => (nsdbClusterSnapshot.getId(address), address))
+
+                          val locations = nodesWithId.map { case (id, _) => Location(metric, id, start, end) }
                           performAddLocationIntoCache(db, namespace, locations)
                         }
                       } yield

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -505,7 +505,7 @@ class MetadataCoordinator(clusterListener: ActorRef,
       performAddOutdatedLocationIntoCache(locations).pipeTo(sender)
     case GetOutdatedLocations =>
       (metadataCache ? GetOutdatedLocationsFromCache)
-        .mapTo[GetOutdatedLocationsFromCache]
+        .mapTo[GetOutdatedLocationsFromCacheResponse]
         .map {
           case OutdatedLocationsFromCacheGot(locations)    => OutdatedLocationsGot(locations.toSeq)
           case GetOutdatedLocationsFromCacheFailed(reason) => GetOutdatedLocationsFailed(reason)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -103,10 +103,10 @@ class ReadCoordinator(metadataCoordinator: ActorRef,
 
     Future
       .sequence(metricsDataActors.collect {
-        case (nodeName, actor) if uniqueLocationsByNode.isDefinedAt(nodeName) =>
+        case (nodeId, actor) if uniqueLocationsByNode.isDefinedAt(nodeId) =>
           actor ? ExecuteSelectStatement(statement,
                                          schema,
-                                         uniqueLocationsByNode.getOrElse(nodeName, Seq.empty),
+                                         uniqueLocationsByNode.getOrElse(nodeId, Seq.empty),
                                          ranges,
                                          timeContext,
                                          isSingleNode)
@@ -155,16 +155,16 @@ class ReadCoordinator(metadataCoordinator: ActorRef,
     }
 
   override def receive: Receive = {
-    case SubscribeMetricsDataActor(actor: ActorRef, nodeName) =>
-      if (!metricsDataActors.get(nodeName).contains(actor)) {
-        metricsDataActors += (nodeName -> actor)
-        log.info(s"subscribed data actor for node $nodeName")
+    case SubscribeMetricsDataActor(actor, nodeId) =>
+      if (!metricsDataActors.get(nodeId).contains(actor)) {
+        metricsDataActors += (nodeId -> actor)
+        log.info(s"subscribed data actor for node $nodeId")
       }
-      sender ! MetricsDataActorSubscribed(actor, nodeName)
-    case UnsubscribeMetricsDataActor(nodeName) =>
-      metricsDataActors -= nodeName
-      log.info(s"metric data actor removed for node $nodeName")
-      sender ! MetricsDataActorUnSubscribed(nodeName)
+      sender ! MetricsDataActorSubscribed(actor, nodeId)
+    case UnsubscribeMetricsDataActor(nodeId) =>
+      metricsDataActors -= nodeId
+      log.info(s"metric data actor removed for node $nodeId")
+      sender ! MetricsDataActorUnSubscribed(nodeId)
     case GetDbs =>
       metadataCoordinator forward GetDbs
     case msg @ GetNamespaces(_) =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
@@ -74,7 +74,7 @@ import scala.util.{Failure, Success, Try}
   * @param writeCoordinator the write coordinator actor
   * @param system the global actor system
   */
-class GrpcEndpoint(readCoordinator: ActorRef, writeCoordinator: ActorRef, metadataCoordinator: ActorRef)(
+class GrpcEndpoint(nodeId: String, readCoordinator: ActorRef, writeCoordinator: ActorRef, metadataCoordinator: ActorRef)(
     implicit system: ActorSystem)
     extends GRPCServer {
 
@@ -104,16 +104,17 @@ class GrpcEndpoint(readCoordinator: ActorRef, writeCoordinator: ActorRef, metada
 
   start() match {
     case Success(_) =>
-      log.info("GrpcEndpoint started on interface {} on port {}", interface, port)
+      log.info(s"GrpcEndpoint started for node $nodeId on interface $interface on port $port")
       system.registerOnTermination {
-        log.error("Shutting down gRPC server at interface {} and port {} since Actor System is shutting down",
-                  interface,
-                  port)
+        log.error(
+          s"Shutting down gRPC server for node $nodeId on interface $interface on port $port since Actor System is shutting down",
+          interface,
+          port)
         stop()
-        log.error("Server at interface {} and port {} shut down", interface, port)
+        log.error(s"Server for node $nodeId on interface $interface on port $port shut down")
       }
     case Failure(ex) =>
-      log.error(s"error in starting Grpc endpoint on interface $interface and port $port", ex)
+      log.error(s"error in starting Grpc endpoint for node $nodeId on interface $interface on port $port", ex)
   }
 
   /**

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/extension/NSDbClusterSnapshot.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/extension/NSDbClusterSnapshot.scala
@@ -33,21 +33,23 @@ class NSDbClusterSnapshotExtension(system: ExtendedActorSystem) extends Extensio
 
   /**
     * Adds a node and associate it to the a unique identifier
-    * @param nodeId the node unique identifier.
     * @param address the actual address of the node.
+    * @param nodeId the node unique identifier.
     */
-  def addNode(nodeId: String, address: String): String = threadSafeMap.put(nodeId, address)
+  def addNode(address: String, nodeId: String): String = threadSafeMap.put(address, nodeId)
 
   /**
     * Removes a node.
     * @param address the actual node address.
     */
-  def removeNode(address: String) = threadSafeMap.values().removeIf(v => v == address)
+  def removeNode(address: String): String = threadSafeMap.remove(address)
 
   /**
     * Returns the current active nodes
     */
   def nodes: Set[(String, String)] = threadSafeMap.asScala.toSet
+
+  def getId(address: String): String = threadSafeMap.get(address)
 }
 
 object NSDbClusterSnapshot extends ExtensionId[NSDbClusterSnapshotExtension] with ExtensionIdProvider {

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/MetadataRestoreSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/MetadataRestoreSpec.scala
@@ -36,8 +36,8 @@ class MetadataRestoreSpecMultiJvmNode2 extends MetadataRestoreSpec {}
 class MetadataRestoreSpec extends MultiNodeSpec(MetadataRestoreSpec) with STMultiNodeSpec with ImplicitSender {
   override def initialParticipants: Int = roles.size
 
-  private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}/metadata-coordinator_${nodeName}_$nodeName"
-  private def schemaCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}/schema-coordinator_${nodeName}_$nodeName"
+  private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/metadata-coordinator_${nodeName}_$nodeName"
+  private def schemaCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/schema-coordinator_${nodeName}_$nodeName"
 
  system.actorOf(Props[DatabaseActorsGuardian], "guardian")
 

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -48,7 +48,7 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
 
   system.actorOf(ClusterListenerTestActor.props(), name = "clusterListener")
 
-  private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}/metadata-coordinator_${nodeName}_$nodeName"
+  private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/metadata-coordinator_${nodeName}_$nodeName"
 
   "Metadata system" must {
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
@@ -22,7 +22,7 @@ import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
-import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.{AddRecordToLocation, DeleteRecordFromLocation}
+import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.DeleteRecordFromLocation
 import io.radicalbit.nsdb.cluster.coordinator.mockedActors.{LocalMetadataCache, LocalMetadataCoordinator}
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Location
@@ -72,7 +72,7 @@ class MetricsDataActorSpec()
 
     val record = Bit(System.currentTimeMillis, 0.5, Map("dimension" -> s"dimension"), Map("tag" -> s"tag"))
 
-    probe.send(metricsDataActor, AddRecordToLocation(db, namespace, record, location(metric)))
+    probe.send(metricsDataActor, AddRecordToShard(db, namespace, location(metric), record))
 
     val expectedAdd = awaitAssert {
       probe.expectMsgType[RecordAccumulated]
@@ -109,7 +109,7 @@ class MetricsDataActorSpec()
 
     val record = Bit(System.currentTimeMillis, 24, Map("dimension" -> s"dimension"), Map("tag" -> s"tag"))
 
-    probe.send(metricsDataActor, AddRecordToLocation(db, namespace1, record, location(metric + "2")))
+    probe.send(metricsDataActor, AddRecordToShard(db, namespace1, location(metric + "2"), record))
 
     awaitAssert {
       probe.expectMsgType[RecordAccumulated]
@@ -139,7 +139,7 @@ class MetricsDataActorSpec()
 
     val record = Bit(System.currentTimeMillis, 23, Map("dimension" -> s"dimension"), Map("tag" -> s"tag"))
 
-    probe.send(metricsDataActor, AddRecordToLocation(db, namespace1, record, location(metric + "2")))
+    probe.send(metricsDataActor, AddRecordToShard(db, namespace1, location(metric + "2"), record))
 
     awaitAssert {
       probe.expectMsgType[RecordAccumulated]

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
@@ -22,7 +22,6 @@ import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor
-import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.AddRecordToLocation
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.AddLocations
 import io.radicalbit.nsdb.cluster.coordinator.mockedActors.{LocalMetadataCache, LocalMetadataCoordinator}
 import io.radicalbit.nsdb.cluster.coordinator.mockedData.MockedData._
@@ -89,11 +88,11 @@ abstract class AbstractReadCoordinatorSpec
 
     Await.result(metadataCoordinator ? AddLocations(db, namespace, Seq(location1(LongMetric.name))), 10 seconds)
     LongMetric.recordsShard1.foreach(r => {
-      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location1(LongMetric.name)), 10 seconds)
+      Await.result(metricsDataActor ? AddRecordToShard(db, namespace, location1(LongMetric.name), r), 10 seconds)
     })
     Await.result(metadataCoordinator ? AddLocations(db, namespace, Seq(location2(LongMetric.name))), 10 seconds)
     LongMetric.recordsShard2.foreach(r => {
-      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location2(LongMetric.name)), 10 seconds)
+      Await.result(metricsDataActor ? AddRecordToShard(db, namespace, location2(LongMetric.name), r), 10 seconds)
     })
 
     //double metric
@@ -110,11 +109,11 @@ abstract class AbstractReadCoordinatorSpec
 
     Await.result(metadataCoordinator ? AddLocations(db, namespace, Seq(location1(DoubleMetric.name))), 10 seconds)
     DoubleMetric.recordsShard1.foreach(r => {
-      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location1(DoubleMetric.name)), 10 seconds)
+      Await.result(metricsDataActor ? AddRecordToShard(db, namespace, location1(DoubleMetric.name), r), 10 seconds)
     })
     Await.result(metadataCoordinator ? AddLocations(db, namespace, Seq(location2(DoubleMetric.name))), 10 seconds)
     DoubleMetric.recordsShard2.foreach(r => {
-      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location2(DoubleMetric.name)), 10 seconds)
+      Await.result(metricsDataActor ? AddRecordToShard(db, namespace, location2(DoubleMetric.name), r), 10 seconds)
     })
 
     //aggregation long metric
@@ -136,13 +135,13 @@ abstract class AbstractReadCoordinatorSpec
     Await.result(metadataCoordinator ? AddLocations(db, namespace, Seq(location1(AggregationLongMetric.name))),
                  10 seconds)
     AggregationLongMetric.recordsShard1.foreach(r => {
-      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location1(AggregationLongMetric.name)),
+      Await.result(metricsDataActor ? AddRecordToShard(db, namespace, location1(AggregationLongMetric.name), r),
                    10 seconds)
     })
     Await.result(metadataCoordinator ? AddLocations(db, namespace, Seq(location2(AggregationLongMetric.name))),
                  10 seconds)
     AggregationLongMetric.recordsShard2.foreach(r => {
-      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location2(AggregationLongMetric.name)),
+      Await.result(metricsDataActor ? AddRecordToShard(db, namespace, location2(AggregationLongMetric.name), r),
                    10 seconds)
     })
 
@@ -165,13 +164,13 @@ abstract class AbstractReadCoordinatorSpec
     Await.result(metadataCoordinator ? AddLocations(db, namespace, Seq(location1(AggregationDoubleMetric.name))),
                  10 seconds)
     AggregationDoubleMetric.recordsShard1.foreach(r => {
-      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location1(AggregationDoubleMetric.name)),
+      Await.result(metricsDataActor ? AddRecordToShard(db, namespace, location1(AggregationDoubleMetric.name), r),
                    10 seconds)
     })
     Await.result(metadataCoordinator ? AddLocations(db, namespace, Seq(location2(AggregationDoubleMetric.name))),
                  10 seconds)
     AggregationDoubleMetric.recordsShard2.foreach(r => {
-      Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location2(AggregationDoubleMetric.name)),
+      Await.result(metricsDataActor ? AddRecordToShard(db, namespace, location2(AggregationDoubleMetric.name), r),
                    10 seconds)
     })
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractTemporalReadCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractTemporalReadCoordinatorSpec.scala
@@ -18,7 +18,6 @@ package io.radicalbit.nsdb.cluster.coordinator
 
 import akka.pattern.ask
 import akka.util.Timeout
-import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.AddRecordToLocation
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.AddLocations
 import io.radicalbit.nsdb.cluster.coordinator.mockedData.MockedData._
 import io.radicalbit.nsdb.model.Location
@@ -74,12 +73,12 @@ abstract class AbstractTemporalReadCoordinatorSpec extends AbstractReadCoordinat
 
     TemporalLongMetric.recordsShard1
       .foreach(r => {
-        Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location1(TemporalLongMetric.name)),
+        Await.result(metricsDataActor ? AddRecordToShard(db, namespace, location1(TemporalLongMetric.name), r),
                      10 seconds)
       })
     TemporalDoubleMetric.recordsShard1
       .foreach(r => {
-        Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location1(TemporalDoubleMetric.name)),
+        Await.result(metricsDataActor ? AddRecordToShard(db, namespace, location1(TemporalDoubleMetric.name), r),
                      10 seconds)
       })
 
@@ -91,12 +90,12 @@ abstract class AbstractTemporalReadCoordinatorSpec extends AbstractReadCoordinat
 
     TemporalLongMetric.recordsShard2
       .foreach(r => {
-        Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location2(TemporalLongMetric.name)),
+        Await.result(metricsDataActor ? AddRecordToShard(db, namespace, location2(TemporalLongMetric.name), r),
                      10 seconds)
       })
     TemporalDoubleMetric.recordsShard2
       .foreach(r => {
-        Await.result(metricsDataActor ? AddRecordToLocation(db, namespace, r, location2(TemporalDoubleMetric.name)),
+        Await.result(metricsDataActor ? AddRecordToShard(db, namespace, location2(TemporalDoubleMetric.name), r),
                      10 seconds)
       })
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
@@ -25,7 +25,6 @@ import akka.util.Timeout
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import io.radicalbit.nsdb.actors.PublisherActor
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor
-import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.AddRecordToLocation
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{GetLocations, GetWriteLocations}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{LocationsGot, WriteLocationsGot}
 import io.radicalbit.nsdb.cluster.coordinator.mockedActors._
@@ -166,11 +165,11 @@ class WriteCoordinatorErrorsSpec
       }
 
       awaitAssert {
-        successAccumulationProbe.expectMsgType[AddRecordToLocation]
+        successAccumulationProbe.expectMsgType[AddRecordToShard]
       }
 
       awaitAssert {
-        failureAccumulationProbe.expectMsgType[AddRecordToLocation]
+        failureAccumulationProbe.expectMsgType[AddRecordToShard]
       }
 
       awaitAssert {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/MockedCommitLogCoordinator.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/MockedCommitLogCoordinator.scala
@@ -17,13 +17,12 @@
 package io.radicalbit.nsdb.cluster.coordinator.mockedActors
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
-import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.AddRecordToLocation
 import io.radicalbit.nsdb.commit_log.CommitLogWriterActor.{
   WriteToCommitLog,
   WriteToCommitLogFailed,
   WriteToCommitLogSucceeded
 }
-import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.DeleteRecordFromShard
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.{AddRecordToShard, DeleteRecordFromShard}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{RecordAccumulated, RecordRejected}
 
 class MockedCommitLogCoordinator(probe: ActorRef) extends Actor with ActorLogging {
@@ -52,10 +51,10 @@ case object MockedCommitLogCoordinator {
 class MockedMetricsDataActor(probe: ActorRef) extends Actor with ActorLogging {
 
   override def receive: Receive = {
-    case msg @ AddRecordToLocation(db, namespace, bit, location) if location.node == "node1" =>
+    case msg @ AddRecordToShard(db, namespace, location, bit) if location.node == "node1" =>
       probe ! msg
       sender() ! RecordAccumulated(db, namespace, location.metric, bit, location, System.currentTimeMillis())
-    case msg @ AddRecordToLocation(db, namespace, bit, location) if location.node == "node2" =>
+    case msg @ AddRecordToShard(db, namespace, location, bit) if location.node == "node2" =>
       probe ! msg
       sender() ! RecordRejected(db,
                                 namespace,

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -94,12 +94,12 @@ object MessageProtocol {
                                   publisher: ActorRef)
         extends NSDbSerializable
 
-    case class SubscribeMetricsDataActor(actor: ActorRef, nodeName: String)     extends NSDbSerializable
-    case class UnsubscribeMetricsDataActor(nodeName: String)                    extends NSDbSerializable
-    case class SubscribeCommitLogCoordinator(actor: ActorRef, nodeName: String) extends NSDbSerializable
-    case class UnSubscribeCommitLogCoordinator(nodeName: String)                extends NSDbSerializable
-    case class SubscribePublisher(actor: ActorRef, nodeName: String)            extends NSDbSerializable
-    case class UnSubscribePublisher(nodeName: String)                           extends NSDbSerializable
+    case class SubscribeMetricsDataActor(actor: ActorRef, nodeId: String)     extends NSDbSerializable
+    case class UnsubscribeMetricsDataActor(nodeId: String)                    extends NSDbSerializable
+    case class SubscribeCommitLogCoordinator(actor: ActorRef, nodeId: String) extends NSDbSerializable
+    case class UnSubscribeCommitLogCoordinator(nodeId: String)                extends NSDbSerializable
+    case class SubscribePublisher(actor: ActorRef, nodeId: String)            extends NSDbSerializable
+    case class UnSubscribePublisher(nodeId: String)                           extends NSDbSerializable
 
     case object GetMetricsDataActors     extends NSDbSerializable
     case object GetCommitLogCoordinators extends NSDbSerializable

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
@@ -52,7 +52,8 @@ trait WebResources extends WsResources with SSLSupport { this: NsdbSecurity =>
   implicit lazy val httpTimeout: Timeout =
     Timeout(config.getDuration("nsdb.http-endpoint.timeout", TimeUnit.SECONDS), TimeUnit.SECONDS)
 
-  def initWebEndpoint(writeCoordinator: ActorRef,
+  def initWebEndpoint(nodeId: String,
+                      writeCoordinator: ActorRef,
                       readCoordinator: ActorRef,
                       metadataCoordinator: ActorRef,
                       publisher: ActorRef)(implicit logger: LoggingAdapter) =
@@ -70,12 +71,14 @@ trait WebResources extends WsResources with SSLSupport { this: NsdbSecurity =>
           if (isSSLEnabled) {
             val interface = config.getString(HttpInterface)
             val port      = config.getInt(HttpsPort)
-            logger.info(s"Cluster Apis started with https protocol at interface $interface on port $port")
+            logger.info(
+              s"Cluster Apis started for node $nodeId with https protocol at interface $interface on port $port")
             httpExt.bindAndHandle(withCors(withNSDbVersion(api)), interface, port, connectionContext = serverContext)
           } else {
             val interface = config.getString(HttpInterface)
             val port      = config.getInt(HttpPort)
-            logger.info(s"Cluster Apis started with http protocol at interface $interface and port $port")
+            logger.info(
+              s"Cluster Apis started for node $nodeId with http protocol at interface $interface and port $port")
             httpExt.bindAndHandle(withCors(withNSDbVersion(api)), interface, port)
           }
 

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/ClusterRestartSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/ClusterRestartSpec.scala
@@ -22,8 +22,11 @@ class ClusterRestartSpec extends ReadCoordinatorClusterSpec {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
+    leave()
+    stopCheck()
     stop()
     start(false)
+    healthCheck()
     waitIndexing()
   }
 }

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/ClusterRestartSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/ClusterRestartSpec.scala
@@ -23,7 +23,6 @@ class ClusterRestartSpec extends ReadCoordinatorClusterSpec {
   override def beforeAll(): Unit = {
     super.beforeAll()
     leave()
-    stopCheck()
     stop()
     start(false)
     healthCheck()

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/GlobalAggregationReadCoordinatorSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/GlobalAggregationReadCoordinatorSpec.scala
@@ -42,8 +42,6 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
 
     super.beforeAll()
 
-    healthCheck()
-
     val firstNode = nodes.head
 
     val nsdbConnection =

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/PublishSubscribeClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/PublishSubscribeClusterSpec.scala
@@ -55,8 +55,6 @@ class PublishSubscribeClusterSpec extends MiniClusterSpec {
                           value = 2,
                           tags = Map.empty)
 
-  healthCheck()
-
   test("subscribe to a query and receive real time updates") {
     val firstNode = nodes.head
     val lastNode  = nodes.last

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/ReadCoordinatorClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/ReadCoordinatorClusterSpec.scala
@@ -37,8 +37,6 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
     super.beforeAll()
 
-    healthCheck()
-
     val firstNode = nodes.head
 
     val nsdbConnection =

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/TemporalReadCoordinatorSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/TemporalReadCoordinatorSpec.scala
@@ -51,13 +51,13 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
     TemporalLongMetric.testRecords.map(_.asApiBit(db, namespace, TemporalLongMetric.name)).foreach { bit =>
       eventually {
-        assert(Await.result(nsdbConnection.write(bit), 10.seconds).completedSuccessfully)
+        assert(Await.result(nsdbConnection.write(bit), 10.seconds).errors == "")
       }
     }
 
     TemporalDoubleMetric.testRecords.map(_.asApiBit(db, namespace, TemporalDoubleMetric.name)).foreach { bit =>
       eventually {
-        assert(Await.result(nsdbConnection.write(bit), 10.seconds).completedSuccessfully)
+        assert(Await.result(nsdbConnection.write(bit), 10.seconds).errors == "")
       }
     }
 

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/WriteCoordinatorClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/WriteCoordinatorClusterSpec.scala
@@ -32,8 +32,6 @@ class WriteCoordinatorClusterSpec extends MiniClusterSpec {
 
   implicit val timeout: Timeout = Timeout(5, TimeUnit.SECONDS)
 
-  healthCheck()
-
   test("add record from first node") {
 
     val firstNode = nodes.head

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/test/MiniClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/test/MiniClusterSpec.scala
@@ -47,10 +47,7 @@ trait MiniClusterSpec extends FunSuite with BeforeAndAfterAll with Eventually wi
 
   override def afterAll(): Unit = {
     leave()
-    stopCheck
     stop()
-    waitIndexing()
-    waitIndexing()
   }
 
 
@@ -66,12 +63,5 @@ trait MiniClusterSpec extends FunSuite with BeforeAndAfterAll with Eventually wi
           assert(NSDbClusterSnapshot(node.system).nodes.size == nodes.size)
         }
       }
-
-  def stopCheck(): Set[Assertion] =
-    nodes.map { node =>
-      eventually {
-        assert(NSDbClusterSnapshot(node.system).nodes.isEmpty)
-      }
-    }
 
 }

--- a/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/NSDBAkkaMiniCluster.scala
+++ b/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/NSDBAkkaMiniCluster.scala
@@ -17,11 +17,12 @@
 package io.radicalbit.nsdb.minicluster
 
 import akka.actor.ActorSystem
+import akka.cluster.Cluster
 import io.radicalbit.nsdb.cluster.NSDbActors
 import io.radicalbit.nsdb.common.configuration.NSDbConfigProvider
 
-import scala.concurrent.duration._
 import scala.concurrent.Await
+import scala.concurrent.duration._
 
 trait NSDBAkkaMiniCluster { this: NSDbConfigProvider with NSDbActors =>
 
@@ -32,6 +33,11 @@ trait NSDBAkkaMiniCluster { this: NSDbConfigProvider with NSDbActors =>
     initTopLevelActors()
   }
 
-  def stop(): Unit = Await.result(system.terminate(), 10.seconds)
+  def leave(): Unit = Cluster(system).down(Cluster(system).selfAddress)
+
+  def stop(): Unit = {
+    Await.result(system.terminate(), 10.seconds)
+    Await.result(system.whenTerminated, 10.seconds)
+  }
 
 }

--- a/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/NSDBAkkaMiniCluster.scala
+++ b/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/NSDBAkkaMiniCluster.scala
@@ -36,8 +36,8 @@ trait NSDBAkkaMiniCluster { this: NSDbConfigProvider with NSDbActors =>
   def leave(): Unit = Cluster(system).down(Cluster(system).selfAddress)
 
   def stop(): Unit = {
-    Await.result(system.terminate(), 10.seconds)
-    Await.result(system.whenTerminated, 10.seconds)
+    Await.result(system.terminate(), Duration.Inf)
+    Await.result(system.whenTerminated, Duration.Inf)
   }
 
 }

--- a/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/NsdbMiniCluster.scala
+++ b/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/NsdbMiniCluster.scala
@@ -53,6 +53,8 @@ trait NsdbMiniCluster extends LazyLogging {
     nodes.foreach(_.start())
   }
 
+  def leave(): Unit = nodes.foreach(_.leave())
+
   def stop(): Unit = nodes.foreach(n => n.stop())
 
 }

--- a/project/Commons.scala
+++ b/project/Commons.scala
@@ -50,8 +50,6 @@ object Commons {
     ),
     parallelExecution in Test := false,
     parallelExecution in IntegrationTest := false,
-    testForkedParallel in Test := false,
-    testForkedParallel in IntegrationTest := false,
     concurrentRestrictions in Test += Tags.limitAll(1),
     concurrentRestrictions in IntegrationTest += Tags.limitAll(1),
     test in assembly := {},

--- a/project/Commons.scala
+++ b/project/Commons.scala
@@ -49,7 +49,11 @@ object Commons {
       Resolver.bintrayRepo("hseeberger", "maven")
     ),
     parallelExecution in Test := false,
-    concurrentRestrictions in Global += Tags.limitAll(1),
+    parallelExecution in IntegrationTest := false,
+    testForkedParallel in Test := false,
+    testForkedParallel in IntegrationTest := false,
+    concurrentRestrictions in Test += Tags.limitAll(1),
+    concurrentRestrictions in IntegrationTest += Tags.limitAll(1),
     test in assembly := {},
     assemblyMergeStrategy in assembly := {
       case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first


### PR DESCRIPTION
This PR updates the `Location` (shard) entity semantic.
To identify a node, the unique identifier is used instead of the address.
The unique identifier is synced with the address by the `NSDbClusterSnapshot` extension whose state is calculated based on the events fired by Akka cluster.

This semantic change will come in handy for better management of the event of a node restart. 
In that case, a node changes the address but not the identifier. 
So, for instance, in case of write failure, it will be possible to retry the operation after a node restart since the location relies on the node id instead of the volatile address 