### PR TITLE
Add Websocket connections Monitoring metric

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,4 +87,4 @@ jobs:
     - stage: "Image Creation Test"
       script: sbt +publishLocal docker:publishLocal
     - stage: "push"
-      script: $TRAVIS_BUILD_DIR/travis-credentials.sh && sbt +publish && docker login -u $DOCKER_USER -p $DOCKER_PASSWORD && sbt docker:publish
+      script: $TRAVIS_BUILD_DIR/travis-credentials.sh && sbt +publish && docker login -u $DOCKER_USER -p $DOCKER_PASSWORD && sbt ";project nsdb-cluster; docker:publish"

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/monitoring/NSDbMonitoring.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/monitoring/NSDbMonitoring.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.monitoring
+
+object NSDbMonitoring {
+
+  final val NSDbWsConnectionsTotal = "nsdb_ws_connections_total"
+
+}

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
@@ -27,7 +27,9 @@ import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import com.typesafe.config.Config
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel._
+import io.radicalbit.nsdb.monitoring.NSDbMonitoring
 import io.radicalbit.nsdb.security.NsdbSecurity
+import kamon.Kamon
 import org.json4s.Formats
 
 import scala.concurrent.duration._
@@ -59,6 +61,7 @@ trait WebResources extends WsResources with SSLSupport { this: NsdbSecurity =>
                       publisher: ActorRef)(implicit logger: LoggingAdapter) =
     authProvider match {
       case Success(provider) =>
+        Kamon.gauge(NSDbMonitoring.NSDbWsConnectionsTotal).withoutTags()
         val api: Route = wsResources(publisher, provider) ~ new ApiResources(publisher,
                                                                              readCoordinator,
                                                                              writeCoordinator,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -103,12 +103,10 @@ object Dependencies {
 
   object kamon {
     lazy val namespace= "io.kamon"
-    lazy val kamonVersion = "2.0.4"
-    lazy val kamonPrometheusVersion = "2.0.1"
+    lazy val kamonVersion = "2.1.8"
     lazy val sigarVersion = "1.6.6-rev002"
     lazy val bundle = namespace %% "kamon-bundle" % kamonVersion
-    lazy val prometheus = namespace %% "kamon-prometheus" %  kamonPrometheusVersion
-    lazy val sigarLoader = namespace % "sigar-loader" % sigarVersion
+    lazy val prometheus = namespace %% "kamon-prometheus" %  kamonVersion
   }
 
   object lithium {
@@ -217,6 +215,8 @@ object Dependencies {
       lucene.grouping,
       lucene.facet,
       lucene.backwardCodecs,
+      kamon.bundle,
+      kamon.prometheus,
       scalatest.core % Test,
       akka.testkit   % Test,
       commonsIo.commonsIo,
@@ -258,9 +258,6 @@ object Dependencies {
       lithium.core,
       scala_logging.scala_logging,
       akka.slf4j,
-      kamon.bundle,
-      kamon.prometheus,
-      kamon.sigarLoader,
       logback.logback,
       scalatest.core % Test,
       akka.testkit   % Test,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,5 @@ addSbtPlugin("com.typesafe.sbt"                  % "sbt-multi-jvm"       % "0.4.
 addSbtPlugin("io.gatling"                        % "gatling-sbt"         % "3.0.0")
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-native-packager" % "1.3.2")
 addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"        % "0.9.21")
-addSbtPlugin("io.kamon"                          % "sbt-kanela-runner"   % "2.0.3")
+addSbtPlugin("io.kamon"                          % "sbt-kanela-runner"   % "2.0.6")
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"       % "0.9.0")


### PR DESCRIPTION
This PR adds a custom kamon metric about the WebSocket opened connection.
It's a Kamon gauge that is incremented during the prestart of the StreamActor (that is 1:1 coupled with the HTTP WebSockets channels) and decremented during its poststop.