### PR TITLE
[HOTFIX] Fix count distinct label for global queries

### DIFF
--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorGlobalAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorGlobalAggregatedStatementsSpec.scala
@@ -342,7 +342,7 @@ class ReadCoordinatorGlobalAggregatedStatementsSpec extends AbstractReadCoordina
               metric = AggregationLongMetric.name,
               distinct = false,
               fields = ListFields(
-                List(Field("*", Some(CountDistinctAggregation("value"))))
+                List(Field("*", Some(CountDistinctAggregation("*"))))
               )
             )
           )
@@ -374,7 +374,7 @@ class ReadCoordinatorGlobalAggregatedStatementsSpec extends AbstractReadCoordina
           probe.expectMsgType[SelectStatementExecuted]
         }
         expected.values shouldBe Seq(
-          Bit(0, 0L, Map.empty, Map("count(distinct *)" -> NSDbLongType(3L)))
+          Bit(0, 0L, Map.empty, Map("count(distinct height)" -> NSDbLongType(3L)))
         )
       }
 
@@ -522,15 +522,15 @@ class ReadCoordinatorGlobalAggregatedStatementsSpec extends AbstractReadCoordina
           probe.expectMsgType[SelectStatementExecuted]
         }
         expected.values.sortBy(_.timestamp) shouldBe Seq(
-          Bit(2L, 2L, Map.empty, Map("name"  -> "John", "count(distinct *)"    -> 5L)),
-          Bit(3L, 2L, Map.empty, Map("name"  -> "John", "count(distinct *)"    -> 5L)),
-          Bit(4L, 3L, Map.empty, Map("name"  -> "John", "count(distinct *)"    -> 5L)),
-          Bit(5L, 3L, Map.empty, Map("name"  -> "John", "count(distinct *)"    -> 5L)),
-          Bit(6L, 5L, Map.empty, Map("name"  -> "Bill", "count(distinct *)"    -> 5L)),
-          Bit(7L, 5L, Map.empty, Map("name"  -> "Bill", "count(distinct *)"    -> 5L)),
-          Bit(8L, 1L, Map.empty, Map("name"  -> "Frank", "count(distinct *)"   -> 5L)),
-          Bit(9L, 1L, Map.empty, Map("name"  -> "Frank", "count(distinct *)"   -> 5L)),
-          Bit(10L, 4L, Map.empty, Map("name" -> "Frankie", "count(distinct *)" -> 5L))
+          Bit(2L, 2L, Map.empty, Map("name"  -> "John", "count(distinct value)"    -> 5L)),
+          Bit(3L, 2L, Map.empty, Map("name"  -> "John", "count(distinct value)"    -> 5L)),
+          Bit(4L, 3L, Map.empty, Map("name"  -> "John", "count(distinct value)"    -> 5L)),
+          Bit(5L, 3L, Map.empty, Map("name"  -> "John", "count(distinct value)"    -> 5L)),
+          Bit(6L, 5L, Map.empty, Map("name"  -> "Bill", "count(distinct value)"    -> 5L)),
+          Bit(7L, 5L, Map.empty, Map("name"  -> "Bill", "count(distinct value)"    -> 5L)),
+          Bit(8L, 1L, Map.empty, Map("name"  -> "Frank", "count(distinct value)"   -> 5L)),
+          Bit(9L, 1L, Map.empty, Map("name"  -> "Frank", "count(distinct value)"   -> 5L)),
+          Bit(10L, 4L, Map.empty, Map("name" -> "Frankie", "count(distinct value)" -> 5L))
         )
       }
 
@@ -552,15 +552,15 @@ class ReadCoordinatorGlobalAggregatedStatementsSpec extends AbstractReadCoordina
           probe.expectMsgType[SelectStatementExecuted]
         }
         expected.values.sortBy(_.timestamp) shouldBe Seq(
-          Bit(2L, 2L, Map.empty, Map("name"  -> "John", "count(distinct *)"    -> 4L)),
-          Bit(3L, 2L, Map.empty, Map("name"  -> "John", "count(distinct *)"    -> 4L)),
-          Bit(4L, 3L, Map.empty, Map("name"  -> "John", "count(distinct *)"    -> 4L)),
-          Bit(5L, 3L, Map.empty, Map("name"  -> "John", "count(distinct *)"    -> 4L)),
-          Bit(6L, 5L, Map.empty, Map("name"  -> "Bill", "count(distinct *)"    -> 4L)),
-          Bit(7L, 5L, Map.empty, Map("name"  -> "Bill", "count(distinct *)"    -> 4L)),
-          Bit(8L, 1L, Map.empty, Map("name"  -> "Frank", "count(distinct *)"   -> 4L)),
-          Bit(9L, 1L, Map.empty, Map("name"  -> "Frank", "count(distinct *)"   -> 4L)),
-          Bit(10L, 4L, Map.empty, Map("name" -> "Frankie", "count(distinct *)" -> 4L))
+          Bit(2L, 2L, Map.empty, Map("name"  -> "John", "count(distinct name)"    -> 4L)),
+          Bit(3L, 2L, Map.empty, Map("name"  -> "John", "count(distinct name)"    -> 4L)),
+          Bit(4L, 3L, Map.empty, Map("name"  -> "John", "count(distinct name)"    -> 4L)),
+          Bit(5L, 3L, Map.empty, Map("name"  -> "John", "count(distinct name)"    -> 4L)),
+          Bit(6L, 5L, Map.empty, Map("name"  -> "Bill", "count(distinct name)"    -> 4L)),
+          Bit(7L, 5L, Map.empty, Map("name"  -> "Bill", "count(distinct name)"    -> 4L)),
+          Bit(8L, 1L, Map.empty, Map("name"  -> "Frank", "count(distinct name)"   -> 4L)),
+          Bit(9L, 1L, Map.empty, Map("name"  -> "Frank", "count(distinct name)"   -> 4L)),
+          Bit(10L, 4L, Map.empty, Map("name" -> "Frankie", "count(distinct name)" -> 4L))
         )
       }
 

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/statement/SQLStatement.scala
@@ -167,6 +167,8 @@ sealed trait Aggregation {
     * Field to apply the aggregation to.
     */
   def fieldName: String
+
+  def concreteFieldName = if (fieldName == "*") "value" else fieldName
 }
 
 /**

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -123,7 +123,11 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
         distinctPrimaryAggregations
           .collectFirst {
             case aggregation: CountDistinctAggregation =>
-              Try(index.uniqueValues(query, schema, groupField, aggregation.fieldName).flatMap(_.uniqueValues).toSet)
+              Try(
+                index
+                  .uniqueValues(query, schema, groupField, aggregation.concreteFieldName)
+                  .flatMap(_.uniqueValues)
+                  .toSet)
           }
           .getOrElse(Success(Set.empty[NSDbType]))
       }
@@ -216,7 +220,7 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
                                   _,
                                   _)) =>
           handleNoIndexResults(
-            Try(index.uniqueValues(q, schema, groupField, aggregation.fieldName))
+            Try(index.uniqueValues(q, schema, groupField, aggregation.concreteFieldName))
           )
         case Right(
             ParsedAggregatedQuery(_, _, q, InternalStandardAggregation(groupField, _: SumAggregation), _, limit)) =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -381,11 +381,11 @@ package object post_proc {
 
     val uniqueValues = rawResults.foldLeft(Set.empty[NSDbType])((acc, b2) => acc ++ b2.uniqueValues)
 
-    //only one count distinct is allowed. This has been checked previously in the flow
+    //only one count distinct is allowed. This has been previously checked by the semantic parser.
     val allAggregationReduced = aggregations.find(_.isInstanceOf[CountDistinctAggregation]) match {
       case Some(aggregation) if finalStep =>
         aggregationsReduced + (s"count(distinct ${aggregation.fieldName})" -> NSDbLongType(uniqueValues.size))
-      case None => aggregationsReduced
+      case _ => aggregationsReduced
     }
 
     val finalUniqueValues = if (finalStep) Set.empty[NSDbType] else uniqueValues

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryParserApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryParserApiSpec.scala
@@ -157,7 +157,7 @@ class QueryParserApiSpec extends NSDbSpec with ScalatestRouteTest {
           |        "name" : "*",
           |        "aggregation" : {
           |          "aggregation" : "count",
-          |          "aggregationField" : "value"
+          |          "aggregationField" : "*"
           |        }
           |      } ]
           |    },
@@ -228,7 +228,7 @@ class QueryParserApiSpec extends NSDbSpec with ScalatestRouteTest {
           |        "name" : "*",
           |        "aggregation" : {
           |          "aggregation" : "count",
-          |          "aggregationField" : "value"
+          |          "aggregationField" : "*"
           |        }
           |      } ]
           |    },
@@ -249,7 +249,7 @@ class QueryParserApiSpec extends NSDbSpec with ScalatestRouteTest {
 
     "correctly query the db with a simple count aggregation query and return the parsed query" in {
       val q =
-        QueryBody("db", "namespace", "metric", "select count(*) from metric limit 1", None, None, None, Some(true))
+        QueryBody("db", "namespace", "metric", "select count(value) from metric limit 1", None, None, None, Some(true))
 
       Post("/query", q) ~> testRoutes ~> check {
         status shouldBe OK

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryParserApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryParserApiSpec.scala
@@ -101,7 +101,7 @@ class QueryParserApiSpec extends NSDbSpec with ScalatestRouteTest {
           |        "name" : "*",
           |        "aggregation" : {
           |          "aggregation" : "count",
-          |          "aggregationField" : "value"
+          |          "aggregationField" : "*"
           |        }
           |      } ]
           |    }
@@ -286,7 +286,7 @@ class QueryParserApiSpec extends NSDbSpec with ScalatestRouteTest {
           |    "distinct" : false,
           |    "fields" : {
           |      "fields" : [ {
-          |        "name" : "*",
+          |        "name" : "value",
           |        "aggregation" : {
           |          "aggregation" : "count",
           |          "aggregationField" : "value"
@@ -1059,7 +1059,7 @@ class QueryParserApiSpec extends NSDbSpec with ScalatestRouteTest {
           |        "name" : "*",
           |        "aggregation" : {
           |          "aggregation" : "count",
-          |          "aggregationField" : "value"
+          |          "aggregationField" : "*"
           |        }
           |      } ]
           |    },
@@ -1153,7 +1153,7 @@ class QueryParserApiSpec extends NSDbSpec with ScalatestRouteTest {
           |        "name" : "*",
           |        "aggregation" : {
           |          "aggregation" : "count",
-          |          "aggregationField" : "value"
+          |          "aggregationField" : "*"
           |        }
           |      } ]
           |    },

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/GlobalAggregationReadCoordinatorSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/GlobalAggregationReadCoordinatorSpec.scala
@@ -140,7 +140,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
 
         assert(readRes.reason == "")
         assert(readRes.records.size == 1)
-        assert(readRes.records.map(_.asBit) == Seq(Bit(0, 0L, Map.empty, Map("count(distinct *)" -> 3L))))
+        assert(readRes.records.map(_.asBit) == Seq(Bit(0, 0L, Map.empty, Map("count(distinct height)" -> 3L))))
       }
     }
   }

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -126,9 +126,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
   }
   private val aggField
     : Parser[Field] = ((sum | min | max | count | first | last | avg) <~ OpenRoundBracket) ~ (Distinct ?) ~ (standardString | All) <~ CloseRoundBracket ^? ({
-    case CountAggregation ~ Some(_) ~ "*"  => Field("*", Some(CountDistinctAggregation("value")))
     case CountAggregation ~ Some(_) ~ name => Field(name, Some(CountDistinctAggregation(name)))
-    case aggregation ~ None ~ "*"          => Field("*", Some(aggregation("value")))
     case aggregation ~ None ~ name         => Field(name, Some(aggregation(name)))
   }, _ => "Distinct clause is only applicable to the count aggregation")
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
@@ -53,7 +53,7 @@ class AggregationSQLStatementSpec extends NSDbSpec {
               namespace = "registry",
               metric = "people",
               distinct = false,
-              fields = ListFields(List(Field("value", Some(MaxAggregation("value"))))),
+              fields = ListFields(List(Field("*", Some(AvgAggregation("*"))))),
               groupBy = None
             )
           ))
@@ -69,7 +69,11 @@ class AggregationSQLStatementSpec extends NSDbSpec {
               namespace = "registry",
               metric = "people",
               distinct = false,
-              fields = ListFields(List(Field("value", Some(MinAggregation("value"))))),
+              fields = ListFields(List(Field("*", Some(AvgAggregation("*"))))),
+              condition = Some(
+                Condition(RangeExpression(dimension = "timestamp",
+                                          value1 = AbsoluteComparisonValue(2L),
+                                          value2 = AbsoluteComparisonValue(4L)))),
               groupBy = None
             )
           ))
@@ -101,13 +105,8 @@ class AggregationSQLStatementSpec extends NSDbSpec {
               namespace = "registry",
               metric = "people",
               distinct = false,
-              fields = ListFields(List(
-                Field("*", Some(CountAggregation("value"))),
-                Field("*", Some(AvgAggregation("value"))),
-                Field("*", Some(MinAggregation("value"))),
-                Field("*", Some(MaxAggregation("value"))),
-                Field("*", Some(SumAggregation("value")))
-              )),
+              fields = ListFields(
+                List(Field("*", Some(CountAggregation("*"))), Field("value", Some(MinAggregation("value"))))),
               condition = Some(
                 Condition(RangeExpression(dimension = "timestamp",
                                           value1 = AbsoluteComparisonValue(2L),
@@ -144,7 +143,7 @@ class AggregationSQLStatementSpec extends NSDbSpec {
               namespace = "registry",
               metric = "people",
               distinct = false,
-              fields = ListFields(List(Field("*", Some(SumAggregation("value"))))),
+              fields = ListFields(List(Field("*", Some(SumAggregation("*"))))),
               groupBy = Some(SimpleGroupByAggregation("name"))
             )
           ))
@@ -159,7 +158,7 @@ class AggregationSQLStatementSpec extends NSDbSpec {
               namespace = "registry",
               metric = "people",
               distinct = false,
-              fields = ListFields(List(Field("*", Some(CountAggregation("value"))))),
+              fields = ListFields(List(Field("*", Some(CountAggregation("*"))))),
               groupBy = Some(SimpleGroupByAggregation("name"))
             )
           ))
@@ -189,7 +188,7 @@ class AggregationSQLStatementSpec extends NSDbSpec {
               namespace = "registry",
               metric = "people",
               distinct = false,
-              fields = ListFields(List(Field("*", Some(MinAggregation("value"))))),
+              fields = ListFields(List(Field("*", Some(MinAggregation("*"))))),
               groupBy = Some(SimpleGroupByAggregation("name"))
             )
           ))
@@ -204,7 +203,7 @@ class AggregationSQLStatementSpec extends NSDbSpec {
               namespace = "registry",
               metric = "people",
               distinct = false,
-              fields = ListFields(List(Field("*", Some(AvgAggregation("value"))))),
+              fields = ListFields(List(Field("*", Some(AvgAggregation("*"))))),
               groupBy = Some(SimpleGroupByAggregation("name"))
             )
           ))
@@ -227,7 +226,7 @@ class AggregationSQLStatementSpec extends NSDbSpec {
             )
           ))
       }
-      "parse it successfully in case of count(*)" in {
+      "parse it successfully in case of count distinct " in {
         val query = "SELECT count( distinct *) FROM people group by name"
         parser.parse(db = "db", namespace = "registry", input = query) should be(
           SqlStatementParserSuccess(
@@ -237,7 +236,7 @@ class AggregationSQLStatementSpec extends NSDbSpec {
               namespace = "registry",
               metric = "people",
               distinct = false,
-              fields = ListFields(List(Field("*", Some(CountDistinctAggregation("value"))))),
+              fields = ListFields(List(Field("*", Some(CountDistinctAggregation("*"))))),
               groupBy = Some(SimpleGroupByAggregation("name"))
             )
           ))
@@ -510,7 +509,7 @@ class AggregationSQLStatementSpec extends NSDbSpec {
                                                    value = AbsoluteComparisonValue(100L)),
                 operator = AndOperator
               ))),
-              fields = ListFields(List(Field("*", Some(CountAggregation("value"))))),
+              fields = ListFields(List(Field("*", Some(CountAggregation("*"))))),
               groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, "D"))
             )
           ))
@@ -535,14 +534,14 @@ class AggregationSQLStatementSpec extends NSDbSpec {
                                                    value = AbsoluteComparisonValue(100L)),
                 operator = AndOperator
               ))),
-              fields = ListFields(List(Field("*", Some(CountAggregation("value"))))),
+              fields = ListFields(List(Field("*", Some(CountAggregation("*"))))),
               groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, "D"))
             )
           ))
       }
 
       "parse it successfully if an aggregation different from count is provided " in {
-        val query = "SELECT sum(*) FROM people WHERE timestamp > 1 and timestamp < 100 group by interval 2d"
+        val query = "SELECT sum(value) FROM people WHERE timestamp > 1 and timestamp < 100 group by interval 2d"
         parser.parse(db = "db", namespace = "registry", input = query) should be(
           SqlStatementParserSuccess(
             query,
@@ -560,7 +559,7 @@ class AggregationSQLStatementSpec extends NSDbSpec {
                                                    value = AbsoluteComparisonValue(100L)),
                 operator = AndOperator
               ))),
-              fields = ListFields(List(Field("*", Some(SumAggregation("value"))))),
+              fields = ListFields(List(Field("value", Some(SumAggregation("value"))))),
               groupBy = Some(TemporalGroupByAggregation(2 * 24 * 3600 * 1000, 2, "D"))
             )
           ))
@@ -585,7 +584,7 @@ class AggregationSQLStatementSpec extends NSDbSpec {
                                                    value = AbsoluteComparisonValue(100L)),
                 operator = AndOperator
               ))),
-              fields = ListFields(List(Field("*", Some(AvgAggregation("value"))))),
+              fields = ListFields(List(Field("*", Some(AvgAggregation("*"))))),
               groupBy = Some(TemporalGroupByAggregation(4 * 24 * 3600 * 1000, 4, "D"))
             )
           ))

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
@@ -136,7 +136,7 @@ class SelectSQLStatementSpec extends NSDbSpec {
                                namespace = "registry",
                                metric = "people",
                                distinct = false,
-                               fields = ListFields(List(Field("*", Some(CountAggregation("value"))))))
+                               fields = ListFields(List(Field("*", Some(CountAggregation("*"))))))
           )
         )
       }
@@ -184,7 +184,7 @@ class SelectSQLStatementSpec extends NSDbSpec {
               metric = "people",
               distinct = false,
               fields = ListFields(
-                List(Field("*", Some(CountAggregation("value"))),
+                List(Field("*", Some(CountAggregation("*"))),
                      Field("surname", None),
                      Field("creationDate", Some(SumAggregation("creationDate")))))
             )


### PR DESCRIPTION
In global queries, it's possible to specify a count distinct aggregation on the value or on a tag. While the aggregation result is always correct,  the label returned is always `count (distinct *)` regardless of the tag used for the aggregation. 

Aim of this PR is to fix this behaviour by making the count distinct label parametric.

e.g. 
```
select count(distinct *) from metric ->  Bit(0,0,count(distinct *) -> 5
select count(distinct tag) from metric ->  Bit(0,0,count(distinct tag) -> 3
```