### PR TITLE
Enable scala 2.13 in APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,6 @@ jobs:
       after_success:
         - bash <(curl -s https://codecov.io/bash)
     - stage: "Image Creation Test"
-      script: sbt docker:publishLocal
+      script: sbt +publishLocal docker:publishLocal
     - stage: "push"
-      script: $TRAVIS_BUILD_DIR/travis-credentials.sh && sbt publish && docker login -u $DOCKER_USER -p $DOCKER_PASSWORD && sbt docker:publish
+      script: $TRAVIS_BUILD_DIR/travis-credentials.sh && sbt +publish && docker login -u $DOCKER_USER -p $DOCKER_PASSWORD && sbt docker:publish

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ addCommandAlias("dist", "packageDist")
 addCommandAlias("deb", "packageDeb")
 addCommandAlias("rpm", "packageRpm")
 lazy val `nsdb-common` = project
-  .settings(Commons.settings: _*)
+  .settings(Commons.crossScalaVersionSettings: _*)
   .settings(PublishSettings.settings: _*)
   .enablePlugins(AutomateHeaderPlugin)
   .enablePlugins(BuildInfoPlugin)
@@ -73,7 +73,7 @@ lazy val `nsdb-http` = project
   .settings(libraryDependencies ++= Dependencies.Http.libraries)
   .dependsOn(`nsdb-core` % "compile->compile;test->test", `nsdb-sql`, `nsdb-security`)
 lazy val `nsdb-rpc` = project
-  .settings(Commons.settings: _*)
+  .settings(Commons.crossScalaVersionSettings: _*)
   .settings(PublishSettings.settings: _*)
   .settings(libraryDependencies ++= Dependencies.RPC.libraries)
   .settings(coverageExcludedPackages := "io\\.radicalbit\\.nsdb.*")
@@ -207,7 +207,7 @@ lazy val `nsdb-security` = project
   .settings(LicenseHeader.settings: _*)
   .dependsOn(`nsdb-common`)
 lazy val `nsdb-sql` = project
-  .settings(Commons.settings: _*)
+  .settings(Commons.crossScalaVersionSettings: _*)
   .settings(PublishSettings.settings: _*)
   .settings(libraryDependencies ++= Dependencies.SQL.libraries)
   .enablePlugins(AutomateHeaderPlugin)
@@ -222,7 +222,7 @@ lazy val `nsdb-java-api` = project
   .settings(LicenseHeader.settings: _*)
   .dependsOn(`nsdb-rpc`)
 lazy val `nsdb-scala-api` = project
-  .settings(Commons.settings: _*)
+  .settings(Commons.crossScalaVersionSettings: _*)
   .settings(PublishSettings.settings: _*)
   .settings(libraryDependencies ++= Dependencies.ScalaAPI.libraries)
   .enablePlugins(AutomateHeaderPlugin)

--- a/project/Commons.scala
+++ b/project/Commons.scala
@@ -23,7 +23,7 @@ import scalafix.sbt.ScalafixPlugin.autoImport.scalafixSemanticdb
 
 object Commons {
 
-  val scalaVer = "2.12.7"
+  val scalaVer = "2.12.12"
 
   val settings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := scalaVer,
@@ -37,8 +37,7 @@ object Commons {
       "-language:implicitConversions",
       "-language:higherKinds",
       "-language:existentials",
-      "-language:postfixOps",
-      "-Ypartial-unification"
+      "-language:postfixOps"
     ),
     organization := "io.radicalbit.nsdb",
     resolvers ++= Seq(
@@ -61,4 +60,6 @@ object Commons {
         oldStrategy(x)
     }
   )
+
+  val crossScalaVersionSettings = settings :+ (crossScalaVersions := Seq("2.12.12", "2.13.3"))
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ import sbt._
 object Dependencies {
 
   object scalaLang {
-    lazy val version   = "2.12.7"
+    lazy val version   = "2.12.12"
     lazy val namespace = "org.scala-lang"
     lazy val compiler = namespace % "scala-compiler" % version excludeAll (ExclusionRule(organization =
                                                                                            "org.scala-lang.modules",
@@ -27,27 +27,27 @@ object Dependencies {
   }
 
   object scalaModules {
-    lazy val version           = "1.1.1"
+    lazy val version           = "1.1.2"
     lazy val namespace         = "org.scala-lang.modules"
     lazy val parserCombinators = namespace %% "scala-parser-combinators" % version
 
-    lazy val java8Compatibility = namespace %% "scala-java8-compat" % "0.9.0"
+    lazy val java8Compatibility = namespace %% "scala-java8-compat" % "0.9.1"
   }
 
   object scopt {
-    lazy val version   = "3.7.0"
+    lazy val version   = "3.7.1"
     lazy val namespace = "com.github.scopt"
     val scopt          = namespace %% "scopt" % version
   }
 
   object cats {
-    lazy val version   = "1.6.1"
+    lazy val version   = "2.0.0"
     lazy val namespace = "org.typelevel"
     lazy val cats_core      = namespace %% "cats-core" % version
   }
 
   object spire {
-    lazy val version   = "0.16.2"
+    lazy val version   = "0.17.0"
     lazy val namespace = "org.typelevel"
     lazy val spire     = namespace %% "spire" % version
   }
@@ -85,7 +85,7 @@ object Dependencies {
   }
 
   object scala_logging {
-    val scala_logging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0"
+    val scala_logging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
   }
 
   object logback {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,6 @@ addSbtPlugin("de.heikoseeberger"                 % "sbt-header"          % "5.1.
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-multi-jvm"       % "0.4.0")
 addSbtPlugin("io.gatling"                        % "gatling-sbt"         % "3.0.0")
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-native-packager" % "1.3.2")
-addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"        % "0.9.4")
+addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"        % "0.9.21")
 addSbtPlugin("io.kamon"                          % "sbt-kanela-runner"   % "2.0.3")
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"       % "0.9.0")


### PR DESCRIPTION
This PR enables cross scala version (2.12 - 2.13) for scala APIs and all the dependant modules.
The other modules won't be affected by this modification.

Many dependencies are updated in order to support the newer scala version and the build has been updated in order to cross-publish the artifacts