### PR TITLE
[HOTFIX] Fix support for empty strings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,6 @@ lazy val `nsdb-cluster` = project
   .settings(scriptClasspath in bashScriptDefines += "../ext-lib/*")
   .settings(SbtMultiJvm.multiJvmSettings)
   .configs(MultiJvm)
-  .settings(assemblyJarName in assembly := "nsdb-cluster.jar")
   .settings(
     /* Docker Settings - to create, run as:
        $ sbt `project nsdb-cluster` docker:publishLocal
@@ -233,7 +232,6 @@ lazy val `nsdb-cli` = project
   .settings(PublishSettings.dontPublish: _*)
   .settings(libraryDependencies ++= Dependencies.CLI.libraries)
   .settings(coverageExcludedPackages := "io\\.radicalbit\\.nsdb.*")
-  .settings(assemblyJarName in assembly := "nsdb-cli.jar")
   .enablePlugins(AutomateHeaderPlugin)
   .settings(LicenseHeader.settings: _*)
   .dependsOn(`nsdb-rpc`)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
@@ -288,10 +288,10 @@ class GrpcEndpoint(nodeId: String, readCoordinator: ActorRef, writeCoordinator: 
       val bit = Bit(
         timestamp = request.timestamp,
         dimensions = request.dimensions.collect {
-          case (k, v) if !v.value.isStringValue || v.getStringValue != "" => (k, dimensionFor(v.value))
+          case (k, v) => (k, dimensionFor(v.value))
         },
         tags = request.tags.collect {
-          case (k, v) if !v.value.isStringValue || v.getStringValue != "" => (k, tagFor(v.value))
+          case (k, v) => (k, tagFor(v.value))
         },
         value = valueFor(request.value)
       )

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSimpleStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorSimpleStatementsSpec.scala
@@ -275,7 +275,7 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
         expected.values.sortBy(_.timestamp) shouldBe Seq(
           Bit(1, 1L, Map("surname"  -> "Doe"), Map.empty),
           Bit(2, 2L, Map("surname"  -> "Doe"), Map.empty),
-          Bit(4, 3L, Map("surname"  -> "D"), Map.empty),
+          Bit(4, 3L, Map("surname"  -> ""), Map.empty),
           Bit(6, 4L, Map("surname"  -> "Doe"), Map.empty),
           Bit(8, 5L, Map("surname"  -> "Doe"), Map.empty),
           Bit(10, 6L, Map("surname" -> "Doe"), Map.empty),
@@ -304,7 +304,7 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
         expected.values.sortBy(_.timestamp) shouldBe Seq(
           Bit(1, 1L, Map("surname"  -> "Doe"), Map("name" -> "John")),
           Bit(2, 2L, Map("surname"  -> "Doe"), Map("name" -> "John")),
-          Bit(4, 3L, Map("surname"  -> "D"), Map("name"   -> "J")),
+          Bit(4, 3L, Map("surname"  -> ""), Map("name"    -> "J")),
           Bit(6, 4L, Map("surname"  -> "Doe"), Map("name" -> "Bill")),
           Bit(8, 5L, Map("surname"  -> "Doe"), Map("name" -> "Frank")),
           Bit(10, 6L, Map("surname" -> "Doe"), Map("name" -> "Frankie")),
@@ -663,6 +663,29 @@ class ReadCoordinatorSimpleStatementsSpec extends AbstractReadCoordinatorSpec {
               fields = ListFields(List(Field("name", None))),
               condition =
                 Some(Condition(EqualityExpression(dimension = "timestamp", value = AbsoluteComparisonValue(2L)))),
+              limit = Some(LimitOperator(4))
+            )
+          )
+        )
+
+        val expected = awaitAssert {
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+        expected.values.size should be(1)
+      }
+
+      "execute it successfully in case of an empty string comparison" in within(5.seconds) {
+        probe.send(
+          readCoordinatorActor,
+          ExecuteStatement(
+            SelectSQLStatement(
+              db = db,
+              namespace = namespace,
+              metric = LongMetric.name,
+              distinct = false,
+              fields = ListFields(List(Field("*", None))),
+              condition =
+                Some(Condition(EqualityExpression(dimension = "surname", value = AbsoluteComparisonValue("")))),
               limit = Some(LimitOperator(4))
             )
           )

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedData/MockedData.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedData/MockedData.scala
@@ -26,7 +26,7 @@ object MockedData {
     val recordsShard1: Seq[Bit] = Seq(
       Bit(1L, 1L, Map("surname" -> "Doe"), Map("name" -> "John")),
       Bit(2L, 2L, Map("surname" -> "Doe"), Map("name" -> "John")),
-      Bit(4L, 3L, Map("surname" -> "D"), Map("name"   -> "J"))
+      Bit(4L, 3L, Map("surname" -> ""), Map("name"    -> "J"))
     )
 
     val recordsShard2: Seq[Bit] = Seq(

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -133,8 +133,9 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
   }, _ => "Distinct clause is only applicable to the count aggregation")
 
   private val dimension = standardString
-  private val stringValue = (specialString | (("'" ?) ~> (specialString +) <~ ("'" ?))) ^^ {
+  private val stringValue = (specialString | (("'" ?) ~> (specialString *) <~ ("'" ?))) ^^ {
     case string: String        => string
+    case Nil                   => ""
     case strings: List[String] => strings.mkString(" ")
   }
 

--- a/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
+++ b/nsdb-sql/src/main/scala/io/radicalbit/nsdb/sql/parser/SQLStatementParser.scala
@@ -175,7 +175,7 @@ final class SQLStatementParser extends RegexParsers with PackratParsers with Reg
 
   private val valueAssignment = (Val ~ Equal) ~> (doubleValue | longValue)
 
-  private val assignment = (dimension <~ Equal) ~ (stringValue | doubleValue | intValue) ^^ {
+  private val assignment = (dimension <~ Equal) ~ (doubleValue | intValue | stringValue) ^^ {
     case k ~ v => k -> NSDbType(v)
   }
 

--- a/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLEqExpressionSpec.scala
+++ b/nsdb-sql/src/test/scala/io/radicalbit/nsdb/sql/parser/SelectSQLEqExpressionSpec.scala
@@ -149,6 +149,23 @@ class SelectSQLEqExpressionSpec extends NSDbSpec {
           ))
       }
 
+      "parse it successfully on an empty string" in {
+        val query = "select name from people where name = '' limit 5"
+        parser.parse(db = "db", namespace = "registry", input = query) should be(
+          SqlStatementParserSuccess(
+            query,
+            SelectSQLStatement(
+              db = "db",
+              namespace = "registry",
+              metric = "people",
+              distinct = false,
+              fields = ListFields(List(Field("name", None))),
+              condition = Some(Condition(EqualityExpression(dimension = "name", value = AbsoluteComparisonValue("")))),
+              limit = Some(LimitOperator(5))
+            )
+          ))
+      }
+
       "not allow wildcard char" in {
         val query = "select name from people where name = 'a$' limit 5"
         parser.parse(db = "db", namespace = "registry", input = query) shouldBe a[SqlStatementParserFailure]

--- a/project/Commons.scala
+++ b/project/Commons.scala
@@ -16,9 +16,6 @@
 
 import sbt.Keys._
 import sbt._
-import sbtassembly.AssemblyKeys._
-import sbtassembly.AssemblyPlugin.autoImport.{MergeStrategy, assemblyMergeStrategy}
-import sbtassembly.PathList
 import scalafix.sbt.ScalafixPlugin.autoImport.scalafixSemanticdb
 
 object Commons {
@@ -49,16 +46,7 @@ object Commons {
     parallelExecution in Test := false,
     parallelExecution in IntegrationTest := false,
     concurrentRestrictions in Test += Tags.limitAll(1),
-    concurrentRestrictions in IntegrationTest += Tags.limitAll(1),
-    test in assembly := {},
-    assemblyMergeStrategy in assembly := {
-      case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
-      case PathList("CHANGELOG.adoc")                           => MergeStrategy.first
-      case PathList("CHANGELOG.html")                           => MergeStrategy.first
-      case x =>
-        val oldStrategy = (assemblyMergeStrategy in assembly).value
-        oldStrategy(x)
-    }
+    concurrentRestrictions in IntegrationTest += Tags.limitAll(1)
   )
 
   val crossScalaVersionSettings = settings :+ (crossScalaVersions := Seq("2.12.12", "2.13.3"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,7 +53,7 @@ object Dependencies {
   }
 
   object akka {
-    lazy val version   = "2.6.3"
+    lazy val version   = "2.6.4"
     lazy val namespace = "com.typesafe.akka"
 
     lazy val actor                  = namespace %% "akka-actor"                  % version
@@ -72,7 +72,7 @@ object Dependencies {
   }
 
   object akka_management {
-    lazy val version   = "1.0.5"
+    lazy val version   = "1.0.6"
     lazy val namespace = "com.lightbend.akka.management"
     lazy val cluster_bootstrap = namespace %% "akka-management-cluster-bootstrap" % version excludeAll (ExclusionRule(organization="com.typesafe.akka"))
     lazy val cluster_http = namespace %% "akka-management-cluster-http" % version excludeAll (ExclusionRule(organization="com.typesafe.akka"))
@@ -93,12 +93,12 @@ object Dependencies {
   }
 
   object akka_http {
-    lazy val version   = "10.1.11"
+    lazy val version   = "10.2.0"
     lazy val namespace = "com.typesafe.akka"
     lazy val default         = namespace                      %% "akka-http"            % version
     lazy val testkit         = namespace                      %% "akka-http-testkit"    % version % Test
     lazy val sprayJson       = "com.typesafe.akka"            %% "akka-http-spray-json" % version
-    lazy val swaggerAkkaHttp = "com.github.swagger-akka-http" %% "swagger-akka-http"    % "2.0.4"
+    lazy val swaggerAkkaHttp = "com.github.swagger-akka-http" %% "swagger-akka-http"    % "2.2.0"
   }
 
   object kamon {
@@ -112,13 +112,13 @@ object Dependencies {
   }
 
   object lithium {
-    lazy val version   = "0.10.0"
+    lazy val version   = "0.11.2"
     lazy val namespace = "com.swissborg"
     lazy val core =  namespace %% "lithium" % version excludeAll (ExclusionRule(organization="com.typesafe.akka"))
   }
 
   object swagger {
-    lazy val version     = "1.5.19"
+    lazy val version     = "1.6.2"
     lazy val namespace   = "io.swagger"
     lazy val coreSwagger = namespace % "swagger-jaxrs" % version
   }
@@ -178,7 +178,7 @@ object Dependencies {
   }
 
   object config {
-    lazy val version   = "1.3.3"
+    lazy val version   = "1.4.0"
     lazy val namespace = "com.typesafe"
     lazy val core      = namespace % "config" % version
   }
@@ -203,7 +203,7 @@ object Dependencies {
   }
 
   object zipUtils {
-    lazy val version   = "1.13"
+    lazy val version   = "1.14"
     lazy val namespace = "org.zeroturnaround"
     lazy val zip       = namespace % "zt-zip" % version
   }

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")

--- a/project/protoc.sbt
+++ b/project/protoc.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.27")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.34")


### PR DESCRIPTION
This PR fixes the management of empty strings as comparison terms.
Now it's possible to insert empty string tags and also to provide an empty string as an equality comparison term. 

e.g. 

```sql
select * from metric where tag = ''
```