### PR TITLE
[HOTFIX] Enable grpc reflection

### DIFF
--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/client/rpc/GRPCServer.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/client/rpc/GRPCServer.scala
@@ -31,6 +31,7 @@ import io.radicalbit.nsdb.rpc.service.NSDBServiceCommandGrpc.NSDBServiceCommand
 import io.radicalbit.nsdb.rpc.service.NSDBServiceSQLGrpc.NSDBServiceSQL
 import io.radicalbit.nsdb.rpc.service.{NSDBServiceCommandGrpc, NSDBServiceSQLGrpc}
 import io.radicalbit.nsdb.sql.parser.SQLStatementParser
+import io.grpc.protobuf.services.ProtoReflectionService
 
 import scala.concurrent.ExecutionContext
 import scala.util.Try
@@ -73,6 +74,7 @@ trait GRPCServer {
     .addService(InitMetricGrpc.bindService(initMetricService, executionContextExecutor))
     .addService(HealthGrpc.bindService(health, executionContextExecutor))
     .addService(RestoreGrpc.bindService(restore, executionContextExecutor))
+    .addService(ProtoReflectionService.newInstance())
     .build
 
   def start(): Try[Server] = Try(server.start())

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -155,6 +155,7 @@ object Dependencies {
     lazy val version         = scalapb.compiler.Version.grpcJavaVersion
     lazy val namespace       = "io.grpc"
     lazy val `grpc-netty`    = namespace % "grpc-netty" % version
+    lazy val `grpc-services` = namespace % "grpc-services" % version
   }
 
   object scalaPB {
@@ -237,6 +238,7 @@ object Dependencies {
     val libraries = Seq(
       slf4j.api,
       gRPC.`grpc-netty`,
+      gRPC.`grpc-services`,
       scalaPB.`runtime`,
       scalaPB.`runtime-grpc`
     )


### PR DESCRIPTION
This PR enables `GRPC Server Reflection Protocol` that is an extension of a Grpc server that allows a client to list all the available service and call a specific method without having the protobuf descriptor