### PR TITLE
[HOTFIX] Exclude Future Buckets from temporal queries

### DIFF
--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
@@ -35,7 +35,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -67,7 +68,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -95,7 +97,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -127,7 +130,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -154,7 +158,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -182,7 +187,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -220,7 +226,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalDoubleMetric.name,
@@ -252,7 +259,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalDoubleMetric.name,
@@ -283,7 +291,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -316,7 +325,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -348,7 +358,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -375,7 +386,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -408,7 +420,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -440,7 +453,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -472,7 +486,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalDoubleMetric.name,
@@ -504,7 +519,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalDoubleMetric.name,
@@ -536,7 +552,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -568,7 +585,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -600,7 +618,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalDoubleMetric.name,
@@ -632,7 +651,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalDoubleMetric.name,
@@ -664,7 +684,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -696,7 +717,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -728,7 +750,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalDoubleMetric.name,
@@ -760,7 +783,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalDoubleMetric.name,
@@ -791,7 +815,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -823,7 +848,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -855,7 +881,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalDoubleMetric.name,
@@ -887,7 +914,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalDoubleMetric.name,
@@ -918,7 +946,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -950,7 +979,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -982,7 +1012,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -1006,7 +1037,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -1014,8 +1046,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
                 fields = ListFields(List(Field("*", Some(CountAggregation("value"))))),
                 groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
                 gracePeriod = Some(GracePeriod("s", 50L))
-              ),
-              timeContext = Some(TimeContext(currentTime = 160000L))
+              )
             )
           )
 
@@ -1036,7 +1067,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -1044,8 +1076,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
                 fields = ListFields(List(Field("*", Some(SumAggregation("value"))))),
                 groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
                 gracePeriod = Some(GracePeriod("s", 80L))
-              ),
-              timeContext = Some(TimeContext(currentTime = 160000L))
+              )
             )
           )
 
@@ -1068,7 +1099,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -1076,8 +1108,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
                 fields = ListFields(List(Field("*", Some(AvgAggregation("value"))))),
                 groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
                 gracePeriod = Some(GracePeriod("s", 80L))
-              ),
-              timeContext = Some(TimeContext(currentTime = 160000L))
+              )
             )
           )
 
@@ -1100,7 +1131,8 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              timeContext = Some(TimeContext(160000)),
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -1112,8 +1144,7 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
                                                  value = AbsoluteComparisonValue(100000L)))),
                 groupBy = Some(TemporalGroupByAggregation(30000, 30, "s")),
                 gracePeriod = Some(GracePeriod("s", 80L))
-              ),
-              timeContext = Some(TimeContext(currentTime = 160000L))
+              )
             )
           )
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalAggregatedStatementsSpec.scala
@@ -442,7 +442,6 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           Bit(100000, 5L, Map("lowerBound" -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(130000, 3L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
           Bit(160000, 2L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(190000, 0L, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
         )
 
       }
@@ -508,7 +507,6 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           Bit(100000, 5.5, Map("lowerBound" -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(130000, 3.5, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
           Bit(160000, 2.5, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(190000, 0.0, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
         )
 
       }
@@ -574,7 +572,6 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           Bit(100000, 5L, Map("lowerBound" -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(130000, 3L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
           Bit(160000, 2L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(190000, 0L, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
         )
 
       }
@@ -640,7 +637,6 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           Bit(100000, 5.5, Map("lowerBound" -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(130000, 3.5, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
           Bit(160000, 2.5, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(190000, 0.0, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
         )
 
       }
@@ -706,7 +702,6 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           Bit(100000, 5L, Map("lowerBound" -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(130000, 3L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
           Bit(160000, 2L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(190000, 0L, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
         )
 
       }
@@ -772,7 +767,6 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           Bit(100000, 5.5, Map("lowerBound" -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(130000, 3.5, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
           Bit(160000, 2.5, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(190000, 0.0, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
         )
 
       }
@@ -837,7 +831,6 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           Bit(100000, 5.0, Map("lowerBound" -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(130000, 3.0, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
           Bit(160000, 2.0, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(190000, 0.0, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
         )
 
       }
@@ -903,7 +896,6 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           Bit(100000, 5.5, Map("lowerBound" -> 70000L, "upperBound"  -> 100000L), Map()),
           Bit(130000, 3.5, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
           Bit(160000, 2.5, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(190000, 0.0, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
         )
 
       }
@@ -1087,7 +1079,6 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           Bit(100000, 5L, Map("lowerBound" -> 80000L, "upperBound"  -> 100000L), Map()),
           Bit(130000, 3L, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
           Bit(160000, 2L, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(190000, 0L, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
         )
 
       }
@@ -1119,7 +1110,6 @@ class ReadCoordinatorTemporalAggregatedStatementsSpec extends AbstractTemporalRe
           Bit(100000, 5.0, Map("lowerBound" -> 80000L, "upperBound"  -> 100000L), Map()),
           Bit(130000, 3.0, Map("lowerBound" -> 100000L, "upperBound" -> 130000L), Map()),
           Bit(160000, 2.0, Map("lowerBound" -> 130000L, "upperBound" -> 160000L), Map()),
-          Bit(190000, 0.0, Map("lowerBound" -> 160000L, "upperBound" -> 190000L), Map())
         )
 
       }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalDistinctAggregatedStatementsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinatorTemporalDistinctAggregatedStatementsSpec.scala
@@ -34,7 +34,7 @@ class ReadCoordinatorTemporalDistinctAggregatedStatementsSpec extends AbstractTe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -65,7 +65,7 @@ class ReadCoordinatorTemporalDistinctAggregatedStatementsSpec extends AbstractTe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -93,7 +93,7 @@ class ReadCoordinatorTemporalDistinctAggregatedStatementsSpec extends AbstractTe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -125,7 +125,7 @@ class ReadCoordinatorTemporalDistinctAggregatedStatementsSpec extends AbstractTe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalDoubleMetric.name,
@@ -156,7 +156,7 @@ class ReadCoordinatorTemporalDistinctAggregatedStatementsSpec extends AbstractTe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalDoubleMetric.name,
@@ -187,7 +187,7 @@ class ReadCoordinatorTemporalDistinctAggregatedStatementsSpec extends AbstractTe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,
@@ -216,7 +216,7 @@ class ReadCoordinatorTemporalDistinctAggregatedStatementsSpec extends AbstractTe
           probe.send(
             readCoordinatorActor,
             ExecuteStatement(
-              SelectSQLStatement(
+              selectStatement = SelectSQLStatement(
                 db = db,
                 namespace = namespace,
                 metric = TemporalLongMetric.name,

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/FileUtils.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/FileUtils.scala
@@ -115,7 +115,7 @@ object FileUtils {
                 .getSubDirs(Paths.get(namespaceDir.getAbsolutePath, "shards"))
                 .collect {
                   case file if file.getName.split("_").length >= 3 =>
-                    val fileName = file.getName
+                    val fileName        = file.getName
                     val Array(from, to) = fileName.split("_").takeRight(2)
                     val metric          = fileName.split(s"_${from}").head
                     LocationWithCoordinates(database,

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/FileUtils.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/FileUtils.scala
@@ -114,8 +114,10 @@ object FileUtils {
               FileUtils
                 .getSubDirs(Paths.get(namespaceDir.getAbsolutePath, "shards"))
                 .collect {
-                  case file if file.getName.split("_").length == 3 =>
-                    val Array(metric, from, to) = file.getName.split("_")
+                  case file if file.getName.split("_").length >= 3 =>
+                    val fileName = file.getName
+                    val Array(from, to) = fileName.split("_").takeRight(2)
+                    val metric          = fileName.split(s"_${from}").head
                     LocationWithCoordinates(database,
                                             namespaceDir.getName,
                                             Location(metric, nodeName, from.toLong, to.toLong))


### PR DESCRIPTION
The time range calculation during the execution of a temporal query is shard based. It might happen that a shard ends in a future timestamp.
Aims of this PR is to exclude temporal buckets that are in the future.
The current tiemstamp  is given by the time-context, and  might be set manually or otherwise os set to the current system time 