### PR TITLE
Count Distinct for group by queries

### DIFF
--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorAggregatedStatementsSpec.scala
@@ -333,7 +333,7 @@ class ReadCoordinatorAggregatedStatementsSpec extends AbstractReadCoordinatorSpe
 
         awaitAssert {
           probe.expectMsgType[SelectStatementExecuted]
-        }.values shouldBe Seq(Bit(0L, 1L, Map.empty, Map("age" -> 20L)), Bit(0L, 4L, Map.empty, Map("age" -> 15L)))
+        }.values shouldBe Seq(Bit(0L, 2L, Map.empty, Map("age" -> 20L)), Bit(0L, 7L, Map.empty, Map("age" -> 15L)))
       }
 
       "execute it successfully with sum aggregation" in within(5.seconds) {
@@ -355,8 +355,8 @@ class ReadCoordinatorAggregatedStatementsSpec extends AbstractReadCoordinatorSpe
         awaitAssert {
           probe.expectMsgType[SelectStatementExecuted]
         }.values shouldBe Seq(
-          Bit(0L, 12L, Map.empty, Map("age" -> 15L)),
-          Bit(0L, 3L, Map.empty, Map("age"  -> 20L))
+          Bit(0L, 20L, Map.empty, Map("age" -> 15L)),
+          Bit(0L, 6L, Map.empty, Map("age"  -> 20L))
         )
       }
     }
@@ -381,9 +381,9 @@ class ReadCoordinatorAggregatedStatementsSpec extends AbstractReadCoordinatorSpe
         awaitAssert {
           probe.expectMsgType[SelectStatementExecuted]
         }.values shouldBe Seq(
-          Bit(0L, 2L, Map.empty, Map("height" -> 32.0)),
-          Bit(0L, 2L, Map.empty, Map("height" -> 30.5)),
-          Bit(0L, 1L, Map.empty, Map("height" -> 31.0))
+          Bit(0L, 4L, Map.empty, Map("height" -> 30.5)),
+          Bit(0L, 3L, Map.empty, Map("height" -> 32.0)),
+          Bit(0L, 2L, Map.empty, Map("height" -> 31.0))
         )
       }
     }
@@ -407,9 +407,9 @@ class ReadCoordinatorAggregatedStatementsSpec extends AbstractReadCoordinatorSpe
       awaitAssert {
         probe.expectMsgType[SelectStatementExecuted]
       }.values shouldBe Seq(
-        Bit(0L, 5L, Map.empty, Map("height" -> 30.5)),
-        Bit(0L, 5L, Map.empty, Map("height" -> 31.0)),
-        Bit(0L, 5L, Map.empty, Map("height" -> 32.0))
+        Bit(0L, 10L, Map.empty, Map("height" -> 30.5)),
+        Bit(0L, 10L, Map.empty, Map("height" -> 31.0)),
+        Bit(0L, 6L, Map.empty, Map("height"  -> 32.0))
       )
     }
 
@@ -457,8 +457,8 @@ class ReadCoordinatorAggregatedStatementsSpec extends AbstractReadCoordinatorSpe
       awaitAssert {
         probe.expectMsgType[SelectStatementExecuted]
       }.values shouldBe Seq(
-        Bit(4L, 3L, Map.empty, Map("height"  -> 30.5)),
-        Bit(6L, 5L, Map.empty, Map("height"  -> 31.0)),
+        Bit(5L, 3L, Map.empty, Map("height"  -> 30.5)),
+        Bit(7L, 5L, Map.empty, Map("height"  -> 31.0)),
         Bit(10L, 4L, Map.empty, Map("height" -> 32.0))
       )
     }
@@ -581,7 +581,7 @@ class ReadCoordinatorAggregatedStatementsSpec extends AbstractReadCoordinatorSpe
       }.values shouldBe Seq(
         Bit(0L, 2.5, Map.empty, Map("height" -> 30.5)),
         Bit(0L, 5.0, Map.empty, Map("height" -> 31.0)),
-        Bit(0L, 2.5, Map.empty, Map("height" -> 32.0))
+        Bit(0L, 2.0, Map.empty, Map("height" -> 32.0))
       )
     }
     "execute it successfully with avg aggregation on a double value metric" in within(5.seconds) {
@@ -606,7 +606,7 @@ class ReadCoordinatorAggregatedStatementsSpec extends AbstractReadCoordinatorSpe
       }.values shouldBe Seq(
         Bit(0L, 2.5, Map.empty, Map("height" -> 30.5)),
         Bit(0L, 5.0, Map.empty, Map("height" -> 31.0)),
-        Bit(0L, 2.5, Map.empty, Map("height" -> 32.0))
+        Bit(0L, 2.0, Map.empty, Map("height" -> 32.0))
       )
     }
   }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorDistinctAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorDistinctAggregatedStatementsSpec.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.coordinator
+
+import io.radicalbit.nsdb.cluster.coordinator.mockedData.MockedData._
+import io.radicalbit.nsdb.common.protocol._
+import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
+
+import scala.concurrent.duration._
+
+class ReadCoordinatorDistinctAggregatedStatementsSpec extends AbstractReadCoordinatorSpec {
+
+  "ReadCoordinator" when {
+
+    "receive a select containing a count distinct and a group by on a string tag" should {
+      "execute it successfully on a long metric" in {
+        probe.send(
+          readCoordinatorActor,
+          ExecuteStatement(
+            SelectSQLStatement(
+              db = db,
+              namespace = namespace,
+              metric = LongMetric.name,
+              distinct = false,
+              fields = ListFields(List(Field("value", Some(CountDistinctAggregation)))),
+              groupBy = Some(SimpleGroupByAggregation("name"))
+            )
+          )
+        )
+
+        val expected = awaitAssert {
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+        expected.values shouldBe Seq(
+          Bit(0, 1L, Map(), Map("name" -> "Bill")),
+          Bit(0, 1L, Map(), Map("name" -> "Frankie")),
+          Bit(0, 1L, Map(), Map("name" -> "J")),
+          Bit(0, 2L, Map(), Map("name" -> "John")),
+          Bit(0, 1L, Map(), Map("name" -> "Frank"))
+        )
+      }
+
+      "execute it successfully in case of a where condition" in {
+        probe.send(
+          readCoordinatorActor,
+          ExecuteStatement(
+            SelectSQLStatement(
+              db = db,
+              namespace = namespace,
+              metric = AggregationLongMetric.name,
+              distinct = false,
+              fields = ListFields(List(Field("value", Some(CountDistinctAggregation)))),
+              condition = Some(
+                Condition(
+                  ComparisonExpression(dimension = "timestamp",
+                                       comparison = GreaterOrEqualToOperator,
+                                       value = AbsoluteComparisonValue(2L)))),
+              groupBy = Some(SimpleGroupByAggregation("name"))
+            )
+          )
+        )
+
+        val expected = awaitAssert {
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+        expected.values shouldBe Seq(
+          Bit(0, 1L, Map(), Map("name" -> "Bill")),
+          Bit(0, 1L, Map(), Map("name" -> "Frankie")),
+          Bit(0, 1L, Map(), Map("name" -> "Frank")),
+          Bit(0, 2L, Map(), Map("name" -> "John"))
+        )
+      }
+    }
+
+    "receive a select containing a count distinct and a group by on a long tag" should {
+      "execute it successfully" in within(5.seconds) {
+        probe.send(
+          readCoordinatorActor,
+          ExecuteStatement(
+            SelectSQLStatement(
+              db = db,
+              namespace = namespace,
+              metric = AggregationLongMetric.name,
+              distinct = false,
+              fields = ListFields(List(Field("value", Some(CountDistinctAggregation)))),
+              groupBy = Some(SimpleGroupByAggregation("age")),
+              order = Some(AscOrderOperator("value"))
+            )
+          )
+        )
+
+        awaitAssert {
+          probe.expectMsgType[SelectStatementExecuted]
+        }.values shouldBe Seq(Bit(0L, 1L, Map.empty, Map("age" -> 20L)), Bit(0L, 4L, Map.empty, Map("age" -> 15L)))
+      }
+    }
+
+    "receive a select containing a count distinct and group by on a double tag" should {
+      "execute it successfully" in within(5.seconds) {
+        probe.send(
+          readCoordinatorActor,
+          ExecuteStatement(
+            SelectSQLStatement(
+              db = db,
+              namespace = namespace,
+              metric = AggregationLongMetric.name,
+              distinct = false,
+              fields = ListFields(List(Field("value", Some(CountDistinctAggregation)))),
+              groupBy = Some(SimpleGroupByAggregation("height")),
+              order = Some(DescOrderOperator("value"))
+            )
+          )
+        )
+
+        awaitAssert {
+          probe.expectMsgType[SelectStatementExecuted]
+        }.values shouldBe Seq(
+          Bit(0L, 2L, Map.empty, Map("height" -> 32.0)),
+          Bit(0L, 2L, Map.empty, Map("height" -> 30.5)),
+          Bit(0L, 1L, Map.empty, Map("height" -> 31.0))
+        )
+      }
+    }
+
+  }
+}

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedData/MockedData.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedData/MockedData.scala
@@ -62,12 +62,16 @@ object MockedData {
 
     val recordsShard1: Seq[Bit] = Seq(
       Bit(2L, 2L, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 15L, "height" -> 30.5)),
-      Bit(4L, 3L, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 20L, "height" -> 30.5))
+      Bit(3L, 2L, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 15L, "height" -> 30.5)),
+      Bit(4L, 3L, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 20L, "height" -> 30.5)),
+      Bit(5L, 3L, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 20L, "height" -> 30.5))
     )
 
     val recordsShard2: Seq[Bit] = Seq(
       Bit(6L, 5L, Map("surname"  -> "Doe"), Map("name" -> "Bill", "age"    -> 15L, "height" -> 31.0)),
+      Bit(7L, 5L, Map("surname"  -> "Doe"), Map("name" -> "Bill", "age"    -> 15L, "height" -> 31.0)),
       Bit(8L, 1L, Map("surname"  -> "Doe"), Map("name" -> "Frank", "age"   -> 15L, "height" -> 32.0)),
+      Bit(9L, 1L, Map("surname"  -> "Doe"), Map("name" -> "Frank", "age"   -> 15L, "height" -> 32.0)),
       Bit(10L, 4L, Map("surname" -> "Doe"), Map("name" -> "Frankie", "age" -> 15L, "height" -> 32.0))
     )
 
@@ -80,12 +84,16 @@ object MockedData {
 
     val recordsShard1: Seq[Bit] = Seq(
       Bit(2L, 2.0, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 15L, "height" -> 30.5)),
-      Bit(4L, 3.0, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 20L, "height" -> 30.5))
+      Bit(3L, 2.0, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 15L, "height" -> 30.5)),
+      Bit(4L, 3.0, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 20L, "height" -> 30.5)),
+      Bit(5L, 3.0, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 20L, "height" -> 30.5))
     )
 
     val recordsShard2: Seq[Bit] = Seq(
       Bit(6L, 5.0, Map("surname"  -> "Doe"), Map("name" -> "Bill", "age"    -> 15L, "height" -> 31.0)),
+      Bit(7L, 5.0, Map("surname"  -> "Doe"), Map("name" -> "Bill", "age"    -> 15L, "height" -> 31.0)),
       Bit(8L, 1.0, Map("surname"  -> "Doe"), Map("name" -> "Frank", "age"   -> 15L, "height" -> 32.0)),
+      Bit(9L, 1.0, Map("surname"  -> "Doe"), Map("name" -> "Frank", "age"   -> 15L, "height" -> 32.0)),
       Bit(10L, 4.0, Map("surname" -> "Doe"), Map("name" -> "Frankie", "age" -> 15L, "height" -> 32.0))
     )
 

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/Bit.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/Bit.scala
@@ -53,6 +53,7 @@ trait TimeSeriesRecord {
   * @param timestamp  record timestamp.
   * @param value      record value.
   * @param dimensions record dimensions.
+  * @param uniqueValues Set containing all the unique values gathered from a count distinct.
   */
 case class Bit(timestamp: Long,
                value: NSDbNumericType,

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/Bit.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/Bit.scala
@@ -54,7 +54,11 @@ trait TimeSeriesRecord {
   * @param value      record value.
   * @param dimensions record dimensions.
   */
-case class Bit(timestamp: Long, value: NSDbNumericType, dimensions: Map[String, NSDbType], tags: Map[String, NSDbType])
+case class Bit(timestamp: Long,
+               value: NSDbNumericType,
+               dimensions: Map[String, NSDbType],
+               tags: Map[String, NSDbType],
+               uniqueValues: Set[NSDbType] = Set.empty)
     extends TimeSeriesRecord {
 
   /**

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -179,12 +179,13 @@ sealed trait DerivedAggregation extends Aggregation {
   def primaryAggregationsRequired: List[Aggregation with PrimaryAggregation]
 }
 
-case object CountAggregation extends GlobalAggregation with PrimaryAggregation
-case object MaxAggregation   extends Aggregation with PrimaryAggregation
-case object MinAggregation   extends Aggregation with PrimaryAggregation
-case object FirstAggregation extends Aggregation with PrimaryAggregation
-case object LastAggregation  extends Aggregation with PrimaryAggregation
-case object SumAggregation   extends Aggregation with PrimaryAggregation
+case object CountAggregation         extends GlobalAggregation with PrimaryAggregation
+case object CountDistinctAggregation extends GlobalAggregation with PrimaryAggregation
+case object MaxAggregation           extends Aggregation with PrimaryAggregation
+case object MinAggregation           extends Aggregation with PrimaryAggregation
+case object FirstAggregation         extends Aggregation with PrimaryAggregation
+case object LastAggregation          extends Aggregation with PrimaryAggregation
+case object SumAggregation           extends Aggregation with PrimaryAggregation
 case object AvgAggregation extends GlobalAggregation with DerivedAggregation {
   override def primaryAggregationsRequired: List[Aggregation with PrimaryAggregation] =
     List(CountAggregation, SumAggregation)

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SqlStatementSerialization.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SqlStatementSerialization.scala
@@ -57,13 +57,14 @@ object SqlStatementSerialization {
 
       override def deserialize(p: JsonParser, ctxt: DeserializationContext): Aggregation = {
         p.getText match {
-          case "CountAggregation" => CountAggregation
-          case "MaxAggregation"   => MaxAggregation
-          case "MinAggregation"   => MinAggregation
-          case "SumAggregation"   => SumAggregation
-          case "FirstAggregation" => FirstAggregation
-          case "LastAggregation"  => LastAggregation
-          case "AvgAggregation"   => AvgAggregation
+          case "CountAggregation"         => CountAggregation
+          case "CountDistinctAggregation" => CountDistinctAggregation
+          case "MaxAggregation"           => MaxAggregation
+          case "MinAggregation"           => MinAggregation
+          case "SumAggregation"           => SumAggregation
+          case "FirstAggregation"         => FirstAggregation
+          case "LastAggregation"          => LastAggregation
+          case "AvgAggregation"           => AvgAggregation
         }
       }
     }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AbstractStructuredIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AbstractStructuredIndex.scala
@@ -244,7 +244,11 @@ abstract class AbstractStructuredIndex extends Index[Bit] with TypeSupport {
               0,
               0,
               Map.empty,
-              Map(groupTagName -> schema.tags(groupTagName).indexType.deserialize(g.groupValue.bytes)),
+              Map(
+                groupTagName -> schema
+                  .tags(groupTagName)
+                  .indexType
+                  .deserialize(new String(g.groupValue.bytes).stripSuffix(stringAuxiliaryFieldSuffix).getBytes)),
               g.uniqueValues.asScala.map { v =>
                 schema.value.indexType.deserialize(new String(v.bytes).stripSuffix(stringAuxiliaryFieldSuffix).getBytes)
               }.toSet,

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/Index.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/Index.scala
@@ -40,9 +40,13 @@ trait Index[T] {
   /**
     * number of occurrences
     */
-  val _countField: String = "_count"
+  protected val _countField: String = "_count"
 
-  val _valueField = "value"
+  protected val _valueField = "value"
+
+  protected val maxGroups = 10000
+
+  protected val stringAuxiliaryFieldSuffix = "_str"
 
   private lazy val searcherManager: SearcherManager = new SearcherManager(directory, null)
 
@@ -152,6 +156,7 @@ trait Index[T] {
 }
 
 object Index {
+
   def handleNumericNoIndexResults[T: Numeric](out: Try[T]): Try[T] = {
     out.recoverWith {
       case _: IndexNotFoundException => Success(implicitly[Numeric[T]].zero)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -268,6 +268,15 @@ package object post_proc {
             NSDbNumericType(bits.map(_.value.rawValue.asInstanceOf[Long]).sum),
             foldMapOfBit(bits, bit => bit.dimensions),
             foldMapOfBit(bits, bit => bit.tags))
+
+      case CountDistinctAggregation =>
+        val uniqueValues = bits.foldLeft(Set.empty[NSDbType])((acc, b2) => acc ++ b2.uniqueValues)
+
+        if (finalStep)
+          Bit(0, uniqueValues.size, Map.empty, bits.head.tags)
+        else
+          Bit(0, 0, Map.empty, bits.head.tags, uniqueValues)
+
       case MaxAggregation =>
         Bit(0,
             NSDbNumericType(bits.map(_.value.rawValue).max),

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -280,9 +280,9 @@ package object post_proc {
         val uniqueValues = bits.foldLeft(Set.empty[NSDbType])((acc, b2) => acc ++ b2.uniqueValues)
 
         if (finalStep)
-          Bit(0, uniqueValues.size.toLong, Map.empty, bits.head.tags)
+          Bit(0, uniqueValues.size.toLong, Map.empty, bits.headOption.map(_.tags).getOrElse(Map.empty))
         else
-          Bit(0, 0L, Map.empty, bits.head.tags, uniqueValues)
+          Bit(0, 0L, Map.empty, bits.headOption.map(_.tags).getOrElse(Map.empty), uniqueValues)
 
       case MaxAggregation =>
         Bit(0,

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/CountDistinctSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/CountDistinctSpec.scala
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.radicalbit.nsdb.index.aux
 
 import java.nio.file.Paths
 import java.util.UUID
 
-import io.radicalbit.nsdb.common.NSDbStringType
 import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.common.{NSDbDoubleType, NSDbIntType, NSDbStringType}
 import io.radicalbit.nsdb.index.TimeSeriesIndex
 import io.radicalbit.nsdb.model.Schema
 import org.apache.lucene.search.MatchAllDocsQuery
@@ -24,12 +40,12 @@ class CountDistinctSpec extends WordSpec with Matchers with OneInstancePerTest {
         Bit(120000, 3.5, Map("surname" -> "Doe"), Map("name" -> "John")),
         Bit(130000, 3.5, Map("surname" -> "Doe"), Map("name" -> "John")),
         Bit(140000, 3.5, Map("surname" -> "Doe"), Map("name" -> "John")),
-        Bit(90000, 5.5, Map("surname" -> "Doe"), Map("name" -> "John")),
-        Bit(60000, 7.5, Map("surname" -> "Doe"), Map("name" -> "Bill")),
-        Bit(70000, 7.5, Map("surname" -> "Doe"), Map("name" -> "Bill")),
-        Bit(80000, 8.5, Map("surname" -> "Doe"), Map("name" -> "Bill")),
-        Bit(30000, 4.5, Map("surname" -> "Doe"), Map("name" -> "Frank")),
-        Bit(0, 1.5, Map("surname"     -> "Doe"), Map("name" -> "Frankie"))
+        Bit(90000, 5.5, Map("surname"  -> "Doe"), Map("name" -> "John")),
+        Bit(60000, 7.5, Map("surname"  -> "Doe"), Map("name" -> "Bill")),
+        Bit(70000, 7.5, Map("surname"  -> "Doe"), Map("name" -> "Bill")),
+        Bit(80000, 8.5, Map("surname"  -> "Doe"), Map("name" -> "Bill")),
+        Bit(30000, 4.5, Map("surname"  -> "Doe"), Map("name" -> "Frank")),
+        Bit(0, 1.5, Map("surname"      -> "Doe"), Map("name" -> "Frankie"))
       )
 
       val timeSeriesIndex =
@@ -41,14 +57,22 @@ class CountDistinctSpec extends WordSpec with Matchers with OneInstancePerTest {
 
       writer.close()
 
-
-      val countDistinct = timeSeriesIndex.countDistinct(new MatchAllDocsQuery, Schema("testMetric", testRecords.head), "name")
+      val countDistinct =
+        timeSeriesIndex.countDistinct(new MatchAllDocsQuery, Schema("testMetric", testRecords.head), "name")
 
       countDistinct shouldBe Seq(
-        Bit(0,3,Map(),Map("name" -> NSDbStringType("John"))),
-        Bit(0,2,Map(),Map("name" -> NSDbStringType("Bill"))),
-        Bit(0,1,Map(),Map("name" -> NSDbStringType("Frank"))),
-        Bit(0,1,Map(),Map("name" -> NSDbStringType("Frankie")))
+        Bit(0,
+            NSDbIntType(0),
+            Map(),
+            Map("name" -> NSDbStringType("John")),
+            Set(NSDbDoubleType(5.5), NSDbDoubleType(3.5), NSDbDoubleType(2.5))),
+        Bit(0,
+            NSDbIntType(0),
+            Map(),
+            Map("name" -> NSDbStringType("Bill")),
+            Set(NSDbDoubleType(8.5), NSDbDoubleType(7.5))),
+        Bit(0, NSDbIntType(0), Map(), Map("name" -> NSDbStringType("Frank")), Set(NSDbDoubleType(4.5))),
+        Bit(0, NSDbIntType(0), Map(), Map("name" -> NSDbStringType("Frankie")), Set(NSDbDoubleType(1.5)))
       )
     }
   }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/CountDistinctSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/CountDistinctSpec.scala
@@ -1,0 +1,56 @@
+package io.radicalbit.nsdb.index.aux
+
+import java.nio.file.Paths
+import java.util.UUID
+
+import io.radicalbit.nsdb.common.NSDbStringType
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.index.TimeSeriesIndex
+import io.radicalbit.nsdb.model.Schema
+import org.apache.lucene.search.MatchAllDocsQuery
+import org.apache.lucene.store.MMapDirectory
+import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
+
+class CountDistinctSpec extends WordSpec with Matchers with OneInstancePerTest {
+
+  "TimeSeriesIndex" should {
+    "calculate count distinct" in {
+
+      val testRecords: Seq[Bit] = Seq(
+        Bit(150000, 2.5, Map("surname" -> "Doe"), Map("name" -> "John")),
+        Bit(160000, 2.5, Map("surname" -> "Doe"), Map("name" -> "John")),
+        Bit(170000, 2.5, Map("surname" -> "Doe"), Map("name" -> "John")),
+        Bit(180000, 2.5, Map("surname" -> "Doe"), Map("name" -> "John")),
+        Bit(120000, 3.5, Map("surname" -> "Doe"), Map("name" -> "John")),
+        Bit(130000, 3.5, Map("surname" -> "Doe"), Map("name" -> "John")),
+        Bit(140000, 3.5, Map("surname" -> "Doe"), Map("name" -> "John")),
+        Bit(90000, 5.5, Map("surname" -> "Doe"), Map("name" -> "John")),
+        Bit(60000, 7.5, Map("surname" -> "Doe"), Map("name" -> "Bill")),
+        Bit(70000, 7.5, Map("surname" -> "Doe"), Map("name" -> "Bill")),
+        Bit(80000, 8.5, Map("surname" -> "Doe"), Map("name" -> "Bill")),
+        Bit(30000, 4.5, Map("surname" -> "Doe"), Map("name" -> "Frank")),
+        Bit(0, 1.5, Map("surname"     -> "Doe"), Map("name" -> "Frankie"))
+      )
+
+      val timeSeriesIndex =
+        new TimeSeriesIndex(new MMapDirectory(Paths.get("target", "test_first_last_index", UUID.randomUUID().toString)))
+
+      val writer = timeSeriesIndex.getWriter
+
+      testRecords.foreach(timeSeriesIndex.write(_)(writer))
+
+      writer.close()
+
+
+      val countDistinct = timeSeriesIndex.countDistinct(new MatchAllDocsQuery, Schema("testMetric", testRecords.head), "name")
+
+      countDistinct shouldBe Seq(
+        Bit(0,3,Map(),Map("name" -> NSDbStringType("John"))),
+        Bit(0,2,Map(),Map("name" -> NSDbStringType("Bill"))),
+        Bit(0,1,Map(),Map("name" -> NSDbStringType("Frank"))),
+        Bit(0,1,Map(),Map("name" -> NSDbStringType("Frankie")))
+      )
+    }
+  }
+
+}

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/CountDistinctSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/CountDistinctSpec.scala
@@ -58,7 +58,7 @@ class CountDistinctSpec extends WordSpec with Matchers with OneInstancePerTest {
       writer.close()
 
       val countDistinct =
-        timeSeriesIndex.countDistinct(new MatchAllDocsQuery, Schema("testMetric", testRecords.head), "name")
+        timeSeriesIndex.uniqueValues(new MatchAllDocsQuery, Schema("testMetric", testRecords.head), "name")
 
       countDistinct shouldBe Seq(
         Bit(0,

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJson.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJson.scala
@@ -114,7 +114,7 @@ object NSDbJson extends DefaultJsonProtocol with SprayJsonSupport {
 
   implicit val QvbFormat: RootJsonFormat[QueryValidationBody] = jsonFormat4(QueryValidationBody.apply)
 
-  implicit val BitFormat: RootJsonFormat[Bit] = jsonFormat4(Bit.apply)
+  implicit val BitFormat: RootJsonFormat[Bit] = jsonFormat5(Bit.apply)
 
   implicit val InsertBodyFormat: RootJsonFormat[InsertBody] = jsonFormat4(InsertBody.apply)
 

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -125,10 +125,11 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
     Field(e, None)
   }
   private val aggField
-    : Parser[Field] = ((sum | min | max | count | first | last | avg) <~ OpenRoundBracket) ~ (Distinct ?) ~ (standardString | All) <~ CloseRoundBracket ^^ {
+    : Parser[Field] = ((sum | min | max | count | first | last | avg) <~ OpenRoundBracket) ~ (Distinct ?) ~ (standardString | All) <~ CloseRoundBracket ^? ({
     case CountAggregation ~ Some(_) ~ name => Field(name, Some(CountDistinctAggregation))
-    case aggregation ~ _ ~ name            => Field(name, Some(aggregation))
-  }
+    case aggregation ~ None ~ name         => Field(name, Some(aggregation))
+  }, _ => "Distinct clause is only applicable to the count aggregation")
+
   private val dimension = standardString
   private val stringValue = (specialString | (("'" ?) ~> (specialString +) <~ ("'" ?))) ^^ {
     case string: String        => string

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
@@ -190,10 +190,14 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
           ))
       }
       "fail in case of other aggregations" in {
-        parser.parse(db = "db", namespace = "registry", input = "SELECT sum( distinct *) FROM people group by name") shouldBe a[SqlStatementParserFailure]
-        parser.parse(db = "db", namespace = "registry", input = "SELECT min( distinct *) FROM people group by name") shouldBe a[SqlStatementParserFailure]
-        parser.parse(db = "db", namespace = "registry", input = "SELECT max( distinct *) FROM people group by name") shouldBe a[SqlStatementParserFailure]
-        parser.parse(db = "db", namespace = "registry", input = "SELECT avg( distinct *) FROM people group by name") shouldBe a[SqlStatementParserFailure]
+        parser.parse(db = "db", namespace = "registry", input = "SELECT sum( distinct *) FROM people group by name") shouldBe a[
+          SqlStatementParserFailure]
+        parser.parse(db = "db", namespace = "registry", input = "SELECT min( distinct *) FROM people group by name") shouldBe a[
+          SqlStatementParserFailure]
+        parser.parse(db = "db", namespace = "registry", input = "SELECT max( distinct *) FROM people group by name") shouldBe a[
+          SqlStatementParserFailure]
+        parser.parse(db = "db", namespace = "registry", input = "SELECT avg( distinct *) FROM people group by name") shouldBe a[
+          SqlStatementParserFailure]
       }
     }
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
@@ -158,6 +158,45 @@ class AggregationSQLStatementSpec extends WordSpec with Matchers {
       }
     }
 
+    "receive a select with a group by and one distinct aggregation" should {
+      "parse it successfully in case of count" in {
+        val query = "SELECT count( distinct value) FROM people group by name"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("value", Some(CountDistinctAggregation)))),
+              groupBy = Some(SimpleGroupByAggregation("name"))
+            )
+          ))
+      }
+      "parse it successfully in case of count * " in {
+        val query = "SELECT count( distinct *) FROM people group by name"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("*", Some(CountDistinctAggregation)))),
+              groupBy = Some(SimpleGroupByAggregation("name"))
+            )
+          ))
+      }
+      "fail in case of other aggregations" in {
+        parser.parse(db = "db", namespace = "registry", input = "SELECT sum( distinct *) FROM people group by name") shouldBe a[SqlStatementParserFailure]
+        parser.parse(db = "db", namespace = "registry", input = "SELECT min( distinct *) FROM people group by name") shouldBe a[SqlStatementParserFailure]
+        parser.parse(db = "db", namespace = "registry", input = "SELECT max( distinct *) FROM people group by name") shouldBe a[SqlStatementParserFailure]
+        parser.parse(db = "db", namespace = "registry", input = "SELECT avg( distinct *) FROM people group by name") shouldBe a[SqlStatementParserFailure]
+      }
+    }
+
     "receive a select containing a range selection and a group by" should {
       "parse it successfully" in {
         val query = "SELECT count(value) FROM people WHERE timestamp IN (2,4) group by name"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -136,7 +136,7 @@ object Dependencies {
   }
 
   object lucene {
-    lazy val version     = "8.6.1"
+    lazy val version     = "8.6.2"
     lazy val namespace   = "org.apache.lucene"
     lazy val core        = namespace % "lucene-core" % version
     lazy val queryParser = namespace % "lucene-queryparser" % version


### PR DESCRIPTION
This PR enables the SQL clause "count distinct" that it's applicable only on the value (on * as syntactic sugar) and only on group by queries.
So for instance, It will be possible to perform queries like

`select count(distinct *) from metric group by tag where timestamp > 0`