### PR TITLE
Count Distinct aggregation for temporal queries

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -31,7 +31,7 @@ import io.radicalbit.nsdb.cluster.logic.ReadNodesSelection
 import io.radicalbit.nsdb.common.NSDbNumericType
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.precision
 import io.radicalbit.nsdb.common.protocol.Bit
-import io.radicalbit.nsdb.model.{Location, Schema, TimeContext, TimeRange}
+import io.radicalbit.nsdb.model.{Location, Schema, TimeContext, TimeRange, TimeRangeContext}
 import io.radicalbit.nsdb.post_proc._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
@@ -95,7 +95,7 @@ class ReadCoordinator(metadataCoordinator: ActorRef,
   private def gatherNodeResults(command: ExecuteStatement,
                                 schema: Schema,
                                 uniqueLocationsByNode: Map[String, Seq[Location]],
-                                ranges: Seq[TimeRange] = Seq.empty)(postProcFun: Seq[Bit] => Seq[Bit])(
+                                timeRangeContext: Option[TimeRangeContext] = None)(postProcFun: Seq[Bit] => Seq[Bit])(
       implicit timeContext: TimeContext): Future[ExecuteSelectStatementResponse] = {
     log.debug("gathering node results for locations {}", uniqueLocationsByNode)
     val statement    = command.selectStatement
@@ -107,7 +107,7 @@ class ReadCoordinator(metadataCoordinator: ActorRef,
           actor ? ExecuteSelectStatement(statement,
                                          schema,
                                          uniqueLocationsByNode.getOrElse(nodeId, Seq.empty),
-                                         ranges,
+                                         timeRangeContext,
                                          timeContext,
                                          isSingleNode)
       })
@@ -239,18 +239,27 @@ class ReadCoordinator(metadataCoordinator: ActorRef,
                 val limitedLocations = gracePeriod.fold(sortedLocations)(gracePeriodInterval =>
                   ReadNodesSelection.filterLocationsThroughGracePeriod(gracePeriodInterval, sortedLocations))
 
-                val globalRanges: Seq[TimeRange] =
-                  if (limitedLocations.isEmpty) Seq.empty[TimeRange]
-                  else
-                    TimeRangeManager.computeRangesForIntervalAndCondition(limitedLocations.last.to,
-                                                                          limitedLocations.head.from,
-                                                                          rangeLength,
-                                                                          condition,
-                                                                          gracePeriod)
+                val timeRangeContext: Option[TimeRangeContext] =
+                  if (limitedLocations.isEmpty) None
+                  else {
+
+                    val upperBound = limitedLocations.last.to
+                    val lowerBound = limitedLocations.head.from
+
+                    Some(
+                      TimeRangeContext(upperBound,
+                                       lowerBound,
+                                       rangeLength,
+                                       TimeRangeManager.computeRangesForIntervalAndCondition(upperBound,
+                                                                                             lowerBound,
+                                                                                             rangeLength,
+                                                                                             condition,
+                                                                                             gracePeriod)))
+                  }
 
                 val limitedUniqueLocationsByNode = readNodesSelection.getDistinctLocationsByNode(limitedLocations)
 
-                gatherNodeResults(msg, schema, limitedUniqueLocationsByNode, globalRanges)(
+                gatherNodeResults(msg, schema, limitedUniqueLocationsByNode, timeRangeContext)(
                   postProcessingTemporalQueryResult(schema, statement, aggregation))
 
               case Left(error) =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -31,7 +31,7 @@ import io.radicalbit.nsdb.cluster.logic.ReadNodesSelection
 import io.radicalbit.nsdb.common.NSDbNumericType
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.precision
 import io.radicalbit.nsdb.common.protocol.Bit
-import io.radicalbit.nsdb.model.{Location, Schema, TimeContext, TimeRange, TimeRangeContext}
+import io.radicalbit.nsdb.model.{Location, Schema, TimeContext, TimeRangeContext}
 import io.radicalbit.nsdb.post_proc._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalDistinctAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalDistinctAggregatedStatementsSpec.scala
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.coordinator
+
+import io.radicalbit.nsdb.cluster.coordinator.mockedData.MockedData._
+import io.radicalbit.nsdb.common.protocol._
+import io.radicalbit.nsdb.common.statement._
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
+
+class ReadCoordinatorTemporalDistinctAggregatedStatementsSpec extends AbstractTemporalReadCoordinatorSpec {
+
+  "ReadCoordinator" when {
+
+    "receive a select containing a temporal group by with count distinct aggregation" should {
+      "execute it successfully when count( distinct *) is used instead of value" in {
+
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalLongMetric.name,
+                distinct = false,
+                fields = ListFields(List(Field("*", Some(CountDistinctAggregation("value"))))),
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s"))
+              )
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values shouldBe Seq(
+          Bit(10000, 1L, Map("lowerBound"  -> 0L, "upperBound"      -> 10000L), Map()),
+          Bit(40000, 1L, Map("lowerBound"  -> 10000L, "upperBound"  -> 40000L), Map()),
+          Bit(70000, 1L, Map("lowerBound"  -> 40000L, "upperBound"  -> 70000L), Map()),
+          Bit(100000, 1L, Map("lowerBound" -> 70000L, "upperBound"  -> 100000L), Map()),
+          Bit(130000, 1L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
+          Bit(160000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
+        )
+
+      }
+
+      "execute it successfully when no shard has picked up" in {
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalLongMetric.name,
+                distinct = false,
+                condition = Some(
+                  Condition(ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterOrEqualToOperator,
+                                                 value = AbsoluteComparisonValue(200000L)))),
+                fields = ListFields(List(Field("*", Some(CountDistinctAggregation("value"))))),
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
+                limit = Some(LimitOperator(2))
+              )
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values.size shouldBe 0
+      }
+
+      "execute it successfully when time ranges contain more than one distinct value" in {
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalLongMetric.name,
+                distinct = false,
+                fields = ListFields(List(Field("value", Some(CountAggregation("value"))))),
+                groupBy = Some(TemporalGroupByAggregation(60000, 60, "s"))
+              )
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values shouldBe Seq(
+          Bit(10000, 1L, Map("lowerBound"  -> 0L, "upperBound"      -> 10000L), Map()),
+          Bit(70000, 2L, Map("lowerBound"  -> 10000L, "upperBound"  -> 70000L), Map()),
+          Bit(130000, 2L, Map("lowerBound" -> 70000L, "upperBound"  -> 130000L), Map()),
+          Bit(190000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 190000L), Map())
+        )
+      }
+
+    }
+
+    "receive a select containing a temporal group by with count distinct aggregation on a double value metric" should {
+      "execute it successfully when count(distinct *) is used instead of value" in {
+
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalDoubleMetric.name,
+                distinct = false,
+                fields = ListFields(List(Field("*", Some(CountDistinctAggregation("value"))))),
+                groupBy = Some(TemporalGroupByAggregation(30000, 30, "s"))
+              )
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values shouldBe Seq(
+          Bit(10000, 1L, Map("lowerBound"  -> 0L, "upperBound"      -> 10000L), Map()),
+          Bit(40000, 1L, Map("lowerBound"  -> 10000L, "upperBound"  -> 40000L), Map()),
+          Bit(70000, 1L, Map("lowerBound"  -> 40000L, "upperBound"  -> 70000L), Map()),
+          Bit(100000, 1L, Map("lowerBound" -> 70000L, "upperBound"  -> 100000L), Map()),
+          Bit(130000, 1L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
+          Bit(160000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map())
+        )
+
+      }
+
+      "execute it successfully when time ranges contain more than one distinct value" in {
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalDoubleMetric.name,
+                distinct = false,
+                fields = ListFields(List(Field("value", Some(CountAggregation("value"))))),
+                groupBy = Some(TemporalGroupByAggregation(60000, 60, "s"))
+              )
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values shouldBe Seq(
+          Bit(10000, 1L, Map("lowerBound"  -> 0L, "upperBound"      -> 10000L), Map()),
+          Bit(70000, 2L, Map("lowerBound"  -> 10000L, "upperBound"  -> 70000L), Map()),
+          Bit(130000, 2L, Map("lowerBound" -> 70000L, "upperBound"  -> 130000L), Map()),
+          Bit(190000, 1L, Map("lowerBound" -> 130000L, "upperBound" -> 190000L), Map())
+        )
+      }
+
+    }
+
+    "receive a select containing a temporal group with count distinct aggregation by with an interval higher than the shard interval" should {
+      "execute it successfully" in {
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalLongMetric.name,
+                distinct = false,
+                fields = ListFields(List(Field("value", Some(CountDistinctAggregation("value"))))),
+                condition = None,
+                groupBy = Some(TemporalGroupByAggregation(100000L, 100, "s"))
+              )
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values.size shouldBe 2
+
+        expected.values shouldBe Seq(
+          Bit(90000, 4L, Map("lowerBound"  -> 0L, "upperBound"     -> 90000L), Map()),
+          Bit(190000, 2L, Map("lowerBound" -> 90000L, "upperBound" -> 190000L), Map())
+        )
+      }
+
+      "execute it successfully in case of a where condition" in {
+        val expected = awaitAssert {
+
+          probe.send(
+            readCoordinatorActor,
+            ExecuteStatement(
+              SelectSQLStatement(
+                db = db,
+                namespace = namespace,
+                metric = TemporalLongMetric.name,
+                distinct = false,
+                fields = ListFields(List(Field("value", Some(CountAggregation("value"))))),
+                condition = Some(
+                  Condition(ComparisonExpression(dimension = "timestamp",
+                                                 comparison = GreaterOrEqualToOperator,
+                                                 value = AbsoluteComparisonValue(60000L)))),
+                groupBy = Some(TemporalGroupByAggregation(100000L, 100, "s"))
+              )
+            )
+          )
+
+          probe.expectMsgType[SelectStatementExecuted]
+        }
+
+        expected.values.size shouldBe 2
+
+        expected.values shouldBe Seq(
+          Bit(90000, 2L, Map("lowerBound"  -> 60000L, "upperBound" -> 90000L), Map()),
+          Bit(190000, 2L, Map("lowerBound" -> 90000L, "upperBound" -> 190000L), Map())
+        )
+      }
+    }
+
+  }
+}

--- a/nsdb-core/src/main/java/org/apache/lucene/search/grouping/NSDbLongRangeFactory.java
+++ b/nsdb-core/src/main/java/org/apache/lucene/search/grouping/NSDbLongRangeFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search.grouping;
+
+/**
+ * Groups long values into ranges starting from a max value.
+ */
+public class NSDbLongRangeFactory extends LongRangeFactory{
+
+    private final long min;
+    private final long width;
+    private final long max;
+
+    /**
+     * Creates a new LongRangeFactory
+     *
+     * @param min   a minimum value; all longs below this value are grouped into a single range
+     * @param width a standard width; all ranges between {@code min} and {@code max} are this wide,
+     *              with the exception of the final range which may be up to this width.  Ranges
+     *              are inclusive at the lower end, and exclusive at the upper end.
+     * @param max   a maximum value; all longs above this value are grouped into a single range
+     */
+    public NSDbLongRangeFactory(long min, long width, long max) {
+        super(min, width, max);
+        this.min = min;
+        this.width = width;
+        this.max = max;
+    }
+
+    /**
+     * Finds the LongRange that a value should be grouped into
+     * @param value the value to group
+     * @param reuse an existing LongRange object to reuse
+     */
+    public LongRange getRange(long value, LongRange reuse) {
+        if (reuse == null)
+            reuse = new LongRange(Long.MIN_VALUE, Long.MAX_VALUE);
+        if (value < min || value > max) {
+            throw new IllegalArgumentException(String.format("value %d is beyond range (%d, %d)",value, min, max));
+        }
+        long bucket = (max - value) / width;
+        long rangeMax = max - (bucket * width);
+        long rangeMin = rangeMax - width;
+        if (rangeMax == min) {
+            reuse.max = rangeMax + width;
+        } else {
+            reuse.max = rangeMax;
+        }
+        reuse.min = Math.max(rangeMin, min);
+        return reuse;
+    }
+}

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/ShardReaderActor.scala
@@ -287,9 +287,9 @@ class ShardReaderActor(val basePath: String, val db: String, val namespace: Stri
                   q,
                   schema,
                   countDistinctAggregation.fieldName,
-                  filteredRanges.headOption.map(_.lowerBound).getOrElse(0L),
+                  filteredRanges.lastOption.map(_.lowerBound).getOrElse(0L),
                   interval,
-                  filteredRanges.lastOption.map(_.upperBound).getOrElse(0L)
+                  filteredRanges.headOption.map(_.upperBound).getOrElse(0L)
                 )))
 
         case Right(ParsedTemporalAggregatedQuery(_, _, q, _, aggregationType, _, _, _, _)) =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AbstractStructuredIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AbstractStructuredIndex.scala
@@ -294,7 +294,7 @@ abstract class AbstractStructuredIndex extends Index[Bit] with TypeSupport {
                         upperBound: Long): Seq[Bit] = {
     val groupSelector =
       new LongRangeGroupSelector(LongValuesSource.fromLongField(_keyField),
-                                 new LongRangeFactory(lowerBound, interval, upperBound));
+                                 new LongRangeFactory(lowerBound, interval, upperBound))
 
     val aggregationSelector = schema.fieldsMap(aggregationField).indexType match {
       case _: VARCHAR => new TermGroupSelector(aggregationField)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AbstractStructuredIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AbstractStructuredIndex.scala
@@ -343,10 +343,11 @@ abstract class AbstractStructuredIndex extends Index[Bit] with TypeSupport {
           }
         }
 
+        val lastLowerBound = if (upperBound - interval < 0) 0 else upperBound - interval
         Bit(
-          upperBound - interval,
+          lastLowerBound,
           0,
-          Map("lowerBound" -> (upperBound - interval), "upperBound" -> upperBound),
+          Map("lowerBound" -> lastLowerBound, "upperBound" -> upperBound),
           Map.empty,
           uniqueValuesBeyondRange.toSet
         ) +: buffer

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AbstractStructuredIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AbstractStructuredIndex.scala
@@ -19,7 +19,7 @@ package io.radicalbit.nsdb.index
 import io.radicalbit.nsdb.common.protocol._
 import io.radicalbit.nsdb.common.{NSDbNumericType, NSDbType}
 import io.radicalbit.nsdb.index.lucene.Index
-import io.radicalbit.nsdb.model.{Schema, SchemaField, TimeRangeContext}
+import io.radicalbit.nsdb.model.{Schema, SchemaField}
 import io.radicalbit.nsdb.statement.FieldsParser.SimpleField
 import org.apache.lucene.document._
 import org.apache.lucene.index.IndexWriter
@@ -276,6 +276,16 @@ abstract class AbstractStructuredIndex extends Index[Bit] with TypeSupport {
     }
   }
 
+  /**
+    * Extracts the unique values for a temporal range.
+    * @param query the query to be executed before grouping.
+    * @param schema bit schema.
+    * @param aggregationField field to use to gather unique values.
+    * @param lowerBound global lower bound.
+    * @param interval range interval.
+    * @param upperBound global upper bound.
+    * @return a sequence of bit, one for each time range, containing a set of unique values.
+    */
   def uniqueRangeValues(query: Query,
                         schema: Schema,
                         aggregationField: String,
@@ -324,9 +334,9 @@ abstract class AbstractStructuredIndex extends Index[Bit] with TypeSupport {
               uniqueValuesBeyondRange ++= uniqueValues
             else
               buffer += Bit(
+                g.groupValue.min,
                 0,
-                0,
-                Map("lowerbound" -> g.groupValue.min, "upperbound" -> g.groupValue.max),
+                Map("lowerBound" -> g.groupValue.min, "upperBound" -> g.groupValue.max),
                 Map.empty,
                 uniqueValues.toSet
               )
@@ -334,9 +344,9 @@ abstract class AbstractStructuredIndex extends Index[Bit] with TypeSupport {
         }
 
         Bit(
+          upperBound - interval,
           0,
-          0,
-          Map("lowerbound" -> (upperBound - interval), "upperbound" -> upperBound),
+          Map("lowerBound" -> (upperBound - interval), "upperBound" -> upperBound),
           Map.empty,
           uniqueValuesBeyondRange.toSet
         ) +: buffer

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/TimeRange.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/TimeRange.scala
@@ -38,3 +38,5 @@ case class TimeRange(lowerBound: Long, upperBound: Long, lowerInclusive: Boolean
 
   def intersect(location: Location): Boolean = this.interval.intersects(location.interval)
 }
+
+case class TimeRangeContext(upperBound: Long, lowerBound: Long, interval: Long, ranges: Seq[TimeRange])

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/TimeRange.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/TimeRange.scala
@@ -39,4 +39,12 @@ case class TimeRange(lowerBound: Long, upperBound: Long, lowerInclusive: Boolean
   def intersect(location: Location): Boolean = this.interval.intersects(location.interval)
 }
 
+/**
+  * Contains all the information required for a temporal group by queries.
+  *
+  * @param upperBound global upper bound.
+  * @param lowerBound lower upper bound.
+  * @param interval range interval.
+  * @param ranges computed ranges based on the the previous parameters.
+  */
 case class TimeRangeContext(upperBound: Long, lowerBound: Long, interval: Long, ranges: Seq[TimeRange])

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -162,6 +162,8 @@ package object post_proc {
                     NSDbNumericType(bits.map(_.value.rawValue.asInstanceOf[Long]).sum),
                     dimensions,
                     tags)
+              case _: CountDistinctAggregation =>
+                Bit(head.timestamp, NSDbNumericType(bits.flatMap(_.uniqueValues).toSet.size), dimensions, tags)
               case _: SumAggregation =>
                 Bit(head.timestamp, NSDbNumericType(bits.map(_.value.rawValue).sum), dimensions, tags)
               case _: MaxAggregation =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -163,7 +163,7 @@ package object post_proc {
                     dimensions,
                     tags)
               case _: CountDistinctAggregation if finalStep =>
-                Bit(head.timestamp, NSDbNumericType(bits.flatMap(_.uniqueValues).toSet.size), dimensions, tags)
+                Bit(head.timestamp, NSDbNumericType(bits.flatMap(_.uniqueValues).toSet.size.toLong), dimensions, tags)
               case _: CountDistinctAggregation =>
                 Bit(head.timestamp, 0L, dimensions, tags, bits.flatMap(_.uniqueValues).toSet)
               case _: SumAggregation =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -162,8 +162,10 @@ package object post_proc {
                     NSDbNumericType(bits.map(_.value.rawValue.asInstanceOf[Long]).sum),
                     dimensions,
                     tags)
-              case _: CountDistinctAggregation =>
+              case _: CountDistinctAggregation if finalStep =>
                 Bit(head.timestamp, NSDbNumericType(bits.flatMap(_.uniqueValues).toSet.size), dimensions, tags)
+              case _: CountDistinctAggregation =>
+                Bit(head.timestamp, 0L, dimensions, tags, bits.flatMap(_.uniqueValues).toSet)
               case _: SumAggregation =>
                 Bit(head.timestamp, NSDbNumericType(bits.map(_.value.rawValue).sum), dimensions, tags)
               case _: MaxAggregation =>

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.{Bit, NSDbSerializable}
 import io.radicalbit.nsdb.common.statement.{DeleteSQLStatement, SelectSQLStatement}
-import io.radicalbit.nsdb.model.{Location, Schema, TimeContext, TimeRange}
+import io.radicalbit.nsdb.model.{Location, Schema, TimeContext, TimeRange, TimeRangeContext}
 
 /**
   * common messages exchanged among all the nsdb actors.
@@ -51,7 +51,7 @@ object MessageProtocol {
     case class ExecuteSelectStatement(selectStatement: SelectSQLStatement,
                                       schema: Schema,
                                       locations: Seq[Location],
-                                      ranges: Seq[TimeRange] = Seq.empty,
+                                      timeRangeContext: Option[TimeRangeContext] = None,
                                       timeContext: TimeContext,
                                       isSingleNode: Boolean)
         extends NSDbSerializable

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.{Bit, NSDbSerializable}
 import io.radicalbit.nsdb.common.statement.{DeleteSQLStatement, SelectSQLStatement}
-import io.radicalbit.nsdb.model.{Location, Schema, TimeContext, TimeRange, TimeRangeContext}
+import io.radicalbit.nsdb.model.{Location, Schema, TimeContext, TimeRangeContext}
 
 /**
   * common messages exchanged among all the nsdb actors.

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/NSDbLongRangeFactoryTest.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/NSDbLongRangeFactoryTest.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.index.aux
+
+import io.radicalbit.nsdb.test.NSDbSpec
+import org.apache.lucene.search.grouping.{LongRange, NSDbLongRangeFactory}
+
+class NSDbLongRangeFactoryTest extends NSDbSpec {
+
+  "NSdbLongRangeFactory" should {
+    "throw an exception if values beyond ranges are provided" in {
+      val factory = new NSDbLongRangeFactory(0, 50000, 30000)
+
+      an[IllegalArgumentException] should be thrownBy (factory.getRange(30001, null))
+      an[IllegalArgumentException] should be thrownBy (factory.getRange(-1, null))
+    }
+
+    "calculate the ranges starting from the upperbound" in {
+      val factory = new NSDbLongRangeFactory(0, 30000, 50000)
+
+      factory.getRange(50000, null) shouldBe new LongRange(20000, 50000)
+      factory.getRange(40000, null) shouldBe new LongRange(20000, 50000)
+      factory.getRange(30000, null) shouldBe new LongRange(20000, 50000)
+      factory.getRange(20000, null) shouldBe new LongRange(0, 20000)
+      factory.getRange(10000, null) shouldBe new LongRange(0, 20000)
+      factory.getRange(0, null) shouldBe new LongRange(0, 20000)
+    }
+
+    "calculate the ranges when width is an exact divider of the range interval" in {
+      val factory = new NSDbLongRangeFactory(120, 30, 180)
+
+      factory.getRange(180, null) shouldBe new LongRange(150, 180)
+      factory.getRange(160, null) shouldBe new LongRange(150, 180)
+      factory.getRange(150, null) shouldBe new LongRange(120, 150)
+      factory.getRange(130, null) shouldBe new LongRange(120, 150)
+      factory.getRange(120, null) shouldBe new LongRange(120, 150)
+    }
+
+    "calculate the ranges when width is not an exact divider of the range interval" in {
+      val factory = new NSDbLongRangeFactory(50, 50, 180)
+
+      factory.getRange(180, null) shouldBe new LongRange(130, 180)
+      factory.getRange(160, null) shouldBe new LongRange(130, 180)
+      factory.getRange(130, null) shouldBe new LongRange(80, 130)
+      factory.getRange(120, null) shouldBe new LongRange(80, 130)
+      factory.getRange(100, null) shouldBe new LongRange(80, 130)
+      factory.getRange(80, null) shouldBe new LongRange(50, 80)
+      factory.getRange(50, null) shouldBe new LongRange(50, 80)
+    }
+  }
+
+}

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/UniqueRangeValuesSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/UniqueRangeValuesSpec.scala
@@ -46,7 +46,7 @@ class UniqueRangeValuesSpec extends WordSpec with Matchers with OneInstancePerTe
   )
 
   "TimeSeriesIndex" should {
-    "calculate unique range unique values on the value" in {
+    "calculate unique range values on the value" in {
 
       val timeSeriesIndex =
         new TimeSeriesIndex(new MMapDirectory(Paths.get("target", "test_unique_index", UUID.randomUUID().toString)))
@@ -57,22 +57,29 @@ class UniqueRangeValuesSpec extends WordSpec with Matchers with OneInstancePerTe
 
       writer.close()
 
-       val timeRangeContext = TimeRangeContext(180000, 0 , 30000, Seq.empty)
-
       val uniqueValues =
-        timeSeriesIndex.uniqueRangeValues(new MatchAllDocsQuery, Schema("testMetric", testRecords.head), "value",timeRangeContext)
+        timeSeriesIndex.uniqueRangeValues(new MatchAllDocsQuery,
+                                          Schema("testMetric", testRecords.head),
+                                          "value",
+                                          0,
+                                          30000,
+                                          180000)
 
       uniqueValues shouldBe Seq(
-        Bit(0,0,Map("lowerbound" -> 150000L, "upperbound" -> 180000L),Map(),Set(NSDbDoubleType(2.5))),
-        Bit(0,0,Map("lowerbound" -> 120000L, "upperbound" -> 150000L),Map(),Set(NSDbDoubleType(3.5))),
-        Bit(0,0,Map("lowerbound" -> 90000L, "upperbound" -> 120000L),Map(),Set(NSDbDoubleType(5.5))),
-        Bit(0,0,Map("lowerbound" -> 60000L, "upperbound" -> 90000L),Map(),Set(NSDbDoubleType(8.5), NSDbDoubleType(7.5))),
-        Bit(0,0,Map("lowerbound" -> 30000L, "upperbound" -> 60000L),Map(),Set(NSDbDoubleType(4.5))),
-        Bit(0,0,Map("lowerbound" -> 0L, "upperbound" -> 30000L),Map(),Set(NSDbDoubleType(1.5)))
+        Bit(0, 0, Map("lowerbound" -> 150000L, "upperbound" -> 180000L), Map(), Set(NSDbDoubleType(2.5))),
+        Bit(0, 0, Map("lowerbound" -> 120000L, "upperbound" -> 150000L), Map(), Set(NSDbDoubleType(3.5))),
+        Bit(0, 0, Map("lowerbound" -> 90000L, "upperbound"  -> 120000L), Map(), Set(NSDbDoubleType(5.5))),
+        Bit(0,
+            0,
+            Map("lowerbound" -> 60000L, "upperbound" -> 90000L),
+            Map(),
+            Set(NSDbDoubleType(8.5), NSDbDoubleType(7.5))),
+        Bit(0, 0, Map("lowerbound" -> 30000L, "upperbound" -> 60000L), Map(), Set(NSDbDoubleType(4.5))),
+        Bit(0, 0, Map("lowerbound" -> 0L, "upperbound"     -> 30000L), Map(), Set(NSDbDoubleType(1.5)))
       )
     }
 
-    "calculate unique range unique values on a tag" in {
+    "calculate unique range values on a tag" in {
 
       val timeSeriesIndex =
         new TimeSeriesIndex(new MMapDirectory(Paths.get("target", "test_unique_index", UUID.randomUUID().toString)))
@@ -83,19 +90,54 @@ class UniqueRangeValuesSpec extends WordSpec with Matchers with OneInstancePerTe
 
       writer.close()
 
-      val timeRangeContext = TimeRangeContext(180000, 0 , 30000, Seq.empty)
+      val timeRangeContext = TimeRangeContext(180000, 0, 30000, Seq.empty)
 
       val uniqueValues =
-        timeSeriesIndex.uniqueRangeValues(new MatchAllDocsQuery, Schema("testMetric", testRecords.head), "name",timeRangeContext)
+        timeSeriesIndex.uniqueRangeValues(new MatchAllDocsQuery,
+                                          Schema("testMetric", testRecords.head),
+                                          "name",
+                                          0,
+                                          30000,
+                                          180000)
 
       uniqueValues shouldBe Seq(
-        Bit(0,0,Map("lowerbound" -> 150000L, "upperbound" -> 180000L),Map(),Set(NSDbStringType("John"),NSDbStringType("Bill"))),
-        Bit(0,0,Map("lowerbound" -> 120000L, "upperbound" -> 150000L),Map(),Set(NSDbStringType("John"),NSDbStringType("Bill"))),
-        Bit(0,0,Map("lowerbound" -> 90000L, "upperbound" -> 120000L),Map(),Set(NSDbStringType("John"))),
-        Bit(0,0,Map("lowerbound" -> 60000L, "upperbound" -> 90000L),Map(),Set(NSDbStringType("Bill"))),
-        Bit(0,0,Map("lowerbound" -> 30000L, "upperbound" -> 60000L),Map(),Set(NSDbStringType("Frank"))),
-        Bit(0,0,Map("lowerbound" -> 0L, "upperbound" -> 30000L),Map(),Set(NSDbStringType("Frankie")))
+        Bit(0,
+            0,
+            Map("lowerbound" -> 150000L, "upperbound" -> 180000L),
+            Map(),
+            Set(NSDbStringType("John"), NSDbStringType("Bill"))),
+        Bit(0,
+            0,
+            Map("lowerbound" -> 120000L, "upperbound" -> 150000L),
+            Map(),
+            Set(NSDbStringType("John"), NSDbStringType("Bill"))),
+        Bit(0, 0, Map("lowerbound" -> 90000L, "upperbound" -> 120000L), Map(), Set(NSDbStringType("John"))),
+        Bit(0, 0, Map("lowerbound" -> 60000L, "upperbound" -> 90000L), Map(), Set(NSDbStringType("Bill"))),
+        Bit(0, 0, Map("lowerbound" -> 30000L, "upperbound" -> 60000L), Map(), Set(NSDbStringType("Frank"))),
+        Bit(0, 0, Map("lowerbound" -> 0L, "upperbound"     -> 30000L), Map(), Set(NSDbStringType("Frankie")))
       )
+    }
+
+    "calculate unique range on an empty interval" in {
+
+      val timeSeriesIndex =
+        new TimeSeriesIndex(new MMapDirectory(Paths.get("target", "test_unique_index", UUID.randomUUID().toString)))
+
+      val writer = timeSeriesIndex.getWriter
+
+      testRecords.foreach(timeSeriesIndex.write(_)(writer))
+
+      writer.close()
+
+      val uniqueValues =
+        timeSeriesIndex.uniqueRangeValues(new MatchAllDocsQuery,
+                                          Schema("testMetric", testRecords.head),
+                                          "value",
+                                          0,
+                                          30000,
+                                          0)
+
+      uniqueValues shouldBe Seq.empty
     }
 
   }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/UniqueRangeValuesSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/UniqueRangeValuesSpec.scala
@@ -66,16 +66,16 @@ class UniqueRangeValuesSpec extends WordSpec with Matchers with OneInstancePerTe
                                           180000)
 
       uniqueValues shouldBe Seq(
-        Bit(0, 0, Map("lowerbound" -> 150000L, "upperbound" -> 180000L), Map(), Set(NSDbDoubleType(2.5))),
-        Bit(0, 0, Map("lowerbound" -> 120000L, "upperbound" -> 150000L), Map(), Set(NSDbDoubleType(3.5))),
-        Bit(0, 0, Map("lowerbound" -> 90000L, "upperbound"  -> 120000L), Map(), Set(NSDbDoubleType(5.5))),
-        Bit(0,
+        Bit(150000, 0, Map("lowerBound" -> 150000L, "upperBound" -> 180000L), Map(), Set(NSDbDoubleType(2.5))),
+        Bit(120000, 0, Map("lowerBound" -> 120000L, "upperBound" -> 150000L), Map(), Set(NSDbDoubleType(3.5))),
+        Bit(90000, 0, Map("lowerBound"  -> 90000L, "upperBound"  -> 120000L), Map(), Set(NSDbDoubleType(5.5))),
+        Bit(60000,
             0,
-            Map("lowerbound" -> 60000L, "upperbound" -> 90000L),
+            Map("lowerBound" -> 60000L, "upperBound" -> 90000L),
             Map(),
             Set(NSDbDoubleType(8.5), NSDbDoubleType(7.5))),
-        Bit(0, 0, Map("lowerbound" -> 30000L, "upperbound" -> 60000L), Map(), Set(NSDbDoubleType(4.5))),
-        Bit(0, 0, Map("lowerbound" -> 0L, "upperbound"     -> 30000L), Map(), Set(NSDbDoubleType(1.5)))
+        Bit(30000, 0, Map("lowerBound" -> 30000L, "upperBound" -> 60000L), Map(), Set(NSDbDoubleType(4.5))),
+        Bit(0, 0, Map("lowerBound"     -> 0L, "upperBound"     -> 30000L), Map(), Set(NSDbDoubleType(1.5)))
       )
     }
 
@@ -90,7 +90,7 @@ class UniqueRangeValuesSpec extends WordSpec with Matchers with OneInstancePerTe
 
       writer.close()
 
-      val timeRangeContext = TimeRangeContext(180000, 0, 30000, Seq.empty)
+      TimeRangeContext(180000, 0, 30000, Seq.empty)
 
       val uniqueValues =
         timeSeriesIndex.uniqueRangeValues(new MatchAllDocsQuery,
@@ -101,43 +101,21 @@ class UniqueRangeValuesSpec extends WordSpec with Matchers with OneInstancePerTe
                                           180000)
 
       uniqueValues shouldBe Seq(
-        Bit(0,
+        Bit(150000,
             0,
-            Map("lowerbound" -> 150000L, "upperbound" -> 180000L),
+            Map("lowerBound" -> 150000L, "upperBound" -> 180000L),
             Map(),
             Set(NSDbStringType("John"), NSDbStringType("Bill"))),
-        Bit(0,
+        Bit(120000,
             0,
-            Map("lowerbound" -> 120000L, "upperbound" -> 150000L),
+            Map("lowerBound" -> 120000L, "upperBound" -> 150000L),
             Map(),
             Set(NSDbStringType("John"), NSDbStringType("Bill"))),
-        Bit(0, 0, Map("lowerbound" -> 90000L, "upperbound" -> 120000L), Map(), Set(NSDbStringType("John"))),
-        Bit(0, 0, Map("lowerbound" -> 60000L, "upperbound" -> 90000L), Map(), Set(NSDbStringType("Bill"))),
-        Bit(0, 0, Map("lowerbound" -> 30000L, "upperbound" -> 60000L), Map(), Set(NSDbStringType("Frank"))),
-        Bit(0, 0, Map("lowerbound" -> 0L, "upperbound"     -> 30000L), Map(), Set(NSDbStringType("Frankie")))
+        Bit(90000, 0, Map("lowerBound" -> 90000L, "upperBound" -> 120000L), Map(), Set(NSDbStringType("John"))),
+        Bit(60000, 0, Map("lowerBound" -> 60000L, "upperBound" -> 90000L), Map(), Set(NSDbStringType("Bill"))),
+        Bit(30000, 0, Map("lowerBound" -> 30000L, "upperBound" -> 60000L), Map(), Set(NSDbStringType("Frank"))),
+        Bit(0, 0, Map("lowerBound"     -> 0L, "upperBound"     -> 30000L), Map(), Set(NSDbStringType("Frankie")))
       )
-    }
-
-    "calculate unique range on an empty interval" in {
-
-      val timeSeriesIndex =
-        new TimeSeriesIndex(new MMapDirectory(Paths.get("target", "test_unique_index", UUID.randomUUID().toString)))
-
-      val writer = timeSeriesIndex.getWriter
-
-      testRecords.foreach(timeSeriesIndex.write(_)(writer))
-
-      writer.close()
-
-      val uniqueValues =
-        timeSeriesIndex.uniqueRangeValues(new MatchAllDocsQuery,
-                                          Schema("testMetric", testRecords.head),
-                                          "value",
-                                          0,
-                                          30000,
-                                          0)
-
-      uniqueValues shouldBe Seq.empty
     }
 
   }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/UniqueRangeValuesSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/UniqueRangeValuesSpec.scala
@@ -23,11 +23,12 @@ import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.{NSDbDoubleType, NSDbStringType}
 import io.radicalbit.nsdb.index.TimeSeriesIndex
 import io.radicalbit.nsdb.model.{Schema, TimeRangeContext}
+import io.radicalbit.nsdb.test.NSDbSpec
 import org.apache.lucene.search.MatchAllDocsQuery
 import org.apache.lucene.store.MMapDirectory
-import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
+import org.scalatest.OneInstancePerTest
 
-class UniqueRangeValuesSpec extends WordSpec with Matchers with OneInstancePerTest {
+class UniqueRangeValuesSpec extends NSDbSpec with OneInstancePerTest {
 
   val testRecords: Seq[Bit] = Seq(
     Bit(180000, 2.5, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 31L)),

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/UniqueRangeValuesSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/aux/UniqueRangeValuesSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.index.aux
+
+import java.nio.file.Paths
+import java.util.UUID
+
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.common.{NSDbDoubleType, NSDbStringType}
+import io.radicalbit.nsdb.index.TimeSeriesIndex
+import io.radicalbit.nsdb.model.{Schema, TimeRangeContext}
+import org.apache.lucene.search.MatchAllDocsQuery
+import org.apache.lucene.store.MMapDirectory
+import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
+
+class UniqueRangeValuesSpec extends WordSpec with Matchers with OneInstancePerTest {
+
+  val testRecords: Seq[Bit] = Seq(
+    Bit(180000, 2.5, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 31L)),
+    Bit(170000, 2.5, Map("surname" -> "Doe"), Map("name" -> "Bill", "age" -> 31L)),
+    Bit(160000, 2.5, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 30L)),
+    Bit(150000, 2.5, Map("surname" -> "Doe"), Map("name" -> "Bill", "age" -> 30L)),
+    Bit(140000, 3.5, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 33L)),
+    Bit(130000, 3.5, Map("surname" -> "Doe"), Map("name" -> "Bill", "age" -> 33L)),
+    Bit(120000, 3.5, Map("surname" -> "Doe"), Map("name" -> "John", "age" -> 32L)),
+    Bit(90000, 5.5, Map("surname"  -> "Doe"), Map("name" -> "John")),
+    Bit(60000, 7.5, Map("surname"  -> "Doe"), Map("name" -> "Bill")),
+    Bit(70000, 7.5, Map("surname"  -> "Doe"), Map("name" -> "Bill", "age" -> 34L)),
+    Bit(80000, 8.5, Map("surname"  -> "Doe"), Map("name" -> "Bill", "age" -> 34L)),
+    Bit(30000, 4.5, Map("surname"  -> "Doe"), Map("name" -> "Frank")),
+    Bit(0, 1.5, Map("surname"      -> "Doe"), Map("name" -> "Frankie"))
+  )
+
+  "TimeSeriesIndex" should {
+    "calculate unique range unique values on the value" in {
+
+      val timeSeriesIndex =
+        new TimeSeriesIndex(new MMapDirectory(Paths.get("target", "test_unique_index", UUID.randomUUID().toString)))
+
+      val writer = timeSeriesIndex.getWriter
+
+      testRecords.foreach(timeSeriesIndex.write(_)(writer))
+
+      writer.close()
+
+       val timeRangeContext = TimeRangeContext(180000, 0 , 30000, Seq.empty)
+
+      val uniqueValues =
+        timeSeriesIndex.uniqueRangeValues(new MatchAllDocsQuery, Schema("testMetric", testRecords.head), "value",timeRangeContext)
+
+      uniqueValues shouldBe Seq(
+        Bit(0,0,Map("lowerbound" -> 150000L, "upperbound" -> 180000L),Map(),Set(NSDbDoubleType(2.5))),
+        Bit(0,0,Map("lowerbound" -> 120000L, "upperbound" -> 150000L),Map(),Set(NSDbDoubleType(3.5))),
+        Bit(0,0,Map("lowerbound" -> 90000L, "upperbound" -> 120000L),Map(),Set(NSDbDoubleType(5.5))),
+        Bit(0,0,Map("lowerbound" -> 60000L, "upperbound" -> 90000L),Map(),Set(NSDbDoubleType(8.5), NSDbDoubleType(7.5))),
+        Bit(0,0,Map("lowerbound" -> 30000L, "upperbound" -> 60000L),Map(),Set(NSDbDoubleType(4.5))),
+        Bit(0,0,Map("lowerbound" -> 0L, "upperbound" -> 30000L),Map(),Set(NSDbDoubleType(1.5)))
+      )
+    }
+
+    "calculate unique range unique values on a tag" in {
+
+      val timeSeriesIndex =
+        new TimeSeriesIndex(new MMapDirectory(Paths.get("target", "test_unique_index", UUID.randomUUID().toString)))
+
+      val writer = timeSeriesIndex.getWriter
+
+      testRecords.foreach(timeSeriesIndex.write(_)(writer))
+
+      writer.close()
+
+      val timeRangeContext = TimeRangeContext(180000, 0 , 30000, Seq.empty)
+
+      val uniqueValues =
+        timeSeriesIndex.uniqueRangeValues(new MatchAllDocsQuery, Schema("testMetric", testRecords.head), "name",timeRangeContext)
+
+      uniqueValues shouldBe Seq(
+        Bit(0,0,Map("lowerbound" -> 150000L, "upperbound" -> 180000L),Map(),Set(NSDbStringType("John"),NSDbStringType("Bill"))),
+        Bit(0,0,Map("lowerbound" -> 120000L, "upperbound" -> 150000L),Map(),Set(NSDbStringType("John"),NSDbStringType("Bill"))),
+        Bit(0,0,Map("lowerbound" -> 90000L, "upperbound" -> 120000L),Map(),Set(NSDbStringType("John"))),
+        Bit(0,0,Map("lowerbound" -> 60000L, "upperbound" -> 90000L),Map(),Set(NSDbStringType("Bill"))),
+        Bit(0,0,Map("lowerbound" -> 30000L, "upperbound" -> 60000L),Map(),Set(NSDbStringType("Frank"))),
+        Bit(0,0,Map("lowerbound" -> 0L, "upperbound" -> 30000L),Map(),Set(NSDbStringType("Frankie")))
+      )
+    }
+
+  }
+
+}

--- a/nsdb-it/README.md
+++ b/nsdb-it/README.md
@@ -30,9 +30,9 @@ discovery {
 ```  
 
 ```scala
-import io.radicalbit.nsdb.minicluster.NsdbMiniCluster
+import io.radicalbit.nsdb.minicluster.NSDbMiniCluster
 
-object MiniClusterStarter extends App with NsdbMiniCluster {
+object MiniClusterStarter extends App with NSDbMiniCluster {
   override protected[this] def nodesNumber              = 3
   override protected[this] def passivateAfter: Duration = Duration.ofHours(1)
 

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/TemporalReadCoordinatorSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/TemporalReadCoordinatorSpec.scala
@@ -41,8 +41,6 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
     super.beforeAll()
 
-    val firstNode = nodes.head
-
     val nsdbConnection =
       eventually {
         Await.result(NSDB.connect(host = firstNode.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
@@ -452,19 +450,18 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
-        .query(s"select avg(*) from ${TemporalLongMetric.name} group by interval 30s")
+        .query(s"select avg(*) from ${TemporalLongMetric.name} group by interval 50s")
 
       eventually {
         val readRes = Await.result(nsdb.execute(query), 10.seconds)
 
         assert(readRes.completedSuccessfully)
-        assert(readRes.records.size == 5)
+        assert(readRes.records.size == 4)
         assert(readRes.records.map(_.asBit) == Seq(
-          Bit(30000, 2.5 , Map("lowerBound" -> 0L, "upperBound" -> 30000L), Map()),
-          Bit(60000, 7.0, Map("lowerBound" -> 30000L, "upperBound" -> 60000L), Map()),
-          Bit(90000, 5.0, Map("lowerBound" -> 60000L, "upperBound" -> 90000L), Map()),
-          Bit(120000, 3.0, Map("lowerBound" -> 90000L, "upperBound" -> 120000L), Map()),
-          Bit(150000, 2.0, Map("lowerBound" -> 120000L, "upperBound" -> 150000L), Map())
+          Bit(0, 2.5 , Map("lowerBound" -> 0L, "upperBound" -> 30000L), Map()),
+          Bit(30000, 7.0, Map("lowerBound" -> 30000L, "upperBound" -> 80000L), Map()),
+          Bit(80000, 4.0, Map("lowerBound" -> 80000L, "upperBound" -> 130000L), Map()),
+          Bit(130000, 2.0, Map("lowerBound" -> 130000L, "upperBound" -> 180000L), Map())
         ))
       }
     }
@@ -506,20 +503,17 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
-        .query(s"select count( distinct *) from ${TemporalLongMetric.name} group by interval 30s")
+        .query(s"select count( distinct *) from ${TemporalLongMetric.name} group by interval 50s")
 
       eventually {
         val readRes = Await.result(nsdb.execute(query), 10.seconds)
 
         assert(readRes.completedSuccessfully)
-        assert(readRes.records.size == 6)
+        assert(readRes.records.size == 3)
         assert(readRes.records.map(_.asBit) == Seq(
-          Bit(0,0L,Map("lowerBound" -> 0L, "upperBound" -> 30000L),Map(),Set()),
-          Bit(30000,0L,Map("lowerBound" -> 30000L, "upperBound" -> 60000L),Map(),Set()),
-          Bit(60000,0L,Map("lowerBound" -> 60000L, "upperBound" -> 90000L),Map(),Set()),
-          Bit(90000,0L,Map("lowerBound" -> 90000L, "upperBound" -> 120000L),Map(),Set()),
-          Bit(120000,0L,Map("lowerBound" -> 120000L, "upperBound" -> 150000L),Map(),Set()),
-          Bit(150000,0L,Map("lowerBound" -> 150000L, "upperBound" -> 180000L),Map(),Set())
+          Bit(0,1L,Map("lowerBound" -> 0L, "upperBound" -> 50000L),Map(),Set()),
+          Bit(50000,1L,Map("lowerBound" -> 50000L, "upperBound" -> 100000L),Map(),Set()),
+          Bit(100000,1L,Map("lowerBound" -> 100000L, "upperBound" -> 150000L),Map(),Set()),
         ))
       }
     }
@@ -534,7 +528,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
-        .query(s"select count( distinct height) from ${TemporalLongMetric.name} group by interval 30s")
+        .query(s"select count( distinct height) from ${TemporalLongMetric.name} group by interval 50s")
 
       eventually {
         val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -542,12 +536,12 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
         assert(readRes.completedSuccessfully)
         assert(readRes.records.size == 6)
         assert(readRes.records.map(_.asBit) == Seq(
-          Bit(0,0L,Map("lowerBound" -> 0L, "upperBound" -> 30000L),Map(),Set()),
-          Bit(30000,0L,Map("lowerBound" -> 30000L, "upperBound" -> 60000L),Map(),Set()),
-          Bit(60000,0L,Map("lowerBound" -> 60000L, "upperBound" -> 90000L),Map(),Set()),
-          Bit(90000,0L,Map("lowerBound" -> 90000L, "upperBound" -> 120000L),Map(),Set()),
-          Bit(120000,0L,Map("lowerBound" -> 120000L, "upperBound" -> 150000L),Map(),Set()),
-          Bit(150000,0L,Map("lowerBound" -> 150000L, "upperBound" -> 180000L),Map(),Set())
+          Bit(0,1L,Map("lowerBound" -> 0L, "upperBound" -> 30000L),Map(),Set()),
+          Bit(30000,1L,Map("lowerBound" -> 30000L, "upperBound" -> 60000L),Map(),Set()),
+          Bit(60000,1L,Map("lowerBound" -> 60000L, "upperBound" -> 90000L),Map(),Set()),
+          Bit(90000,1L,Map("lowerBound" -> 90000L, "upperBound" -> 120000L),Map(),Set()),
+          Bit(120000,1L,Map("lowerBound" -> 120000L, "upperBound" -> 150000L),Map(),Set()),
+          Bit(150000,1L,Map("lowerBound" -> 150000L, "upperBound" -> 180000L),Map(),Set())
         ))
       }
     }

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/TemporalReadCoordinatorSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/TemporalReadCoordinatorSpec.scala
@@ -458,10 +458,10 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
         assert(readRes.completedSuccessfully)
         assert(readRes.records.size == 4)
         assert(readRes.records.map(_.asBit) == Seq(
-          Bit(0, 2.5 , Map("lowerBound" -> 0L, "upperBound" -> 30000L), Map()),
-          Bit(30000, 7.0, Map("lowerBound" -> 30000L, "upperBound" -> 80000L), Map()),
-          Bit(80000, 4.0, Map("lowerBound" -> 80000L, "upperBound" -> 130000L), Map()),
-          Bit(130000, 2.0, Map("lowerBound" -> 130000L, "upperBound" -> 180000L), Map())
+          Bit(30000, 2.5 , Map("lowerBound" -> 0L, "upperBound" -> 30000L), Map()),
+          Bit(80000, 7.0, Map("lowerBound" -> 30000L, "upperBound" -> 80000L), Map()),
+          Bit(130000, 4.0, Map("lowerBound" -> 80000L, "upperBound" -> 130000L), Map()),
+          Bit(180000, 2.0, Map("lowerBound" -> 130000L, "upperBound" -> 180000L), Map())
         ))
       }
     }
@@ -509,11 +509,11 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
         val readRes = Await.result(nsdb.execute(query), 10.seconds)
 
         assert(readRes.completedSuccessfully)
-        assert(readRes.records.size == 3)
         assert(readRes.records.map(_.asBit) == Seq(
-          Bit(0,1L,Map("lowerBound" -> 0L, "upperBound" -> 50000L),Map(),Set()),
-          Bit(50000,1L,Map("lowerBound" -> 50000L, "upperBound" -> 100000L),Map(),Set()),
-          Bit(100000,1L,Map("lowerBound" -> 100000L, "upperBound" -> 150000L),Map(),Set()),
+          Bit(30000,2L,Map("lowerBound" -> 0L, "upperBound" -> 30000L),Map()),
+          Bit(80000,1L,Map("lowerBound" -> 30000L, "upperBound" -> 80000L),Map()),
+          Bit(130000,2L,Map("lowerBound" -> 80000L, "upperBound" -> 130000L),Map()),
+          Bit(180000,1L,Map("lowerBound" -> 130000L, "upperBound" -> 180000L),Map())
         ))
       }
     }
@@ -528,20 +528,18 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
-        .query(s"select count( distinct height) from ${TemporalLongMetric.name} group by interval 50s")
+        .query(s"select count( distinct height) from ${TemporalLongMetric.name} group by interval 30s order by timestamp desc")
 
       eventually {
         val readRes = Await.result(nsdb.execute(query), 10.seconds)
 
         assert(readRes.completedSuccessfully)
-        assert(readRes.records.size == 6)
         assert(readRes.records.map(_.asBit) == Seq(
-          Bit(0,1L,Map("lowerBound" -> 0L, "upperBound" -> 30000L),Map(),Set()),
-          Bit(30000,1L,Map("lowerBound" -> 30000L, "upperBound" -> 60000L),Map(),Set()),
-          Bit(60000,1L,Map("lowerBound" -> 60000L, "upperBound" -> 90000L),Map(),Set()),
-          Bit(90000,1L,Map("lowerBound" -> 90000L, "upperBound" -> 120000L),Map(),Set()),
-          Bit(120000,1L,Map("lowerBound" -> 120000L, "upperBound" -> 150000L),Map(),Set()),
-          Bit(150000,1L,Map("lowerBound" -> 150000L, "upperBound" -> 180000L),Map(),Set())
+          Bit(150000,1L,Map("lowerBound" -> 120000L, "upperBound" -> 150000L),Map(),Set()),
+          Bit(120000,1L,Map("lowerBound" -> 90000L, "upperBound" -> 120000L),Map(),Set()),
+          Bit(90000,1L,Map("lowerBound" -> 60000L, "upperBound" -> 90000L),Map(),Set()),
+          Bit(60000,1L,Map("lowerBound" -> 30000L, "upperBound" -> 60000L),Map(),Set()),
+          Bit(30000,1L,Map("lowerBound" -> 0L, "upperBound" -> 30000L),Map(),Set())
         ))
       }
     }

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/test/MiniClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/test/MiniClusterSpec.scala
@@ -20,14 +20,14 @@ import java.time.Duration
 import java.util.logging.{Level, Logger}
 
 import io.radicalbit.nsdb.cluster.extension.NSDbClusterSnapshot
-import io.radicalbit.nsdb.minicluster.NsdbMiniCluster
+import io.radicalbit.nsdb.minicluster.{NSDbMiniCluster, NSDbMiniClusterNode}
 import org.json4s.DefaultFormats
 import org.scalatest.concurrent.Eventually
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{Assertion, BeforeAndAfterAll}
 
-trait MiniClusterSpec extends AnyFunSuite with BeforeAndAfterAll with Eventually with NsdbMiniCluster {
+trait MiniClusterSpec extends AnyFunSuite with BeforeAndAfterAll with Eventually with NSDbMiniCluster {
 
   Logger.getLogger("io.grpc.internal").setLevel(Level.OFF)
 
@@ -51,6 +51,7 @@ trait MiniClusterSpec extends AnyFunSuite with BeforeAndAfterAll with Eventually
     stop()
   }
 
+  lazy val firstNode: NSDbMiniClusterNode = nodes.head
 
   protected lazy val indexingTime: Long =
     nodes.head.system.settings.config.getDuration("nsdb.write.scheduler.interval").toMillis

--- a/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/MiniClusterStarter.scala
+++ b/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/MiniClusterStarter.scala
@@ -18,7 +18,7 @@ package io.radicalbit.nsdb.minicluster
 
 import java.time.Duration
 
-object MiniClusterStarter extends App with NsdbMiniCluster {
+object MiniClusterStarter extends App with NSDbMiniCluster {
   override protected[this] def nodesNumber              = 3
   override protected[this] def replicationFactor: Int   = 2
   override protected[this] def rootFolder: String       = s"target/minicluster/$instanceId"

--- a/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/NSDbMiniCluster.scala
+++ b/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/NSDbMiniCluster.scala
@@ -23,7 +23,7 @@ import java.util.UUID
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.io.FileUtils
 
-trait NsdbMiniCluster extends LazyLogging {
+trait NSDbMiniCluster extends LazyLogging {
 
   protected[this] val instanceId = { UUID.randomUUID }
 

--- a/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/test/MiniClusterSingleNodeSpec.scala
+++ b/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/test/MiniClusterSingleNodeSpec.scala
@@ -19,14 +19,14 @@ package io.radicalbit.nsdb.minicluster.test
 import java.time.Duration
 import java.util.logging.{Level, Logger}
 
-import io.radicalbit.nsdb.minicluster.NsdbMiniCluster
+import io.radicalbit.nsdb.minicluster.NSDbMiniCluster
 import org.json4s.DefaultFormats
 import org.scalatest.concurrent.Eventually
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.BeforeAndAfterAll
 
-trait MiniClusterSingleNodeSpec extends AnyFunSuite with BeforeAndAfterAll with Eventually with NsdbMiniCluster {
+trait MiniClusterSingleNodeSpec extends AnyFunSuite with BeforeAndAfterAll with Eventually with NSDbMiniCluster {
 
   Logger.getLogger("io.grpc.internal").setLevel(Level.OFF)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -124,7 +124,7 @@ object Dependencies {
   }
 
   object javaWebsocket {
-    lazy val version       = "1.3.8"
+    lazy val version       = "1.5.1"
     lazy val namespace     = "org.java-websocket"
     lazy val javaWebsocket = namespace % "Java-WebSocket" % version
   }
@@ -136,7 +136,7 @@ object Dependencies {
   }
 
   object lucene {
-    lazy val version     = "8.6.2"
+    lazy val version     = "8.6.3"
     lazy val namespace   = "org.apache.lucene"
     lazy val core        = namespace % "lucene-core" % version
     lazy val queryParser = namespace % "lucene-queryparser" % version


### PR DESCRIPTION
This PR enables count distinct aggregation on temporal queries.
For instance, expressions like
```
select count(distinct *) from metric group by interval 60s
select count(distinct *) from metric group by interval 60s where tag = "constant" order by timestamp desc
```

will be supported