### PR TITLE
Lightened location load at node startup

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
@@ -39,6 +39,7 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{
 }
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.extension.NSDbClusterSnapshot
+import io.radicalbit.nsdb.cluster.logic.WriteConfig.MetadataConsistency
 import io.radicalbit.nsdb.cluster.metrics.NSDbMetrics
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel._
 import io.radicalbit.nsdb.model.LocationWithCoordinates
@@ -176,7 +177,7 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
                 case ((db, namespace), locations) =>
                   metadataCoordinator ? AddLocations(db, namespace, locations.map {
                     case LocationWithCoordinates(_, _, location) => location
-                  })
+                  }, consistency = Some(MetadataConsistency.Local))
               }
             }
             .map(ErrorManagementUtils.partitionResponses[LocationsAdded, AddLocationsFailed])

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
@@ -19,9 +19,9 @@ class ClusterListenerSpecMultiJvmNode2 extends ClusterListenerSpec
 
 class MetaDataCoordinatorForTest extends Actor with ActorLogging {
   def receive: Receive = {
-    case AddLocations("success", namespace, locations) =>
+    case AddLocations("success", namespace, locations, _) =>
       sender() ! LocationsAdded("success", namespace, locations)
-    case AddLocations("failure", namespace, locations) =>
+    case AddLocations("failure", namespace, locations, _) =>
       sender() ! AddLocationsFailed("failure", namespace, locations)
     case UnsubscribeMetricsDataActor(nodeName)     => sender() ! MetricsDataActorUnSubscribed(nodeName)
     case UnSubscribeCommitLogCoordinator(nodeName) => sender() ! CommitLogCoordinatorUnSubscribed(nodeName)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
@@ -55,7 +55,7 @@ class LocalMetadataCache extends Actor {
     case DropNamespaceFromCache(db, namespace) =>
       coordinates --= coordinates.filter(c => c.db == db && c.namespace == namespace)
       sender() ! NamespaceFromCacheDropped(db, namespace)
-    case PutLocationInCache(db, namespace, metric, value) =>
+    case PutLocationInCache(db, namespace, metric, value, _) =>
       val key              = MetricLocationsCacheKey(db, namespace, metric)
       val previousLocation = locations.getOrElse(key, Set.empty)
       locations.put(key, previousLocation + value)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
@@ -93,7 +93,7 @@ class LocalMetadataCoordinator(cache: ActorRef) extends Actor {
                                     s"unexpected response while trying to put metadata in cache $e")
         }
         .pipeTo(sender())
-    case AddLocations(db, namespace, locations) =>
+    case AddLocations(db, namespace, locations, _) =>
       Future
         .sequence(
           locations.map(location =>

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -147,6 +147,7 @@ class PublisherActorSpec
       probe.expectMsgType[SubscribedByQueryString]
 
       publisherActor.underlyingActor.temporalAggregatedQueries.keys.size shouldBe 1
+      publisherActor.underlyingActor.temporalAggregatedTasks.keys.size shouldBe 1
       publisherActor.underlyingActor.temporalAggregatedQueries.values.head.query shouldBe testTemporalAggregatedSqlStatement(
         CountAggregation("value"))
 
@@ -157,6 +158,7 @@ class PublisherActorSpec
       probe.expectMsgType[Unsubscribed]
 
       publisherActor.underlyingActor.subscribedActorsByQueryId.keys.size shouldBe 0
+      publisherActor.underlyingActor.temporalAggregatedTasks.keys.size shouldBe 0
     }
 
     "subscribe more than once" in {
@@ -279,6 +281,10 @@ class PublisherActorSpec
                                 Some(testTimeContext))
       )
       secondProbe.expectMsgType[SubscribedByQueryString]
+
+      publisherActor.underlyingActor.temporalAggregatedTasks.size shouldBe 1
+      publisherActor.underlyingActor.subscribedActorsByQueryId.size shouldBe 1
+      publisherActor.underlyingActor.subscribedActorsByQueryId.head._2.size shouldBe 2
 
       probe.send(publisherActor, PublishRecord("db", "registry", "people", testRecordSatisfy, schema))
       val recordPublished = probe.expectMsgType[RecordsPublished]


### PR DESCRIPTION
This PR aims at :

- making the location load process at the node startup faster by adding entries to the akka cache with the local consistency (synchronous ack from the local node only then asynchronous dissemination)
- fixing the realtime query unsubscribe process by properly closing the created scheduler task 