### PR TITLE
Count Distinct for global queries

### DIFF
--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -275,8 +275,7 @@ object ShardReaderActor {
     * @param quantities single quantities (count, sum etc.).
     * @param uniqueValues unique values that will be used for count distinct calculation.
     */
-  case class PrimaryAggregationResults(quantities: Map[String, NSDbNumericType] = Map.empty,
-                                       uniqueValues: Set[NSDbType] = Set.empty)
+  case class PrimaryAggregationResults(quantities: Map[String, NSDbNumericType], uniqueValues: Set[NSDbType])
 
   def props(basePath: String, db: String, namespace: String, location: Location): Props =
     Props(new ShardReaderActor(basePath, db, namespace, location))

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -90,7 +90,8 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
     }.distinct
 
     (for {
-      (groupField, groupFieldSchemaField) <- Try(schema.tags.head)
+      (groupField, groupFieldSchemaField) <- Try(
+        schema.tags.headOption.getOrElse(Schema.timestampField -> schema.timestamp))
       quantities <- flatten(distinctPrimaryAggregations
         .collect {
           case CountAggregation =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/Index.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/Index.scala
@@ -157,19 +157,9 @@ trait Index[T] {
 
 object Index {
 
-  def handleNumericNoIndexResults[T: Numeric](out: Try[T]): Try[T] = {
-    out.recoverWith {
-      case _: IndexNotFoundException => Success(implicitly[Numeric[T]].zero)
-    }
-  }
   def handleNoIndexResults[T](out: Try[Seq[T]]): Try[Seq[T]] = {
     out.recoverWith {
       case _: IndexNotFoundException => Success(Seq.empty)
-    }
-  }
-  def handleUniqueValuesNoIndexResults[T](out: Try[Set[T]]): Try[Set[T]] = {
-    out.recoverWith {
-      case _: IndexNotFoundException => Success(Set.empty)
     }
   }
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/Index.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/lucene/Index.scala
@@ -167,4 +167,9 @@ object Index {
       case _: IndexNotFoundException => Success(Seq.empty)
     }
   }
+  def handleUniqueValuesNoIndexResults[T](out: Try[Set[T]]): Try[Set[T]] = {
+    out.recoverWith {
+      case _: IndexNotFoundException => Success(Set.empty)
+    }
+  }
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
@@ -19,6 +19,7 @@ package io.radicalbit.nsdb.model
 import io.radicalbit.nsdb.common.NSDbType
 import io.radicalbit.nsdb.common.protocol._
 import io.radicalbit.nsdb.index.{IndexType, TypeSupport}
+import io.radicalbit.nsdb.model.Schema.{timestampField, valueField}
 
 import scala.util.{Failure, Success, Try}
 
@@ -67,14 +68,14 @@ class Schema private (val metric: String, val fieldsMap: Map[String, SchemaField
   }
 
   /**
-    * True if there are no tags for the current schema.
+    * extract value from fieldsMap
     */
-  lazy val isTagless: Boolean = tags.isEmpty
+  lazy val value: SchemaField = fieldsMap(valueField)
 
   /**
     * extract value from fieldsMap
     */
-  lazy val value: SchemaField = fieldsMap("value")
+  lazy val timestamp: SchemaField = fieldsMap(timestampField)
 
   override def equals(obj: scala.Any): Boolean = {
     if (obj != null && obj.isInstanceOf[Schema]) {
@@ -87,6 +88,9 @@ class Schema private (val metric: String, val fieldsMap: Map[String, SchemaField
 }
 
 object Schema extends TypeSupport {
+
+  final val valueField     = "value"
+  final val timestampField = "timestamp"
 
   /**
     * Creates a schema by analyzing a [[Bit]] structure.

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParser.scala
@@ -116,21 +116,17 @@ object StatementParser {
           case (None, fieldsList) if distinctValue && fieldsList.size > 1 =>
             Left(StatementParserErrors.MORE_FIELDS_DISTINCT)
           case (None, fieldsList) if FieldsParser.containsOnlyGlobalAggregations(fieldsList) =>
-            if (parsedFieldsList.requireTags && schema.isTagless)
-              Left(StatementParserErrors.TAGLESS_AGGREGATIONS)
-            else {
-              val (aggregatedFields, plainFields) = fieldsList.partition(_.aggregation.isDefined)
-              Right(
-                ParsedGlobalAggregatedQuery(
-                  statement.namespace,
-                  statement.metric,
-                  exp.q,
-                  limitOpt.getOrElse(Int.MaxValue),
-                  plainFields,
-                  aggregatedFields.flatMap(_.aggregation).distinct,
-                  sortOpt
-                ))
-            }
+            val (aggregatedFields, plainFields) = fieldsList.partition(_.aggregation.isDefined)
+            Right(
+              ParsedGlobalAggregatedQuery(
+                statement.namespace,
+                statement.metric,
+                exp.q,
+                limitOpt.getOrElse(Int.MaxValue),
+                plainFields,
+                aggregatedFields.flatMap(_.aggregation).distinct,
+                sortOpt
+              ))
           case (None, fieldsList) =>
             Right(
               ParsedSimpleQuery(

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParserErrors.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParserErrors.scala
@@ -25,8 +25,6 @@ object StatementParserErrors {
     s"cannot execute a query with a non global aggregation without a groupBy field"
   lazy val GROUP_BY_DISTINCT =
     s"cannot execute a query with a group by and a distinct clause"
-  lazy val TAGLESS_AGGREGATIONS =
-    s"the provided aggregations require at least one tag defined for a metric"
   lazy val SIMPLE_AGGREGATION_NOT_ON_TAG =
     "cannot execute a groupBy query grouping by a field that is not a tag"
   lazy val AGGREGATION_NOT_ON_VALUE =

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserAggregationsSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserAggregationsSpec.scala
@@ -161,7 +161,7 @@ class StatementParserAggregationsSpec extends WordSpec with Matchers {
         )
       }
 
-      "fail if average is provided" in {
+      "parse it successfully if average is provided" in {
         StatementParser.parseStatement(
           SelectSQLStatement(
             db = "db",
@@ -173,7 +173,15 @@ class StatementParserAggregationsSpec extends WordSpec with Matchers {
           ),
           taglessSchema
         ) should be(
-          Left(StatementParserErrors.TAGLESS_AGGREGATIONS)
+          Right(
+            ParsedGlobalAggregatedQuery(
+              "registry",
+              "people",
+              new MatchAllDocsQuery(),
+              4,
+              List(),
+              List(AvgAggregation)
+            ))
         )
       }
     }


### PR DESCRIPTION
This PR enables the count distinct for global queries (i.e. queries without a group by clause).
For instance, now expressions like

```
select count(distinct *) from metric 
select count(distinct *) from metric where tag = "constant"
```

will be supported