### PR TITLE
Update scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ lazy val `nsdb-core` = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(LicenseHeader.settings: _*)
   .settings(libraryDependencies ++= Dependencies.Core.libraries)
-  .dependsOn(`nsdb-common`)
+  .dependsOn(`nsdb-common` % "compile->compile;test->test")
 lazy val `nsdb-http` = project
   .settings(Commons.settings: _*)
   .settings(PublishSettings.dontPublish: _*)
@@ -212,7 +212,7 @@ lazy val `nsdb-sql` = project
   .settings(libraryDependencies ++= Dependencies.SQL.libraries)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(LicenseHeader.settings: _*)
-  .dependsOn(`nsdb-common`)
+  .dependsOn(`nsdb-common` % "compile->compile;test->test")
 lazy val `nsdb-java-api` = project
   .settings(Commons.settings: _*)
   .settings(crossPaths := false)

--- a/build.sbt
+++ b/build.sbt
@@ -237,6 +237,7 @@ lazy val `nsdb-cli` = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(LicenseHeader.settings: _*)
   .dependsOn(`nsdb-rpc`)
+  .dependsOn(`nsdb-common` % "compile->compile;test->test")
 lazy val `nsdb-perf` = (project in file("nsdb-perf"))
   .settings(Commons.settings: _*)
   .settings(PublishSettings.dontPublish: _*)

--- a/nsdb-cli/src/test/scala/io/radicalbit/nsdb/cli/ASCIITableBuilderSpec.scala
+++ b/nsdb-cli/src/test/scala/io/radicalbit/nsdb/cli/ASCIITableBuilderSpec.scala
@@ -18,12 +18,11 @@ package io.radicalbit.nsdb.cli
 
 import io.radicalbit.nsdb.cli.table.ASCIITableBuilder
 import io.radicalbit.nsdb.common.protocol.{Bit, SQLStatementExecuted}
-import org.scalatest.matchers.should
-import org.scalatest.wordspec.AnyWordSpec
+import io.radicalbit.nsdb.test.NSDbSpec
 
 import scala.util.Success
 
-class ASCIITableBuilderSpec extends AnyWordSpec with should.Matchers {
+class ASCIITableBuilderSpec extends NSDbSpec {
 
   def statementFor(res: Seq[Bit]) = SQLStatementExecuted(db = "db", namespace = "registry", metric = "people", res)
 

--- a/nsdb-cli/src/test/scala/io/radicalbit/nsdb/cli/ASCIITableBuilderSpec.scala
+++ b/nsdb-cli/src/test/scala/io/radicalbit/nsdb/cli/ASCIITableBuilderSpec.scala
@@ -18,11 +18,12 @@ package io.radicalbit.nsdb.cli
 
 import io.radicalbit.nsdb.cli.table.ASCIITableBuilder
 import io.radicalbit.nsdb.common.protocol.{Bit, SQLStatementExecuted}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.util.Success
 
-class ASCIITableBuilderSpec extends WordSpec with Matchers {
+class ASCIITableBuilderSpec extends AnyWordSpec with should.Matchers {
 
   def statementFor(res: Seq[Bit]) = SQLStatementExecuted(db = "db", namespace = "registry", metric = "people", res)
 

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/STMultiNodeSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/STMultiNodeSpec.scala
@@ -2,14 +2,14 @@ package io.radicalbit.nsdb
 
 import akka.cluster.Cluster
 import akka.remote.testconductor.RoleName
-import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
-import org.scalatest.Matchers
 import akka.remote.testkit.{MultiNodeSpec, MultiNodeSpecCallbacks}
+import io.radicalbit.nsdb.test.NSDbSpecLike
+import org.scalatest.BeforeAndAfterAll
 
 /**
   * Hooks up MultiNodeSpec with ScalaTest
   */
-trait STMultiNodeSpec extends MultiNodeSpecCallbacks with WordSpecLike with Matchers with BeforeAndAfterAll { this: MultiNodeSpec =>
+trait STMultiNodeSpec extends MultiNodeSpecCallbacks with NSDbSpecLike with BeforeAndAfterAll { this: MultiNodeSpec =>
 
   protected lazy val cluster: Cluster = Cluster(system)
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/actor/MetricsDataActorSpec.scala
@@ -28,7 +28,8 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
-import org.scalatest.{BeforeAndAfter, FlatSpecLike, Matchers}
+import io.radicalbit.nsdb.test.NSDbFlatSpecLike
+import org.scalatest.BeforeAndAfter
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -36,8 +37,7 @@ import scala.concurrent.duration._
 class MetricsDataActorSpec()
     extends TestKit(ActorSystem("metricsDataActorSpec"))
     with ImplicitSender
-    with FlatSpecLike
-    with Matchers
+    with NSDbFlatSpecLike
     with BeforeAndAfter {
 
   val probe      = TestProbe()

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
@@ -28,9 +28,8 @@ import io.radicalbit.nsdb.cluster.coordinator.mockedData.MockedData._
 import io.radicalbit.nsdb.cluster.logic.LocalityReadNodesSelection
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
+import io.radicalbit.nsdb.test.NSDbSpecLike
 import org.scalatest._
-import org.scalatest.matchers.should
-import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.Await
 
@@ -45,8 +44,7 @@ abstract class AbstractReadCoordinatorSpec
           .withValue("akka.log-dead-letters-during-shutdown", ConfigValueFactory.fromAnyRef("off"))
       ))
     with ImplicitSender
-    with AnyWordSpecLike
-    with should.Matchers
+    with NSDbSpecLike
     with BeforeAndAfterAll
     with WriteInterval {
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
@@ -29,6 +29,8 @@ import io.radicalbit.nsdb.cluster.logic.LocalityReadNodesSelection
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import org.scalatest._
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.Await
 
@@ -43,8 +45,8 @@ abstract class AbstractReadCoordinatorSpec
           .withValue("akka.log-dead-letters-during-shutdown", ConfigValueFactory.fromAnyRef("off"))
       ))
     with ImplicitSender
-    with WordSpecLike
-    with Matchers
+    with AnyWordSpecLike
+    with should.Matchers
     with BeforeAndAfterAll
     with WriteInterval {
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/CommitLogCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/CommitLogCoordinatorSpec.scala
@@ -25,15 +25,15 @@ import io.radicalbit.nsdb.commit_log.CommitLogWriterActor._
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement.{AbsoluteComparisonValue, Condition, DeleteSQLStatement, RangeExpression}
 import io.radicalbit.nsdb.model.Location
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import io.radicalbit.nsdb.test.NSDbSpecLike
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.duration._
 
 class CommitLogCoordinatorSpec
     extends TestKit(ActorSystem("CommitLogCoordinatorSpec"))
     with ImplicitSender
-    with WordSpecLike
-    with Matchers
+    with NSDbSpecLike
     with BeforeAndAfterAll {
 
   private val commitLogCoordinatorActor = system actorOf Props[CommitLogCoordinator]

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -33,6 +33,7 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.MetricInfoGot
+import io.radicalbit.nsdb.test.NSDbSpecLike
 import org.scalatest._
 
 import scala.concurrent.Await
@@ -49,8 +50,7 @@ class MetadataCoordinatorSpec
           .withValue("nsdb.sharding.interval", ConfigValueFactory.fromAnyRef("60s"))
       ))
     with ImplicitSender
-    with WordSpecLike
-    with Matchers
+    with NSDbSpecLike
     with BeforeAndAfterEach
     with BeforeAndAfterAll {
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
@@ -37,6 +37,7 @@ import io.radicalbit.nsdb.common.protocol._
 import io.radicalbit.nsdb.common.statement.{AscOrderOperator, ListFields, SelectSQLStatement}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{InputMapped, SelectStatementExecuted}
+import io.radicalbit.nsdb.test.NSDbSpecLike
 import org.scalatest._
 
 import scala.concurrent.Await
@@ -55,8 +56,7 @@ class RetentionSpec
           .withValue("nsdb.retention.check.interval", ConfigValueFactory.fromAnyRef("50ms"))
       ))
     with ImplicitSender
-    with WordSpecLike
-    with Matchers
+    with NSDbSpecLike
     with BeforeAndAfterAll
     with WriteInterval {
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/SchemaCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/SchemaCoordinatorSpec.scala
@@ -24,6 +24,7 @@ import io.radicalbit.nsdb.common.protocol._
 import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
+import io.radicalbit.nsdb.test.NSDbFlatSpecLike
 import org.scalatest._
 
 import scala.concurrent.Await
@@ -32,8 +33,7 @@ import scala.concurrent.duration._
 class SchemaCoordinatorSpec
     extends TestKit(ActorSystem("SchemaCoordinatorSpec"))
     with ImplicitSender
-    with FlatSpecLike
-    with Matchers
+    with NSDbFlatSpecLike
     with OneInstancePerTest
     with BeforeAndAfter {
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -36,7 +36,7 @@ import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
-import org.scalatest.{Matchers, _}
+import io.radicalbit.nsdb.test.NSDbSpecLike
 
 import scala.concurrent.duration._
 
@@ -55,7 +55,7 @@ class FakeReadCoordinatorActor extends Actor {
   }
 }
 
-trait WriteCoordinatorBehaviour { this: TestKit with WordSpecLike with Matchers =>
+trait WriteCoordinatorBehaviour { this: TestKit with NSDbSpecLike =>
 
   val probe = TestProbe()
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
@@ -33,7 +33,8 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.RecordRejected
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Matchers, WordSpecLike}
+import io.radicalbit.nsdb.test.NSDbSpecLike
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import scala.collection.mutable
 import scala.concurrent.Await
@@ -65,8 +66,7 @@ class WriteCoordinatorErrorsSpec
           .withValue("nsdb.sharding.interval", ConfigValueFactory.fromAnyRef("5s"))
       ))
     with ImplicitSender
-    with WordSpecLike
-    with Matchers
+    with NSDbSpecLike
     with BeforeAndAfter
     with BeforeAndAfterAll {
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
@@ -22,6 +22,7 @@ import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
+import io.radicalbit.nsdb.test.NSDbSpecLike
 import org.scalatest._
 
 import scala.concurrent.Await
@@ -36,8 +37,7 @@ class WriteCoordinatorSpec
           .withValue("nsdb.sharding.interval", ConfigValueFactory.fromAnyRef("5s"))
       ))
     with ImplicitSender
-    with WordSpecLike
-    with Matchers
+    with NSDbSpecLike
     with BeforeAndAfter
     with BeforeAndAfterAll
     with WriteCoordinatorBehaviour {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/index/LocationIndexTest.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/index/LocationIndexTest.scala
@@ -22,11 +22,12 @@ import java.util.UUID
 import io.radicalbit.nsdb.index.StorageStrategy.Memory
 import io.radicalbit.nsdb.index.{DirectorySupport, StorageStrategy}
 import io.radicalbit.nsdb.model.Location
+import io.radicalbit.nsdb.test.NSDbFlatSpec
 import org.apache.lucene.analysis.standard.StandardAnalyzer
 import org.apache.lucene.index.{IndexWriter, IndexWriterConfig}
-import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
 
-class LocationIndexTest extends FlatSpec with Matchers with OneInstancePerTest with DirectorySupport {
+class LocationIndexTest extends NSDbFlatSpec with OneInstancePerTest with DirectorySupport {
 
   override def indexStorageStrategy: StorageStrategy = Memory
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndexTest.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/index/MetricInfoIndexTest.scala
@@ -22,9 +22,10 @@ import java.util.UUID
 import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.index.StorageStrategy.Memory
 import io.radicalbit.nsdb.index.{DirectorySupport, StorageStrategy}
-import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
+import io.radicalbit.nsdb.test.NSDbFlatSpec
+import org.scalatest.OneInstancePerTest
 
-class MetricInfoIndexTest extends FlatSpec with Matchers with OneInstancePerTest with DirectorySupport {
+class MetricInfoIndexTest extends NSDbFlatSpec with OneInstancePerTest with DirectorySupport {
 
   override def indexStorageStrategy: StorageStrategy = Memory
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/logic/CapacityWriteNodesSelectionLogicSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/logic/CapacityWriteNodesSelectionLogicSpec.scala
@@ -19,12 +19,12 @@ package io.radicalbit.nsdb.cluster.logic
 import akka.cluster.metrics._
 import akka.actor.Address
 import io.radicalbit.nsdb.cluster.metrics.{DiskMetricsSelector, NSDbMixMetricSelector}
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
 /**
   * only the disk metric selector is tested because the other selectors have been already accurately tested inside the akka project.
   */
-class CapacityWriteNodesSelectionLogicSpec extends WordSpec with Matchers {
+class CapacityWriteNodesSelectionLogicSpec extends NSDbSpec {
 
   def akkaClusterMetric: Set[Metric] =
     Set(

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelectionSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelectionSpec.scala
@@ -17,9 +17,9 @@
 package io.radicalbit.nsdb.cluster.logic
 
 import io.radicalbit.nsdb.model.Location
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class LocalityReadNodesSelectionSpec extends WordSpec with Matchers {
+class LocalityReadNodesSelectionSpec extends NSDbSpec {
 
   val localityReadNodesSelection = new LocalityReadNodesSelection("this")
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/metrics/DiskMetricsSelectorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/metrics/DiskMetricsSelectorSpec.scala
@@ -22,10 +22,10 @@ import akka.actor.Address
 import akka.cluster.metrics.StandardMetrics._
 import akka.cluster.metrics.{Metric, NodeMetrics}
 import io.radicalbit.nsdb.cluster.metrics.NSDbMetrics._
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 import org.scalatest.OptionValues._
 
-class DiskMetricsSelectorSpec extends WordSpec with Matchers {
+class DiskMetricsSelectorSpec extends NSDbSpec {
 
   val emptyNode      = Address("nsdb", "NSDb", "emptyNode", 2552)
   val almostFullNode = Address("nsdb", "NSDb", "node1", 2552)

--- a/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbConfigProviderSpec.scala
+++ b/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbConfigProviderSpec.scala
@@ -19,9 +19,10 @@ package io.radicalbit.nsdb.common.configuration
 import com.typesafe.config.{Config, ConfigFactory}
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel._
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.LowLevel._
-import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
+import io.radicalbit.nsdb.test._
+import org.scalatest.OneInstancePerTest
 
-class NSDbConfigProviderSpec extends WordSpec with Matchers with OneInstancePerTest with NSDbConfigProvider {
+class NSDbConfigProviderSpec extends NSDbSpec with OneInstancePerTest with NSDbConfigProvider {
 
   override def userDefinedConfig: Config      = ConfigFactory.parseResources("nsdb-test.conf").resolve()
   override def lowLevelTemplateConfig: Config = ConfigFactory.parseResources("application-test.conf")

--- a/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbNumericTypeSpec.scala
+++ b/nsdb-common/src/test/scala/io/radicalbit/nsdb/common/configuration/NSDbNumericTypeSpec.scala
@@ -19,9 +19,9 @@ package io.radicalbit.nsdb.common.configuration
 import java.math.{MathContext, RoundingMode}
 
 import io.radicalbit.nsdb.common.NSDbNumericType
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class NSDbNumericTypeSpec extends WordSpec with Matchers {
+class NSDbNumericTypeSpec extends NSDbSpec {
 
   implicit val mathContext: MathContext = new MathContext(10, RoundingMode.HALF_UP)
 

--- a/nsdb-common/src/test/scala/io/radicalbit/nsdb/test/NSdbSpecLike.scala
+++ b/nsdb-common/src/test/scala/io/radicalbit/nsdb/test/NSdbSpecLike.scala
@@ -14,23 +14,16 @@
  * limitations under the License.
  */
 
-package io.radicalbit.nsdb.actors
+package io.radicalbit.nsdb.test
 
-import akka.actor.ActorSystem
-import akka.testkit.{ImplicitSender, TestKit}
-import io.radicalbit.nsdb.test.NSDbSpecLike
-import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.{AnyFlatSpec, AnyFlatSpecLike}
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.{AnyWordSpec, AnyWordSpecLike}
 
-class JournalServiceSpec
-    extends TestKit(ActorSystem("nsdb-test"))
-    with ImplicitSender
-    with NSDbSpecLike
-    with BeforeAndAfterAll {
+trait NSDbSpecLike extends AnyWordSpecLike with should.Matchers
 
-  "A partition" when {
-    "inserted" should {
-      "be saved correctly" in {}
-    }
-  }
+trait NSDbFlatSpec extends AnyFlatSpec with should.Matchers
 
-}
+trait NSDbFlatSpecLike extends AnyFlatSpecLike with should.Matchers
+
+trait NSDbSpec extends AnyWordSpec with should.Matchers

--- a/nsdb-common/src/test/scala/io/radicalbit/nsdb/test/NSdbSpecLike.scala
+++ b/nsdb-common/src/test/scala/io/radicalbit/nsdb/test/NSdbSpecLike.scala
@@ -20,10 +20,22 @@ import org.scalatest.flatspec.{AnyFlatSpec, AnyFlatSpecLike}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.{AnyWordSpec, AnyWordSpecLike}
 
+/**
+  * Mix-in scalatest [[AnyWordSpecLike]] with should matchers
+  */
 trait NSDbSpecLike extends AnyWordSpecLike with should.Matchers
 
+/**
+  * Mix-in scalatest [[AnyFlatSpec]] with should matchers
+  */
 trait NSDbFlatSpec extends AnyFlatSpec with should.Matchers
 
+/**
+  * Mix-in scalatest [[AnyFlatSpecLike]] with should matchers
+  */
 trait NSDbFlatSpecLike extends AnyFlatSpecLike with should.Matchers
 
+/**
+  * Mix-in scalatest [[AnyWordSpec]] with should matchers
+  */
 trait NSDbSpec extends AnyWordSpec with should.Matchers

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParserErrors.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/statement/StatementParserErrors.scala
@@ -32,8 +32,8 @@ object StatementParserErrors {
   lazy val MULTIPLE_COUNT_AGGREGATIONS = "Only one Count and one Count Distinct is allowed"
   lazy val SORT_DIMENSION_NOT_IN_GROUP =
     "cannot sort group by query result by a field not in group by clause"
-  lazy val GRACE_PERIOD_NOT_ALLOWED           = "grace period clause is allowed only in temporal group by queries"
-  def notExistingField(field: String)       = s"field $field does not exist"
+  lazy val GRACE_PERIOD_NOT_ALLOWED          = "grace period clause is allowed only in temporal group by queries"
+  def notExistingField(field: String)        = s"field $field does not exist"
   def notExistingFields(fields: Seq[String]) = s"field [${fields.mkString(",")}] does not exist"
   def nonCompatibleOperator(operator: String, dimTypeAllowed: String) =
     s"cannot use $operator operator on dimension different from $dimTypeAllowed"

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
@@ -28,7 +28,8 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.{Location, Schema}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
-import org.scalatest.{BeforeAndAfter, FlatSpecLike, Matchers}
+import io.radicalbit.nsdb.test.NSDbFlatSpecLike
+import org.scalatest.BeforeAndAfter
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -36,8 +37,7 @@ import scala.concurrent.duration._
 class MetricAccumulatorActorSpec()
     extends TestKit(ActorSystem("metricAccumulatorSpec"))
     with ImplicitSender
-    with FlatSpecLike
-    with Matchers
+    with NSDbFlatSpecLike
     with BeforeAndAfter {
 
   val probe      = TestProbe()

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricPerformerActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricPerformerActorSpec.scala
@@ -28,8 +28,9 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.exception.InvalidLocationsInNode
 import io.radicalbit.nsdb.index.BrokenTimeSeriesIndex
 import io.radicalbit.nsdb.model.Location
+import io.radicalbit.nsdb.test.NSDbFlatSpecLike
 import org.apache.lucene.store.MMapDirectory
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
@@ -56,8 +57,7 @@ class TestSupervisorActor(probe: ActorRef) extends Actor with ActorLogging {
 class MetricPerformerActorSpec
     extends TestKit(ActorSystem("IndexerActorSpec"))
     with ImplicitSender
-    with FlatSpecLike
-    with Matchers
+    with NSDbFlatSpecLike
     with BeforeAndAfterAll {
 
   val probe      = TestProbe()

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -25,6 +25,7 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.model.{Schema, TimeContext}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
+import io.radicalbit.nsdb.test.NSDbSpecLike
 import org.scalatest._
 
 import scala.concurrent.duration._
@@ -32,8 +33,7 @@ import scala.concurrent.duration._
 class PublisherActorSpec
     extends TestKit(ActorSystem("PublisherActorSpec"))
     with ImplicitSender
-    with WordSpecLike
-    with Matchers
+    with NSDbSpecLike
     with OneInstancePerTest
     with BeforeAndAfter {
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/CommitLogFileSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/CommitLogFileSpec.scala
@@ -18,9 +18,10 @@ package io.radicalbit.nsdb.commit_log
 import java.io.{File, FileOutputStream}
 import java.util.UUID
 
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
+import org.scalatest.BeforeAndAfterAll
 
-class CommitLogFileSpec extends WordSpec with Matchers with CommitLogSpec with BeforeAndAfterAll {
+class CommitLogFileSpec extends NSDbSpec with CommitLogSpec with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {
     new File(directory).mkdirs()

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/RollingCommitLogFileWriterSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/RollingCommitLogFileWriterSpec.scala
@@ -25,15 +25,15 @@ import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import io.radicalbit.nsdb.commit_log.CommitLogWriterActor.{RejectedEntryAction, WriteToCommitLog}
 import io.radicalbit.nsdb.commit_log.RollingCommitLogFileWriter.ForceRolling
 import io.radicalbit.nsdb.model.Location
-import org.scalatest.{BeforeAndAfter, Matchers, WordSpecLike}
+import io.radicalbit.nsdb.test.NSDbSpecLike
+import org.scalatest.BeforeAndAfter
 
 import scala.concurrent.duration.FiniteDuration
 
 class RollingCommitLogFileWriterSpec
     extends TestKit(ActorSystem("radicaldb-test"))
+    with NSDbSpecLike
     with ImplicitSender
-    with WordSpecLike
-    with Matchers
     with BeforeAndAfter
     with CommitLogSpec {
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializerSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/commit_log/StandardCommitLogSerializerSpec.scala
@@ -19,9 +19,9 @@ package io.radicalbit.nsdb.commit_log
 import io.radicalbit.nsdb.commit_log.CommitLogWriterActor._
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement._
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class StandardCommitLogSerializerSpec extends WordSpec with Matchers {
+class StandardCommitLogSerializerSpec extends NSDbSpec {
 
   "A CommitLogEntry" when {
     val entryService = new StandardCommitLogSerializer

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/AllFacetIndexSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/AllFacetIndexSpec.scala
@@ -25,11 +25,12 @@ import io.radicalbit.nsdb.common.{NSDbDoubleType, NSDbLongType}
 import io.radicalbit.nsdb.index.StorageStrategy.Memory
 import io.radicalbit.nsdb.model.{Location, TimeRange}
 import io.radicalbit.nsdb.statement.StatementParser.InternalTemporalAggregation
+import io.radicalbit.nsdb.test.NSDbSpec
 import org.apache.lucene.search.MatchAllDocsQuery
 import org.apache.lucene.store.MMapDirectory
-import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
+import org.scalatest.OneInstancePerTest
 
-class AllFacetIndexSpec extends WordSpec with Matchers with OneInstancePerTest {
+class AllFacetIndexSpec extends NSDbSpec with OneInstancePerTest {
 
   "AllFacetIndex" should {
     "Combine Results for temporal average calculation" in {

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/FacetIndexTest.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/FacetIndexTest.scala
@@ -21,11 +21,12 @@ import java.util.UUID
 import io.radicalbit.nsdb.common._
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Location
+import io.radicalbit.nsdb.test.NSDbSpec
 import org.apache.lucene.document.LongPoint
 import org.apache.lucene.search.{MatchAllDocsQuery, Sort, SortField}
-import org.scalatest.{Assertion, Matchers, OneInstancePerTest, WordSpec}
+import org.scalatest.{Assertion, OneInstancePerTest}
 
-class FacetIndexTest extends WordSpec with Matchers with OneInstancePerTest {
+class FacetIndexTest extends NSDbSpec with OneInstancePerTest {
 
   val facetIndexes =
     new AllFacetIndexes(

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeRangeFacetTest.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeRangeFacetTest.scala
@@ -23,13 +23,14 @@ import io.radicalbit.nsdb.common.NSDbLongType
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement.CountAggregation
 import io.radicalbit.nsdb.model.TimeRange
+import io.radicalbit.nsdb.test.NSDbSpec
 import org.apache.lucene.document.LongPoint
 import org.apache.lucene.index.Term
 import org.apache.lucene.search.{MatchAllDocsQuery, TermQuery}
 import org.apache.lucene.store.MMapDirectory
-import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
+import org.scalatest.OneInstancePerTest
 
-class TimeRangeFacetTest extends WordSpec with Matchers with OneInstancePerTest {
+class TimeRangeFacetTest extends NSDbSpec with OneInstancePerTest {
 
   "FacetRangeIndex" should {
     "supports facet range query on timestamp without where conditions" in {

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeSeriesIndexTest.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TimeSeriesIndexTest.scala
@@ -21,13 +21,14 @@ import java.util.UUID
 
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Schema
+import io.radicalbit.nsdb.test.NSDbFlatSpec
 import org.apache.lucene.document.LongPoint
 import org.apache.lucene.index.Term
 import org.apache.lucene.search._
 import org.apache.lucene.store.MMapDirectory
-import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
 
-class TimeSeriesIndexTest extends FlatSpec with Matchers with OneInstancePerTest {
+class TimeSeriesIndexTest extends NSDbFlatSpec with OneInstancePerTest {
 
   private val schema = Schema("", Bit(0, 0, Map("dimension" -> "d"), Map("tag" -> "t")))
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TypeSupportSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/TypeSupportSpec.scala
@@ -17,9 +17,9 @@
 package io.radicalbit.nsdb.index
 
 import io.radicalbit.nsdb.common.NSDbNumericType
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class TypeSupportSpec extends WordSpec with Matchers {
+class TypeSupportSpec extends NSDbSpec {
 
   "TypeSupport" when {
     "Index type are used" should {

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/FirstLastIndexSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/FirstLastIndexSpec.scala
@@ -23,13 +23,14 @@ import io.radicalbit.nsdb.common.NSDbType
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.index.TimeSeriesIndex
 import io.radicalbit.nsdb.model.Schema
+import io.radicalbit.nsdb.test.NSDbFlatSpec
 import org.apache.lucene.document.LongPoint
 import org.apache.lucene.index.Term
 import org.apache.lucene.search.{MatchAllDocsQuery, TermQuery}
 import org.apache.lucene.store.MMapDirectory
-import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
 
-class FirstLastIndexSpec extends FlatSpec with Matchers with OneInstancePerTest {
+class FirstLastIndexSpec extends NSDbFlatSpec with OneInstancePerTest {
 
   private val BigIntValueSchema = Schema("testMetric",
                                          Bit(0,

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/MinMaxIndexSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/MinMaxIndexSpec.scala
@@ -23,13 +23,14 @@ import io.radicalbit.nsdb.common.NSDbType
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.index.TimeSeriesIndex
 import io.radicalbit.nsdb.model.Schema
+import io.radicalbit.nsdb.test.NSDbFlatSpec
 import org.apache.lucene.document.LongPoint
 import org.apache.lucene.index.Term
 import org.apache.lucene.search.{MatchAllDocsQuery, TermQuery}
 import org.apache.lucene.store.MMapDirectory
-import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
 
-class MinMaxIndexSpec extends FlatSpec with Matchers with OneInstancePerTest {
+class MinMaxIndexSpec extends NSDbFlatSpec with OneInstancePerTest {
   private val BigIntValueSchema = Schema("testMetric",
                                          Bit(0,
                                              0,

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/UniqueValuesSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/UniqueValuesSpec.scala
@@ -23,11 +23,12 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.{NSDbDoubleType, NSDbIntType, NSDbLongType, NSDbStringType}
 import io.radicalbit.nsdb.index.TimeSeriesIndex
 import io.radicalbit.nsdb.model.Schema
+import io.radicalbit.nsdb.test.NSDbSpec
 import org.apache.lucene.search.MatchAllDocsQuery
 import org.apache.lucene.store.MMapDirectory
-import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
+import org.scalatest.OneInstancePerTest
 
-class UniqueValuesSpec extends WordSpec with Matchers with OneInstancePerTest {
+class UniqueValuesSpec extends NSDbSpec with OneInstancePerTest {
 
   val testRecords: Seq[Bit] = Seq(
     Bit(150000, 2.5, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 30L)),

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/FieldsParserSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/FieldsParserSpec.scala
@@ -20,9 +20,9 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.statement.FieldsParser.{ParsedFields, SimpleField}
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class FieldsParserSpec extends WordSpec with Matchers {
+class FieldsParserSpec extends NSDbSpec {
 
   private val schema = Schema(
     "people",

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserAggregationsSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserAggregationsSpec.scala
@@ -21,11 +21,11 @@ import io.radicalbit.nsdb.common.statement.{SumAggregation => SqlSumAggregation,
 import io.radicalbit.nsdb.model.{Schema, TimeContext}
 import io.radicalbit.nsdb.statement.FieldsParser.SimpleField
 import io.radicalbit.nsdb.statement.StatementParser._
+import io.radicalbit.nsdb.test.NSDbSpec
 import org.apache.lucene.document.LongPoint
 import org.apache.lucene.search._
-import org.scalatest.{Matchers, WordSpec}
 
-class StatementParserAggregationsSpec extends WordSpec with Matchers {
+class StatementParserAggregationsSpec extends NSDbSpec {
 
   implicit val timeContext: TimeContext = TimeContext()
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserRelativeTimeSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserRelativeTimeSpec.scala
@@ -22,13 +22,13 @@ import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.model.{Schema, TimeContext}
 import io.radicalbit.nsdb.statement.FieldsParser.SimpleField
 import io.radicalbit.nsdb.statement.StatementParser._
+import io.radicalbit.nsdb.test.NSDbSpec
 import org.apache.lucene.document.LongPoint
 import org.apache.lucene.search._
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.concurrent.duration.Duration
 
-class StatementParserRelativeTimeSpec extends WordSpec with Matchers {
+class StatementParserRelativeTimeSpec extends NSDbSpec {
 
   implicit val timeContext: TimeContext = TimeContext()
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
@@ -21,12 +21,12 @@ import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.model.{Schema, TimeContext}
 import io.radicalbit.nsdb.statement.FieldsParser.SimpleField
 import io.radicalbit.nsdb.statement.StatementParser._
+import io.radicalbit.nsdb.test.NSDbSpec
 import org.apache.lucene.document.{DoublePoint, LongPoint}
 import org.apache.lucene.index.Term
 import org.apache.lucene.search._
-import org.scalatest.{Matchers, WordSpec}
 
-class StatementParserSpec extends WordSpec with Matchers {
+class StatementParserSpec extends NSDbSpec {
 
   implicit val timeContext: TimeContext = TimeContext()
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/TimeRangeManagerSpec.scala
@@ -18,12 +18,12 @@ package io.radicalbit.nsdb.statement
 
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.model.{Location, TimeContext, TimeRange}
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 import spire.implicits._
 import spire.math.Interval
 import spire.math.interval.{Closed, Open, Unbound}
 
-class TimeRangeManagerSpec extends WordSpec with Matchers {
+class TimeRangeManagerSpec extends NSDbSpec {
 
   implicit val timeContext: TimeContext = TimeContext()
 

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/util/FutureRetryUtilitySpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/util/FutureRetryUtilitySpec.scala
@@ -19,18 +19,14 @@ package io.radicalbit.nsdb.util
 import akka.actor.{ActorSystem, Scheduler, Status}
 import akka.event.{Logging, LoggingAdapter}
 import akka.testkit.{TestKit, TestProbe}
-import org.scalatest.{Matchers, WordSpecLike}
+import io.radicalbit.nsdb.test.NSDbSpecLike
 
 import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class FutureRetryUtilitySpec
-    extends TestKit(ActorSystem("MySpec"))
-    with WordSpecLike
-    with Matchers
-    with FutureRetryUtility {
+class FutureRetryUtilitySpec extends TestKit(ActorSystem("MySpec")) with NSDbSpecLike with FutureRetryUtility {
 
   implicit val schedule: Scheduler    = system.scheduler
   implicit val logger: LoggingAdapter = Logging.getLogger(system, this)

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiTest.scala
@@ -27,11 +27,11 @@ import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.security.http.NSDBAuthProvider
+import io.radicalbit.nsdb.test.NSDbFlatSpec
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes.CommandApi
 import org.json4s.DefaultFormats
 import org.json4s.jackson.Serialization.write
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -57,7 +57,7 @@ object CommandApiTest {
   }
 }
 
-class CommandApiTest extends FlatSpec with Matchers with ScalatestRouteTest with CommandApi {
+class CommandApiTest extends NSDbFlatSpec with ScalatestRouteTest with CommandApi {
 
   import FakeReadCoordinator.Data._
   import io.radicalbit.nsdb.web.CommandApiTest._

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/DataApiTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/DataApiTest.scala
@@ -28,6 +28,7 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.MapInput
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.InputMapped
 import io.radicalbit.nsdb.security.http.{EmptyAuthorization, NSDBAuthProvider}
+import io.radicalbit.nsdb.test.NSDbFlatSpec
 import io.radicalbit.nsdb.web.DataApiTest.FakeWriteCoordinator
 import io.radicalbit.nsdb.web.NSDbJson._
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
@@ -35,7 +36,6 @@ import io.radicalbit.nsdb.web.routes.{DataApi, InsertBody}
 import io.radicalbit.nsdb.web.validation.{FieldErrorInfo, ModelValidationRejection}
 import org.json4s._
 import org.json4s.jackson.Serialization.write
-import org.scalatest._
 
 import scala.concurrent.duration._
 
@@ -61,7 +61,7 @@ trait MyRejectionHandler {
       .result()
 }
 
-class DataApiTest extends FlatSpec with Matchers with ScalatestRouteTest with MyRejectionHandler {
+class DataApiTest extends NSDbFlatSpec with ScalatestRouteTest with MyRejectionHandler {
 
   val writeCoordinatorActor: ActorRef = system.actorOf(Props[FakeWriteCoordinator])
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryApiSpec.scala
@@ -31,11 +31,11 @@ import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
 import scala.concurrent.duration._
 
-class QueryApiSpec extends WordSpec with Matchers with ScalatestRouteTest {
+class QueryApiSpec extends NSDbSpec with ScalatestRouteTest {
 
   val readCoordinatorActor: ActorRef  = system.actorOf(Props[FakeReadCoordinator])
   val writeCoordinatorActor: ActorRef = system.actorOf(Props[FakeWriteCoordinator])

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryEnrichmentSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryEnrichmentSpec.scala
@@ -18,9 +18,9 @@ package io.radicalbit.nsdb.web
 
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.web.Filters._
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class QueryEnrichmentSpec extends WordSpec with Matchers {
+class QueryEnrichmentSpec extends NSDbSpec {
 
   "QueryEnrichment " when {
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryParserApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryParserApiSpec.scala
@@ -28,11 +28,11 @@ import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
 import scala.concurrent.duration._
 
-class QueryParserApiSpec extends WordSpec with Matchers with ScalatestRouteTest {
+class QueryParserApiSpec extends NSDbSpec with ScalatestRouteTest {
 
   val readCoordinatorActor: ActorRef                  = system.actorOf(Props[FakeReadCoordinator])
   val writeCoordinatorActor: ActorRef                 = system.actorOf(Props[FakeWriteCoordinator])

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryValidationApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/QueryValidationApiSpec.scala
@@ -24,15 +24,15 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.util.Timeout
 import io.radicalbit.nsdb.actor.FakeReadCoordinator
 import io.radicalbit.nsdb.security.http.{EmptyAuthorization, NSDBAuthProvider}
+import io.radicalbit.nsdb.test.NSDbFlatSpec
 import io.radicalbit.nsdb.web.NSDbJson._
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import io.radicalbit.nsdb.web.routes._
 import org.json4s._
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._
 
-class QueryValidationApiSpec extends FlatSpec with Matchers with ScalatestRouteTest {
+class QueryValidationApiSpec extends NSDbFlatSpec with ScalatestRouteTest {
 
   val readCoordinatorActor: ActorRef = system.actorOf(Props[FakeReadCoordinator])
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeApiSpec.scala
@@ -29,11 +29,11 @@ import io.radicalbit.nsdb.security.http.EmptyAuthorization
 import io.radicalbit.nsdb.web.auth.TestAuthProvider
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
 import scala.concurrent.duration._
 
-class RealTimeApiSpec extends WordSpec with ScalatestRouteTest with Matchers with WsResources {
+class RealTimeApiSpec extends NSDbSpec with ScalatestRouteTest with WsResources {
 
   override def logger: LoggingAdapter = system.log
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeFiltersSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeFiltersSpec.scala
@@ -31,12 +31,12 @@ import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.PublishRecord
 import io.radicalbit.nsdb.security.http.EmptyAuthorization
 import io.radicalbit.nsdb.web.NSDbJson.RealTimeOutGoingMessageWriter._
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 import spray.json._
 
 import scala.concurrent.duration._
 
-class RealTimeFiltersSpec extends WordSpec with ScalatestRouteTest with Matchers with WsResources {
+class RealTimeFiltersSpec extends NSDbSpec with ScalatestRouteTest with WsResources {
 
   override def logger: LoggingAdapter = system.log
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/validation/ValidatorsTest.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/validation/ValidatorsTest.scala
@@ -16,12 +16,12 @@
 
 package io.radicalbit.nsdb.web.validation
 
-import org.scalatest.{FlatSpec, Matchers}
-import Validators._
 import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.test.NSDbFlatSpec
 import io.radicalbit.nsdb.web.routes.InsertBody
+import io.radicalbit.nsdb.web.validation.Validators._
 
-class ValidatorsTest extends FlatSpec with Matchers {
+class ValidatorsTest extends NSDbFlatSpec {
   "Validators" should "validate InsertBody returning empty errors" in {
     val metric = "metric"
     val result = insertBodyValidator.apply(InsertBody("db", "namespace", metric, Bit.empty))

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/test/MiniClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/test/MiniClusterSpec.scala
@@ -23,10 +23,11 @@ import io.radicalbit.nsdb.cluster.extension.NSDbClusterSnapshot
 import io.radicalbit.nsdb.minicluster.NsdbMiniCluster
 import org.json4s.DefaultFormats
 import org.scalatest.concurrent.Eventually
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.time.{Seconds, Span}
-import org.scalatest.{Assertion, BeforeAndAfterAll, FunSuite}
+import org.scalatest.{Assertion, BeforeAndAfterAll}
 
-trait MiniClusterSpec extends FunSuite with BeforeAndAfterAll with Eventually with NsdbMiniCluster {
+trait MiniClusterSpec extends AnyFunSuite with BeforeAndAfterAll with Eventually with NsdbMiniCluster {
 
   Logger.getLogger("io.grpc.internal").setLevel(Level.OFF)
 

--- a/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/test/MiniClusterSingleNodeSpec.scala
+++ b/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/test/MiniClusterSingleNodeSpec.scala
@@ -22,10 +22,11 @@ import java.util.logging.{Level, Logger}
 import io.radicalbit.nsdb.minicluster.NsdbMiniCluster
 import org.json4s.DefaultFormats
 import org.scalatest.concurrent.Eventually
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.time.{Seconds, Span}
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.BeforeAndAfterAll
 
-trait MiniClusterSingleNodeSpec extends FunSuite with BeforeAndAfterAll with Eventually with NsdbMiniCluster {
+trait MiniClusterSingleNodeSpec extends AnyFunSuite with BeforeAndAfterAll with Eventually with NsdbMiniCluster {
 
   Logger.getLogger("io.grpc.internal").setLevel(Level.OFF)
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/AggregationSQLStatementSpec.scala
@@ -18,9 +18,9 @@ package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult.{SqlStatementParserFailure, SqlStatementParserSuccess}
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class AggregationSQLStatementSpec extends WordSpec with Matchers {
+class AggregationSQLStatementSpec extends NSDbSpec {
 
   private val parser = new SQLStatementParser
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/CommandStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/CommandStatementSpec.scala
@@ -18,9 +18,9 @@ package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult._
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class CommandStatementSpec extends WordSpec with Matchers {
+class CommandStatementSpec extends NSDbSpec {
 
   private val parser = new CommandStatementParser("db")
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/DeleteSQLStatementSpec.scala
@@ -18,9 +18,9 @@ package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult._
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class DeleteSQLStatementSpec extends WordSpec with Matchers {
+class DeleteSQLStatementSpec extends NSDbSpec {
 
   private val parser = new SQLStatementParser
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/GracePeriodStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/GracePeriodStatementSpec.scala
@@ -19,9 +19,9 @@ package io.radicalbit.nsdb.sql.parser
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult._
 import org.scalatest.Inside._
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class GracePeriodStatementSpec extends WordSpec with Matchers {
+class GracePeriodStatementSpec extends NSDbSpec {
 
   private val parser = new SQLStatementParser
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/InsertSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/InsertSQLStatementSpec.scala
@@ -19,9 +19,9 @@ package io.radicalbit.nsdb.sql.parser
 import io.radicalbit.nsdb.common.NSDbType
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult.SqlStatementParserSuccess
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class InsertSQLStatementSpec extends WordSpec with Matchers {
+class InsertSQLStatementSpec extends NSDbSpec {
 
   private val parser = new SQLStatementParser
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/RelativeTimeSQLStatementSpec.scala
@@ -21,9 +21,9 @@ import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult._
 import org.scalatest.Inside._
 import org.scalatest.OptionValues._
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class RelativeTimeSQLStatementSpec extends WordSpec with Matchers {
+class RelativeTimeSQLStatementSpec extends NSDbSpec {
 
   private val parser = new SQLStatementParser
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SQLStatementBracketsSpec.scala
@@ -18,9 +18,9 @@ package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult._
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class SQLStatementBracketsSpec extends WordSpec with Matchers {
+class SQLStatementBracketsSpec extends NSDbSpec {
 
   private val parser = new SQLStatementParser
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLEqExpressionSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLEqExpressionSpec.scala
@@ -18,9 +18,9 @@ package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult.{SqlStatementParserFailure, SqlStatementParserSuccess}
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class SelectSQLEqExpressionSpec extends WordSpec with Matchers {
+class SelectSQLEqExpressionSpec extends NSDbSpec {
 
   private val parser = new SQLStatementParser
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLLikeExpressionSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLLikeExpressionSpec.scala
@@ -18,9 +18,9 @@ package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult.SqlStatementParserSuccess
-import org.scalatest._
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class SelectSQLLikeExpressionSpec extends WordSpec with Matchers {
+class SelectSQLLikeExpressionSpec extends NSDbSpec {
 
   private val parser = new SQLStatementParser
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLStatementSpec.scala
@@ -18,9 +18,9 @@ package io.radicalbit.nsdb.sql.parser
 
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.sql.parser.StatementParserResult.{SqlStatementParserFailure, SqlStatementParserSuccess}
-import org.scalatest.{Matchers, WordSpec}
+import io.radicalbit.nsdb.test.NSDbSpec
 
-class SelectSQLStatementSpec extends WordSpec with Matchers {
+class SelectSQLStatementSpec extends NSDbSpec {
 
   private val parser = new SQLStatementParser
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -146,7 +146,7 @@ object Dependencies {
   }
 
   object scalatest {
-    lazy val version   = "3.0.7"
+    lazy val version   = "3.2.2"
     lazy val namespace = "org.scalatest"
     lazy val core      = namespace %% "scalatest" % version
   }


### PR DESCRIPTION
This PR is to update scalatest dependency in order to make it support scala 2.13.

A set of common traits are created into the `nsdb-common` module which wraps the scalatest traits.