### PR TITLE
Grpc Security 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ lazy val `nsdb-rpc` = project
   ))
   .settings(LicenseHeader.settings: _*)
   .enablePlugins(AutomateHeaderPlugin)
-  .dependsOn(`nsdb-sql`)
+  .dependsOn(`nsdb-sql`, `nsdb-security`)
 lazy val `nsdb-cluster` = project
   .settings(Commons.settings: _*)
   .settings(PublishSettings.dontPublish: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -78,12 +78,17 @@ lazy val `nsdb-rpc` = project
   .settings(PublishSettings.settings: _*)
   .settings(libraryDependencies ++= Dependencies.RPC.libraries)
   .settings(coverageExcludedPackages := "io\\.radicalbit\\.nsdb.*")
-  .settings(PB.targets in Compile := Seq(
+  .settings(
+    PB.targets in Compile := Seq(
     scalapb.gen() -> (sourceManaged in Compile).value
-  ))
+  ),
+    PB.targets in Test := Seq(
+      scalapb.gen() -> (sourceManaged in Test).value
+    )
+  )
   .settings(LicenseHeader.settings: _*)
   .enablePlugins(AutomateHeaderPlugin)
-  .dependsOn(`nsdb-sql`, `nsdb-security`)
+  .dependsOn(`nsdb-sql`, `nsdb-security`, `nsdb-common` % "compile->compile;test->test")
 lazy val `nsdb-cluster` = project
   .settings(Commons.settings: _*)
   .settings(PublishSettings.dontPublish: _*)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ version: '3'
 services:
 
     nsdb:
-      image: weareradicalbit/nsdb:1.0.0-SNAPSHOT
+      image: weareradicalbit/nsdb:1.3.0-SNAPSHOT
       volumes:
         - ./nsdb-cluster/src/main/resources:/opt/nsdb-cluster/conf
         - ./data:/opt/nsdb/data

--- a/nsdb-cluster/src/main/resources/nsdb.conf
+++ b/nsdb-cluster/src/main/resources/nsdb.conf
@@ -97,6 +97,7 @@ nsdb {
     enabled = false
     enabled = ${?SECURITY_ENABLED}
     auth-provider-class = ""
+    auth-provider-class = ${?SECURITY_AUTH_PROVIDER_CLASS}
   }
 
   read {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
@@ -70,10 +70,13 @@ class NsdbNodeEndpoint(nodeId: String,
 
   authProvider match {
     case Right(provider: NSDbAuthorizationProvider) =>
-      new GrpcEndpoint(nodeId = nodeId,
-                       readCoordinator = readCoordinator,
-                       writeCoordinator = writeCoordinator,
-                       metadataCoordinator = metadataCoordinator)
+      new GrpcEndpoint(
+        nodeId = nodeId,
+        readCoordinator = readCoordinator,
+        writeCoordinator = writeCoordinator,
+        metadataCoordinator = metadataCoordinator,
+        authorizationProvider = provider
+      )
 
       initWebEndpoint(nodeId, writeCoordinator, readCoordinator, metadataCoordinator, publisher, provider)
     case Left(error) =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
@@ -80,7 +80,7 @@ class NsdbNodeEndpoint(nodeId: String,
 
       initWebEndpoint(nodeId, writeCoordinator, readCoordinator, metadataCoordinator, publisher, provider)
     case Left(error) =>
-      logger.error(s"Error during Security initialization \n $error")
+      logger.error(s"Error during Security initialization: $error")
       System.exit(1)
   }
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
@@ -16,13 +16,9 @@
 
 package io.radicalbit.nsdb.cluster.endpoint
 
-import java.util.concurrent.TimeUnit
-
 import akka.actor.{ActorRef, ActorSystem}
 import akka.pattern.ask
 import akka.util.Timeout
-import io.radicalbit.nsdb.client.rpc.GRPCServer
-import io.radicalbit.nsdb.client.rpc.converter.GrpcBitConverters._
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{ExecuteRestoreMetadata, PutMetricInfo}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{
   MetadataRestored,
@@ -30,40 +26,21 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{
   MetricInfoPut
 }
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel._
-import io.radicalbit.nsdb.common.exception.InvalidStatementException
 import io.radicalbit.nsdb.common.model.MetricInfo
-import io.radicalbit.nsdb.common.protocol._
-import io.radicalbit.nsdb.common.statement._
-import io.radicalbit.nsdb.common.{NSDbNumericType, NSDbType}
-import io.radicalbit.nsdb.model.Schema
-import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
-import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
-import io.radicalbit.nsdb.rpc.common.{Dimension, Tag}
 import io.radicalbit.nsdb.rpc.health.HealthCheckResponse.ServingStatus
 import io.radicalbit.nsdb.rpc.health.HealthGrpc.Health
 import io.radicalbit.nsdb.rpc.health.{HealthCheckRequest, HealthCheckResponse}
 import io.radicalbit.nsdb.rpc.init.InitMetricGrpc.InitMetric
 import io.radicalbit.nsdb.rpc.init.{InitMetricRequest, InitMetricResponse}
-import io.radicalbit.nsdb.rpc.request.RPCInsert
-import io.radicalbit.nsdb.rpc.requestCommand.{DescribeMetric, ShowMetrics, ShowNamespaces}
-import io.radicalbit.nsdb.rpc.requestSQL.SQLRequestStatement
-import io.radicalbit.nsdb.rpc.response.RPCInsertResult
-import io.radicalbit.nsdb.rpc.responseCommand.DescribeMetricResponse.MetricField.{FieldClassType => GrpcFieldClassType}
-import io.radicalbit.nsdb.rpc.responseCommand.DescribeMetricResponse.{MetricInfo => GrpcMetricInfo}
-import io.radicalbit.nsdb.rpc.responseCommand.{
-  Namespaces,
-  DescribeMetricResponse => GrpcDescribeMetricResponse,
-  MetricsGot => GrpcMetricsGot
-}
-import io.radicalbit.nsdb.rpc.responseSQL.SQLStatementResponse
 import io.radicalbit.nsdb.rpc.restore.RestoreGrpc.Restore
 import io.radicalbit.nsdb.rpc.restore.{RestoreRequest, RestoreResponse}
+import io.radicalbit.nsdb.rpc.server.GRPCServer
 import io.radicalbit.nsdb.rpc.service.NSDBServiceCommandGrpc.NSDBServiceCommand
-import io.radicalbit.nsdb.rpc.service.NSDBServiceSQLGrpc.NSDBServiceSQL
+import io.radicalbit.nsdb.security.NSDbAuthorizationProvider
 import io.radicalbit.nsdb.sql.parser.SQLStatementParser
-import io.radicalbit.nsdb.sql.parser.StatementParserResult._
 import org.slf4j.LoggerFactory
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 import scala.util.{Failure, Success, Try}
@@ -74,8 +51,11 @@ import scala.util.{Failure, Success, Try}
   * @param writeCoordinator the write coordinator actor
   * @param system the global actor system
   */
-class GrpcEndpoint(nodeId: String, readCoordinator: ActorRef, writeCoordinator: ActorRef, metadataCoordinator: ActorRef)(
-    implicit system: ActorSystem)
+class GrpcEndpoint(nodeId: String,
+                   readCoordinator: ActorRef,
+                   writeCoordinator: ActorRef,
+                   metadataCoordinator: ActorRef,
+                   override val authorizationProvider: NSDbAuthorizationProvider)(implicit system: ActorSystem)
     extends GRPCServer {
 
   private val log = LoggerFactory.getLogger(classOf[GrpcEndpoint])
@@ -86,15 +66,17 @@ class GrpcEndpoint(nodeId: String, readCoordinator: ActorRef, writeCoordinator: 
 
   override protected[this] val executionContextExecutor: ExecutionContext = implicitly[ExecutionContext]
 
-  override protected[this] def serviceSQL: NSDBServiceSQL = GrpcEndpointServiceSQL
+  override protected[this] lazy val serviceSQL =
+    new GrpcEndpointServiceSQL(writeCoordinator, readCoordinator, parserSQL)
 
-  override protected[this] def serviceCommand: NSDBServiceCommand = GrpcEndpointServiceCommand
+  override protected[this] lazy val serviceCommand: NSDBServiceCommand =
+    new GrpcEndpointServiceCommand(metadataCoordinator, readCoordinator)
 
-  override protected[this] def initMetricService: InitMetric = InitMetricService
+  override protected[this] lazy val initMetricService: InitMetric = InitMetricService
 
-  override protected[this] def health: Health = GrpcEndpointServiceHealth
+  override protected[this] lazy val health: Health = GrpcEndpointServiceHealth
 
-  override protected[this] def restore: Restore = GrpcEndpointServiceRestore
+  override protected[this] lazy val restore: Restore = GrpcEndpointServiceRestore
 
   override protected[this] val interface: String = system.settings.config.getString(GrpcInterface)
 
@@ -185,308 +167,6 @@ class GrpcEndpoint(nodeId: String, readCoordinator: ActorRef, writeCoordinator: 
                                errorMsg = ex.getMessage))
       }
     }
-  }
-
-  /**
-    * Concrete implementation of the command Grpc service
-    */
-  protected[this] object GrpcEndpointServiceCommand extends NSDBServiceCommand {
-    override def showMetrics(
-        request: ShowMetrics
-    ): Future[GrpcMetricsGot] = {
-      log.debug("Received command ShowMetrics for namespace {}", request.namespace)
-      (metadataCoordinator ? GetMetrics(request.db, request.namespace)).map {
-        case MetricsGot(db, namespace, metrics) =>
-          GrpcMetricsGot(db, namespace, metrics.toList, completedSuccessfully = true)
-        case _ =>
-          GrpcMetricsGot(request.db,
-                         request.namespace,
-                         List.empty,
-                         completedSuccessfully = false,
-                         "Unknown server error")
-      }
-    }
-
-    override def describeMetric(request: DescribeMetric): Future[GrpcDescribeMetricResponse] = {
-
-      def extractField(schema: Option[Schema]): Iterable[MetricField] =
-        schema
-          .map(_.fieldsMap.map {
-            case (_, field) =>
-              MetricField(name = field.name,
-                          fieldClassType = field.fieldClassType,
-                          `type` = field.indexType.getClass.getSimpleName)
-          })
-          .getOrElse(Iterable.empty[MetricField])
-
-      def extractFieldClassType(f: MetricField): GrpcFieldClassType = {
-        f.fieldClassType match {
-          case DimensionFieldType => GrpcFieldClassType.DIMENSION
-          case TagFieldType       => GrpcFieldClassType.TAG
-          case TimestampFieldType => GrpcFieldClassType.TIMESTAMP
-          case ValueFieldType     => GrpcFieldClassType.VALUE
-        }
-      }
-
-      //TODO: add failure handling
-      log.debug("Received command DescribeMetric for metric {}", request.metric)
-
-      Future
-        .sequence(
-          Seq(
-            readCoordinator ? GetSchema(db = request.db, namespace = request.namespace, metric = request.metric),
-            metadataCoordinator ? GetMetricInfo(db = request.db, namespace = request.namespace, metric = request.metric)
-          ))
-        .map {
-          case SchemaGot(db, namespace, metric, schema) :: MetricInfoGot(_, _, _, metricInfoOpt) :: Nil =>
-            GrpcDescribeMetricResponse(
-              db,
-              namespace,
-              metric,
-              extractField(schema)
-                .map(f => GrpcDescribeMetricResponse.MetricField(f.name, extractFieldClassType(f), f.`type`))
-                .toSeq,
-              metricInfoOpt.map(mi => GrpcMetricInfo(mi.shardInterval, mi.retention)),
-              completedSuccessfully = true
-            )
-          case _ =>
-            GrpcDescribeMetricResponse(request.db,
-                                       request.namespace,
-                                       request.metric,
-                                       completedSuccessfully = false,
-                                       errors = "unknown message received from server")
-        }
-    }
-
-    override def showNamespaces(
-        request: ShowNamespaces
-    ): Future[Namespaces] = {
-      log.debug("Received command ShowNamespaces for db: {}", request.db)
-      (metadataCoordinator ? GetNamespaces(db = request.db))
-        .map {
-          case NamespacesGot(db, namespaces) =>
-            Namespaces(db = db, namespaces = namespaces.toSeq, completedSuccessfully = true)
-          case _ =>
-            Namespaces(db = request.db, completedSuccessfully = false, errors = "Cluster unable to fulfill request")
-        }
-        .recoverWith {
-          case _ =>
-            Future.successful(
-              Namespaces(db = request.db, completedSuccessfully = false, errors = "Cluster unable to fulfill request"))
-        }
-    }
-  }
-
-  /**
-    * Concrete implementation of the Sql Grpc service
-    */
-  protected[this] object GrpcEndpointServiceSQL extends NSDBServiceSQL {
-
-    override def insertBit(request: RPCInsert): Future[RPCInsertResult] = {
-      log.debug("Received a write request {}", request)
-
-      val bit = Bit(
-        timestamp = request.timestamp,
-        dimensions = request.dimensions.collect {
-          case (k, v) => (k, dimensionFor(v.value))
-        },
-        tags = request.tags.collect {
-          case (k, v) => (k, tagFor(v.value))
-        },
-        value = valueFor(request.value)
-      )
-
-      val res = (writeCoordinator ? MapInput(
-        db = request.database,
-        namespace = request.namespace,
-        metric = request.metric,
-        ts = request.timestamp,
-        record = bit
-      )).map {
-        case _: InputMapped =>
-          RPCInsertResult(completedSuccessfully = true)
-        case msg: RecordRejected =>
-          RPCInsertResult(completedSuccessfully = false, errors = msg.reasons.mkString(","))
-        case _ => RPCInsertResult(completedSuccessfully = false, errors = "unknown reason")
-      } recover {
-        case t =>
-          log.error(s"error while inserting $bit", t)
-          RPCInsertResult(completedSuccessfully = false, t.getMessage)
-      }
-
-      res.onComplete {
-        case Success(res: RPCInsertResult) =>
-          log.debug("Completed the write request {}", request)
-          if (res.completedSuccessfully)
-            log.debug("The result is {}", res)
-          else
-            log.error("The result is {}", res)
-        case Failure(t: Throwable) =>
-          log.error(s"error on request $request", t)
-      }
-      res
-    }
-
-    private def valueFor(v: RPCInsert.Value): NSDbNumericType = v match {
-      case _: RPCInsert.Value.DecimalValue => NSDbNumericType(v.decimalValue.get)
-      case _: RPCInsert.Value.LongValue    => NSDbNumericType(v.longValue.get)
-    }
-
-    private def dimensionFor(v: Dimension.Value): NSDbType = v match {
-      case _: Dimension.Value.DecimalValue => NSDbType(v.decimalValue.get)
-      case _: Dimension.Value.LongValue    => NSDbType(v.longValue.get)
-      case _                               => NSDbType(v.stringValue.get)
-    }
-
-    private def tagFor(v: Tag.Value): NSDbType = v match {
-      case _: Tag.Value.DecimalValue => NSDbType(v.decimalValue.get)
-      case _: Tag.Value.LongValue    => NSDbType(v.longValue.get)
-      case _                         => NSDbType(v.stringValue.get)
-    }
-
-    override def executeSQLStatement(
-        request: SQLRequestStatement
-    ): Future[SQLStatementResponse] = {
-      val requestDb        = request.db
-      val requestNamespace = request.namespace
-      parserSQL.parse(request.db, request.namespace, request.statement) match {
-        // Parsing Success
-        case SqlStatementParserSuccess(_, statement) =>
-          statement match {
-            case select: SelectSQLStatement =>
-              log.debug("Received a select request {}", select)
-              (readCoordinator ? ExecuteStatement(select))
-                .map {
-                  // SelectExecution Success
-                  case SelectStatementExecuted(statement, values: Seq[Bit], _) =>
-                    log.debug("SQL statement succeeded on db {} with namespace {} and metric {}",
-                              statement.db,
-                              statement.namespace,
-                              statement.metric)
-                    SQLStatementResponse(
-                      db = statement.db,
-                      namespace = statement.namespace,
-                      metric = statement.metric,
-                      completedSuccessfully = true,
-                      records = values.map(bit => bit.asGrpcBit)
-                    )
-                  // SelectExecution Failure
-                  case SelectStatementFailed(statement, reason, _) =>
-                    SQLStatementResponse(
-                      db = requestDb,
-                      namespace = requestNamespace,
-                      completedSuccessfully = false,
-                      reason = reason
-                    )
-                }
-                .recoverWith {
-                  case t =>
-                    log.error(s"Error in executing statement $statement", t)
-                    Future.successful(
-                      SQLStatementResponse(
-                        db = requestDb,
-                        namespace = requestNamespace,
-                        completedSuccessfully = false,
-                        reason = t.getMessage
-                      ))
-                }
-            case insert: InsertSQLStatement =>
-              log.debug("Received a insert request {}", insert)
-              val result = InsertSQLStatement
-                .unapply(insert)
-                .map {
-                  case (db, namespace, metric, ts, dimensions, tags, value) =>
-                    val timestamp = ts getOrElse System.currentTimeMillis
-                    writeCoordinator ? MapInput(
-                      timestamp,
-                      db,
-                      namespace,
-                      metric,
-                      Bit(timestamp = timestamp,
-                          value = value,
-                          dimensions = dimensions.map(_.fields).getOrElse(Map.empty),
-                          tags = tags.map(_.fields).getOrElse(Map.empty))
-                    )
-                }
-                .getOrElse(Future(throw new InvalidStatementException("The insert SQL statement is invalid.")))
-
-              result
-                .map {
-                  case InputMapped(db, namespace, metric, record) =>
-                    SQLStatementResponse(db = db,
-                                         namespace = namespace,
-                                         metric = metric,
-                                         completedSuccessfully = true,
-                                         records = Seq(record.asGrpcBit))
-                  case msg: RecordRejected =>
-                    SQLStatementResponse(db = msg.db,
-                                         namespace = msg.namespace,
-                                         metric = msg.metric,
-                                         completedSuccessfully = false,
-                                         reason = msg.reasons.mkString(","))
-                  case _ =>
-                    SQLStatementResponse(db = insert.db,
-                                         namespace = insert.namespace,
-                                         metric = insert.metric,
-                                         completedSuccessfully = false,
-                                         reason = "unknown reason")
-                }
-
-            case delete: DeleteSQLStatement =>
-              (writeCoordinator ? ExecuteDeleteStatement(delete))
-                .mapTo[DeleteStatementExecuted]
-                .map(
-                  x =>
-                    SQLStatementResponse(db = x.db,
-                                         namespace = x.namespace,
-                                         metric = x.metric,
-                                         completedSuccessfully = true,
-                                         records = Seq.empty))
-                .recoverWith {
-                  case t =>
-                    Future.successful(
-                      SQLStatementResponse(
-                        db = requestDb,
-                        namespace = requestNamespace,
-                        completedSuccessfully = false,
-                        reason = t.getMessage
-                      ))
-                }
-
-            case _: DropSQLStatement =>
-              (writeCoordinator ? DropMetric(statement.db, statement.namespace, statement.metric))
-                .mapTo[MetricDropped]
-                .map(
-                  x =>
-                    SQLStatementResponse(db = x.db,
-                                         namespace = x.namespace,
-                                         metric = x.metric,
-                                         completedSuccessfully = true,
-                                         records = Seq.empty))
-                .recoverWith {
-                  case t =>
-                    Future.successful(
-                      SQLStatementResponse(
-                        db = requestDb,
-                        namespace = requestNamespace,
-                        completedSuccessfully = false,
-                        reason = t.getMessage
-                      ))
-                }
-          }
-
-        //Parsing Failure
-        case SqlStatementParserFailure(_, error) =>
-          Future.successful(
-            SQLStatementResponse(db = request.db,
-                                 namespace = request.namespace,
-                                 completedSuccessfully = false,
-                                 reason = "sql statement not valid",
-                                 message = error)
-          )
-      }
-    }
-
   }
 
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpointServiceCommand.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpointServiceCommand.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.endpoint
+
+import akka.actor.ActorRef
+import akka.pattern.ask
+import akka.util.Timeout
+import io.radicalbit.nsdb.common.protocol._
+import io.radicalbit.nsdb.model.Schema
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.{GetMetricInfo, GetMetrics, GetNamespaces, GetSchema}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{MetricInfoGot, MetricsGot, NamespacesGot, SchemaGot}
+import io.radicalbit.nsdb.rpc.requestCommand.{DescribeMetric, ShowMetrics, ShowNamespaces}
+import io.radicalbit.nsdb.rpc.responseCommand.DescribeMetricResponse.MetricField.{FieldClassType => GrpcFieldClassType}
+import io.radicalbit.nsdb.rpc.responseCommand.DescribeMetricResponse.{MetricInfo => GrpcMetricInfo}
+import io.radicalbit.nsdb.rpc.responseCommand.{
+  Namespaces,
+  DescribeMetricResponse => GrpcDescribeMetricResponse,
+  MetricsGot => GrpcMetricsGot
+}
+import io.radicalbit.nsdb.rpc.server.GRPCService
+import io.radicalbit.nsdb.rpc.service.NSDBServiceCommandGrpc.NSDBServiceCommand
+import org.slf4j.LoggerFactory
+import scalapb.descriptors.ServiceDescriptor
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Concrete implementation of the command Grpc service
+  */
+private[endpoint] class GrpcEndpointServiceCommand(metadataCoordinator: ActorRef, readCoordinator: ActorRef)(
+    implicit timeout: Timeout,
+    executionContext: ExecutionContext)
+    extends NSDBServiceCommand
+    with GRPCService {
+
+  private val log = LoggerFactory.getLogger(classOf[GrpcEndpointServiceCommand])
+
+  override def serviceDescriptor: ServiceDescriptor = this.serviceCompanion.scalaDescriptor
+
+  override def showMetrics(
+      request: ShowMetrics
+  ): Future[GrpcMetricsGot] = {
+    log.debug("Received command ShowMetrics for namespace {}", request.namespace)
+    (metadataCoordinator ? GetMetrics(request.db, request.namespace)).map {
+      case MetricsGot(db, namespace, metrics) =>
+        GrpcMetricsGot(db, namespace, metrics.toList, completedSuccessfully = true)
+      case _ =>
+        GrpcMetricsGot(request.db, request.namespace, List.empty, completedSuccessfully = false, "Unknown server error")
+    }
+  }
+
+  override def describeMetric(request: DescribeMetric): Future[GrpcDescribeMetricResponse] = {
+
+    def extractField(schema: Option[Schema]): Iterable[MetricField] =
+      schema
+        .map(_.fieldsMap.map {
+          case (_, field) =>
+            MetricField(name = field.name,
+                        fieldClassType = field.fieldClassType,
+                        `type` = field.indexType.getClass.getSimpleName)
+        })
+        .getOrElse(Iterable.empty[MetricField])
+
+    def extractFieldClassType(f: MetricField): GrpcFieldClassType = {
+      f.fieldClassType match {
+        case DimensionFieldType => GrpcFieldClassType.DIMENSION
+        case TagFieldType       => GrpcFieldClassType.TAG
+        case TimestampFieldType => GrpcFieldClassType.TIMESTAMP
+        case ValueFieldType     => GrpcFieldClassType.VALUE
+      }
+    }
+
+    //TODO: add failure handling
+    log.debug("Received command DescribeMetric for metric {}", request.metric)
+
+    Future
+      .sequence(
+        Seq(
+          readCoordinator ? GetSchema(db = request.db, namespace = request.namespace, metric = request.metric),
+          metadataCoordinator ? GetMetricInfo(db = request.db, namespace = request.namespace, metric = request.metric)
+        ))
+      .map {
+        case SchemaGot(db, namespace, metric, schema) :: MetricInfoGot(_, _, _, metricInfoOpt) :: Nil =>
+          GrpcDescribeMetricResponse(
+            db,
+            namespace,
+            metric,
+            extractField(schema)
+              .map(f => GrpcDescribeMetricResponse.MetricField(f.name, extractFieldClassType(f), f.`type`))
+              .toSeq,
+            metricInfoOpt.map(mi => GrpcMetricInfo(mi.shardInterval, mi.retention)),
+            completedSuccessfully = true
+          )
+        case _ =>
+          GrpcDescribeMetricResponse(request.db,
+                                     request.namespace,
+                                     request.metric,
+                                     completedSuccessfully = false,
+                                     errors = "unknown message received from server")
+      }
+  }
+
+  override def showNamespaces(
+      request: ShowNamespaces
+  ): Future[Namespaces] = {
+    log.debug("Received command ShowNamespaces for db: {}", request.db)
+    (metadataCoordinator ? GetNamespaces(db = request.db))
+      .map {
+        case NamespacesGot(db, namespaces) =>
+          Namespaces(db = db, namespaces = namespaces.toSeq, completedSuccessfully = true)
+        case _ =>
+          Namespaces(db = request.db, completedSuccessfully = false, errors = "Cluster unable to fulfill request")
+      }
+      .recoverWith {
+        case _ =>
+          Future.successful(
+            Namespaces(db = request.db, completedSuccessfully = false, errors = "Cluster unable to fulfill request"))
+      }
+  }
+}

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpointServiceSQL.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpointServiceSQL.scala
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.endpoint
+
+import akka.actor.ActorRef
+import akka.pattern.ask
+import akka.util.Timeout
+import io.radicalbit.nsdb.client.rpc.converter.GrpcBitConverters._
+import io.radicalbit.nsdb.common.exception.InvalidStatementException
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.common.statement.{
+  DeleteSQLStatement,
+  DropSQLStatement,
+  InsertSQLStatement,
+  SelectSQLStatement
+}
+import io.radicalbit.nsdb.common.{NSDbNumericType, NSDbType}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.{
+  DropMetric,
+  ExecuteDeleteStatement,
+  ExecuteStatement,
+  MapInput
+}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
+import io.radicalbit.nsdb.rpc.common.{Dimension, Tag}
+import io.radicalbit.nsdb.rpc.request.RPCInsert
+import io.radicalbit.nsdb.rpc.requestSQL.SQLRequestStatement
+import io.radicalbit.nsdb.rpc.response.RPCInsertResult
+import io.radicalbit.nsdb.rpc.responseSQL.SQLStatementResponse
+import io.radicalbit.nsdb.rpc.server.GRPCService
+import io.radicalbit.nsdb.rpc.service.NSDBServiceSQLGrpc.NSDBServiceSQL
+import io.radicalbit.nsdb.sql.parser.SQLStatementParser
+import io.radicalbit.nsdb.sql.parser.StatementParserResult.{SqlStatementParserFailure, SqlStatementParserSuccess}
+import org.slf4j.LoggerFactory
+import scalapb.descriptors.ServiceDescriptor
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+/**
+  * Concrete implementation of the Sql Grpc service
+  */
+class GrpcEndpointServiceSQL(writeCoordinator: ActorRef, readCoordinator: ActorRef, parserSQL: SQLStatementParser)(
+    implicit timeout: Timeout,
+    executionContext: ExecutionContext)
+    extends NSDBServiceSQL
+    with GRPCService {
+
+  private val log = LoggerFactory.getLogger(classOf[GrpcEndpointServiceSQL])
+
+  override def serviceDescriptor: ServiceDescriptor = this.serviceCompanion.scalaDescriptor
+
+  override def insertBit(request: RPCInsert): Future[RPCInsertResult] = {
+    log.debug("Received a write request {}", request)
+
+    val bit = Bit(
+      timestamp = request.timestamp,
+      dimensions = request.dimensions.collect {
+        case (k, v) => (k, dimensionFor(v.value))
+      },
+      tags = request.tags.collect {
+        case (k, v) => (k, tagFor(v.value))
+      },
+      value = valueFor(request.value)
+    )
+
+    val res = (writeCoordinator ? MapInput(
+      db = request.database,
+      namespace = request.namespace,
+      metric = request.metric,
+      ts = request.timestamp,
+      record = bit
+    )).map {
+      case _: InputMapped =>
+        RPCInsertResult(completedSuccessfully = true)
+      case msg: RecordRejected =>
+        RPCInsertResult(completedSuccessfully = false, errors = msg.reasons.mkString(","))
+      case _ => RPCInsertResult(completedSuccessfully = false, errors = "unknown reason")
+    } recover {
+      case t =>
+        log.error(s"error while inserting $bit", t)
+        RPCInsertResult(completedSuccessfully = false, t.getMessage)
+    }
+
+    res.onComplete {
+      case Success(res: RPCInsertResult) =>
+        log.debug("Completed the write request {}", request)
+        if (res.completedSuccessfully)
+          log.debug("The result is {}", res)
+        else
+          log.error("The result is {}", res)
+      case Failure(t: Throwable) =>
+        log.error(s"error on request $request", t)
+    }
+    res
+  }
+
+  private def valueFor(v: RPCInsert.Value): NSDbNumericType = v match {
+    case _: RPCInsert.Value.DecimalValue => NSDbNumericType(v.decimalValue.get)
+    case _: RPCInsert.Value.LongValue    => NSDbNumericType(v.longValue.get)
+  }
+
+  private def dimensionFor(v: Dimension.Value): NSDbType = v match {
+    case _: Dimension.Value.DecimalValue => NSDbType(v.decimalValue.get)
+    case _: Dimension.Value.LongValue    => NSDbType(v.longValue.get)
+    case _                               => NSDbType(v.stringValue.get)
+  }
+
+  private def tagFor(v: Tag.Value): NSDbType = v match {
+    case _: Tag.Value.DecimalValue => NSDbType(v.decimalValue.get)
+    case _: Tag.Value.LongValue    => NSDbType(v.longValue.get)
+    case _                         => NSDbType(v.stringValue.get)
+  }
+
+  override def executeSQLStatement(
+      request: SQLRequestStatement
+  ): Future[SQLStatementResponse] = {
+    val requestDb        = request.db
+    val requestNamespace = request.namespace
+    parserSQL.parse(request.db, request.namespace, request.statement) match {
+      // Parsing Success
+      case SqlStatementParserSuccess(_, statement) =>
+        statement match {
+          case select: SelectSQLStatement =>
+            log.debug("Received a select request {}", select)
+            (readCoordinator ? ExecuteStatement(select))
+              .map {
+                // SelectExecution Success
+                case SelectStatementExecuted(statement, values: Seq[Bit], _) =>
+                  log.debug("SQL statement succeeded on db {} with namespace {} and metric {}",
+                            statement.db,
+                            statement.namespace,
+                            statement.metric)
+                  SQLStatementResponse(
+                    db = statement.db,
+                    namespace = statement.namespace,
+                    metric = statement.metric,
+                    completedSuccessfully = true,
+                    records = values.map(bit => bit.asGrpcBit)
+                  )
+                // SelectExecution Failure
+                case SelectStatementFailed(statement, reason, _) =>
+                  SQLStatementResponse(
+                    db = requestDb,
+                    namespace = requestNamespace,
+                    completedSuccessfully = false,
+                    reason = reason
+                  )
+              }
+              .recoverWith {
+                case t =>
+                  log.error(s"Error in executing statement $statement", t)
+                  Future.successful(
+                    SQLStatementResponse(
+                      db = requestDb,
+                      namespace = requestNamespace,
+                      completedSuccessfully = false,
+                      reason = t.getMessage
+                    ))
+              }
+          case insert: InsertSQLStatement =>
+            log.debug("Received a insert request {}", insert)
+            val result = InsertSQLStatement
+              .unapply(insert)
+              .map {
+                case (db, namespace, metric, ts, dimensions, tags, value) =>
+                  val timestamp = ts getOrElse System.currentTimeMillis
+                  writeCoordinator ? MapInput(
+                    timestamp,
+                    db,
+                    namespace,
+                    metric,
+                    Bit(timestamp = timestamp,
+                        value = value,
+                        dimensions = dimensions.map(_.fields).getOrElse(Map.empty),
+                        tags = tags.map(_.fields).getOrElse(Map.empty))
+                  )
+              }
+              .getOrElse(Future(throw new InvalidStatementException("The insert SQL statement is invalid.")))
+
+            result
+              .map {
+                case InputMapped(db, namespace, metric, record) =>
+                  SQLStatementResponse(db = db,
+                                       namespace = namespace,
+                                       metric = metric,
+                                       completedSuccessfully = true,
+                                       records = Seq(record.asGrpcBit))
+                case msg: RecordRejected =>
+                  SQLStatementResponse(db = msg.db,
+                                       namespace = msg.namespace,
+                                       metric = msg.metric,
+                                       completedSuccessfully = false,
+                                       reason = msg.reasons.mkString(","))
+                case _ =>
+                  SQLStatementResponse(db = insert.db,
+                                       namespace = insert.namespace,
+                                       metric = insert.metric,
+                                       completedSuccessfully = false,
+                                       reason = "unknown reason")
+              }
+
+          case delete: DeleteSQLStatement =>
+            (writeCoordinator ? ExecuteDeleteStatement(delete))
+              .mapTo[DeleteStatementExecuted]
+              .map(
+                x =>
+                  SQLStatementResponse(db = x.db,
+                                       namespace = x.namespace,
+                                       metric = x.metric,
+                                       completedSuccessfully = true,
+                                       records = Seq.empty))
+              .recoverWith {
+                case t =>
+                  Future.successful(
+                    SQLStatementResponse(
+                      db = requestDb,
+                      namespace = requestNamespace,
+                      completedSuccessfully = false,
+                      reason = t.getMessage
+                    ))
+              }
+
+          case _: DropSQLStatement =>
+            (writeCoordinator ? DropMetric(statement.db, statement.namespace, statement.metric))
+              .mapTo[MetricDropped]
+              .map(
+                x =>
+                  SQLStatementResponse(db = x.db,
+                                       namespace = x.namespace,
+                                       metric = x.metric,
+                                       completedSuccessfully = true,
+                                       records = Seq.empty))
+              .recoverWith {
+                case t =>
+                  Future.successful(
+                    SQLStatementResponse(
+                      db = requestDb,
+                      namespace = requestNamespace,
+                      completedSuccessfully = false,
+                      reason = t.getMessage
+                    ))
+              }
+        }
+
+      //Parsing Failure
+      case SqlStatementParserFailure(_, error) =>
+        Future.successful(
+          SQLStatementResponse(db = request.db,
+                               namespace = request.namespace,
+                               completedSuccessfully = false,
+                               reason = "sql statement not valid",
+                               message = error)
+        )
+    }
+  }
+}

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/exception/Exceptions.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/exception/Exceptions.scala
@@ -25,5 +25,4 @@ trait NSDbException extends RuntimeException with NoStackTrace
 
 class InvalidStatementException(val message: String) extends NSDbException
 class TypeNotSupportedException(val message: String) extends NSDbException
-class NsdbSecurityException(val message: String)     extends NSDbException
 class InvalidNodeIdException(address: String)        extends NSDbException

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
@@ -56,6 +56,7 @@ trait WebResources extends WsResources with SSLSupport {
                       writeCoordinator: ActorRef,
                       readCoordinator: ActorRef,
                       metadataCoordinator: ActorRef,
+//<<<<<<< HEAD
                       publisher: ActorRef,
                       authProvider: NSDbAuthorizationProvider)(implicit logger: LoggingAdapter) = {
     Kamon.gauge(NSDbMonitoring.NSDbWsConnectionsTotal).withoutTags()
@@ -65,6 +66,17 @@ trait WebResources extends WsResources with SSLSupport {
                                                                              writeCoordinator,
                                                                              metadataCoordinator,
                                                                              authProvider).apiResources(config)
+//=======
+//                      publisher: ActorRef)(implicit logger: LoggingAdapter) =
+//    authProvider match {
+//      case Right(provider) =>
+//        Kamon.gauge(NSDbMonitoring.NSDbWsConnectionsTotal).withoutTags()
+//        val api: Route = wsResources(publisher, provider) ~ new ApiResources(publisher,
+//                                                                             readCoordinator,
+//                                                                             writeCoordinator,
+//                                                                             metadataCoordinator,
+//                                                                             provider).apiResources(config)
+//>>>>>>> 4a4ef970... test grpc interceptor
 
     val httpExt = akka.http.scaladsl.Http()
 
@@ -87,7 +99,13 @@ trait WebResources extends WsResources with SSLSupport {
         .onComplete { _ =>
           system.terminate()
         }
+//<<<<<<< HEAD
       Await.result(system.whenTerminated, 60 seconds)
+//=======
+//      case Left(error) =>
+//        logger.error(s"error on loading authorization provider $error")
+//        System.exit(1)
+//>>>>>>> 4a4ef970... test grpc interceptor
     }
   }
 

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WebResources.scala
@@ -56,7 +56,6 @@ trait WebResources extends WsResources with SSLSupport {
                       writeCoordinator: ActorRef,
                       readCoordinator: ActorRef,
                       metadataCoordinator: ActorRef,
-//<<<<<<< HEAD
                       publisher: ActorRef,
                       authProvider: NSDbAuthorizationProvider)(implicit logger: LoggingAdapter) = {
     Kamon.gauge(NSDbMonitoring.NSDbWsConnectionsTotal).withoutTags()
@@ -66,17 +65,6 @@ trait WebResources extends WsResources with SSLSupport {
                                                                              writeCoordinator,
                                                                              metadataCoordinator,
                                                                              authProvider).apiResources(config)
-//=======
-//                      publisher: ActorRef)(implicit logger: LoggingAdapter) =
-//    authProvider match {
-//      case Right(provider) =>
-//        Kamon.gauge(NSDbMonitoring.NSDbWsConnectionsTotal).withoutTags()
-//        val api: Route = wsResources(publisher, provider) ~ new ApiResources(publisher,
-//                                                                             readCoordinator,
-//                                                                             writeCoordinator,
-//                                                                             metadataCoordinator,
-//                                                                             provider).apiResources(config)
-//>>>>>>> 4a4ef970... test grpc interceptor
 
     val httpExt = akka.http.scaladsl.Http()
 
@@ -99,13 +87,7 @@ trait WebResources extends WsResources with SSLSupport {
         .onComplete { _ =>
           system.terminate()
         }
-//<<<<<<< HEAD
       Await.result(system.whenTerminated, 60 seconds)
-//=======
-//      case Left(error) =>
-//        logger.error(s"error on loading authorization provider $error")
-//        System.exit(1)
-//>>>>>>> 4a4ef970... test grpc interceptor
     }
   }
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/auth/TestAuthProvider.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/auth/TestAuthProvider.scala
@@ -32,6 +32,8 @@ class TestAuthProvider extends NSDbAuthorizationProvider {
   override def extractWsSecurityPayload(subProtocols: java.util.List[String]): String =
     subProtocols.asScala.mkString(" ")
 
+  override def getGrpcSecurityHeader(): String = "dummyHeader"
+
   override def checkDbAuth(db: String, userInfo: String, writePermission: Boolean): AuthorizationResponse =
     if (userInfo.isEmpty) new AuthorizationResponse(false, "header not provided")
     else if (db == "notAuthorizedDb")

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/GlobalAggregationReadCoordinatorSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/GlobalAggregationReadCoordinatorSpec.scala
@@ -70,6 +70,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select count(*) from ${LongMetric.name}")
 
       eventually {
@@ -91,6 +92,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select count(*) from ${LongMetric.name} limit 4")
 
       eventually {
@@ -112,6 +114,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(AggregationLongMetric.name)
         .query(s"select count(distinct *) from ${AggregationLongMetric.name}")
 
       eventually {
@@ -133,6 +136,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(AggregationLongMetric.name)
         .query(s"select count(distinct height) from ${AggregationLongMetric.name}")
 
       eventually {
@@ -154,6 +158,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(AggregationLongMetric.name)
         .query(s"select avg(*) from ${LongMetric.name}")
 
       eventually {
@@ -175,6 +180,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select max(*) from ${LongMetric.name}")
 
       eventually {
@@ -196,6 +202,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select min(*) from ${LongMetric.name}")
 
       eventually {
@@ -217,6 +224,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select sum(*) from ${LongMetric.name}")
 
       eventually {
@@ -238,6 +246,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select max(*), min(*), sum(*), avg(*), count(*), count(distinct *) from ${LongMetric.name}")
 
       eventually {
@@ -259,6 +268,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(AggregationLongMetric.name)
         .query(
           s"select count(*), count(distinct *), avg(*), max(*), min(*), sum(*), name from ${AggregationLongMetric.name} order by timestamp")
 
@@ -343,6 +353,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select avg(*), name from ${LongMetric.name}")
 
       eventually {
@@ -372,6 +383,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select max(*), name from ${LongMetric.name}")
 
       eventually {
@@ -401,6 +413,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select min(*), name from ${LongMetric.name}")
 
       eventually {
@@ -430,6 +443,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select sum(*), name from ${LongMetric.name}")
 
       eventually {
@@ -458,6 +472,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(AggregationLongMetric.name)
         .query(s"select count(*), min(*), max(*), sum(*) from ${AggregationLongMetric.name} where height < 31")
 
       eventually {
@@ -482,6 +497,7 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select first(*) from ${LongMetric.name}")
 
       eventually {

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/ReadCoordinatorClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/ReadCoordinatorClusterSpec.scala
@@ -81,6 +81,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select * from ${LongMetric.name} limit 2")
 
       eventually {
@@ -101,6 +102,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select * from ${LongMetric.name} order by timestamp desc limit 2")
 
       eventually {
@@ -123,6 +125,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select * from ${LongMetric.name} where name = 'John' order by timestamp limit 2")
 
       eventually {
@@ -143,6 +146,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select * from ${LongMetric.name} order by value desc limit 2")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -164,6 +168,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select * from ${LongMetric.name} order by name desc limit 3")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -184,6 +189,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(LongMetric.name)
         .query(s"select name from ${LongMetric.name}")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -204,7 +210,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select surname from ${LongMetric.name}")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -222,7 +228,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select name, surname from ${LongMetric.name}")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -248,7 +254,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select distinct name from ${LongMetric.name} limit 6")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -270,7 +276,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select distinct name from ${LongMetric.name} limit 2")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -284,7 +290,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select distinct name from ${LongMetric.name} order by name limit 6")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -308,7 +314,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select distinct name from ${LongMetric.name} order by name desc limit 6")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -332,7 +338,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select distinct * from ${LongMetric.name}")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -348,7 +354,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select count(*), name from ${LongMetric.name}")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -371,7 +377,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select count(*) from ${LongMetric.name}")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -388,7 +394,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select count(*), surname, sum(creationDate) from ${LongMetric.name}")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -403,7 +409,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select distinct name, surname from ${LongMetric.name}")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -418,7 +424,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select name from ${LongMetric.name} where timestamp in (2,4) limit 4")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -433,7 +439,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select name from ${LongMetric.name} where timestamp >= 10")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -448,7 +454,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select name from ${LongMetric.name} where not timestamp >= 10")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -462,7 +468,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select name from ${LongMetric.name} where timestamp > 2 and timestamp <= 4 limit 4")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -476,7 +482,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select name from ${LongMetric.name} where timestamp >= 2 or timestamp <= 4")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -490,7 +496,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select name from ${LongMetric.name} where timestamp = 2 ")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -504,7 +510,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select name from ${LongMetric.name} where timestamp >= 2 and name = John")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -518,7 +524,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select sum(value) from ${LongMetric.name} where timestamp >= 3 group by name order by name")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -539,7 +545,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select first(value) from ${LongMetric.name} where timestamp <= 8 group by name order by name")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -560,7 +566,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select last(value) from ${LongMetric.name} where timestamp <= 8 group by name order by name")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -581,7 +587,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select creationDate from ${LongMetric.name} where timestamp => 2 group by name")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -596,7 +602,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select creationDate from nonexisting where timestamp => 2 group by name")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -611,7 +617,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select count(value) from ${LongMetric.name} group by name order by name")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -627,18 +633,17 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val distinctQuery = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(DoubleMetric.name)
         .query(s"select count(distinct value) from ${DoubleMetric.name} group by name order by name")
 
-      val distinctReadRes = Await.result(nsdb.execute(query), 10.seconds)
+      val distinctReadRes = Await.result(nsdb.execute(distinctQuery), 10.seconds)
 
       assert(
         distinctReadRes.records.map(_.asBit) == Seq(
           Bit(0L, 1L, Map.empty, Map("name" -> "Bill")),
           Bit(0L, 1L, Map.empty, Map("name" -> "Frank")),
           Bit(0L, 1L, Map.empty, Map("name" -> "Frankie")),
-          Bit(0L, 1L, Map.empty, Map("name" -> "J")),
-          Bit(0L, 2L, Map.empty, Map("name" -> "John"))
+          Bit(0L, 1L, Map.empty, Map("name" -> "John"))
         ))
     }
   }
@@ -649,7 +654,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val countQuery = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select count(value) from ${LongMetric.name} group by name order by name desc")
 
       var readRes = Await.result(nsdb.execute(countQuery), 10.seconds)
@@ -665,7 +670,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val countDistinctQuery = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(DoubleMetric.name)
         .query(s"select count(distinct value) from ${DoubleMetric.name} group by name order by name desc")
 
        readRes = Await.result(nsdb.execute(countDistinctQuery), 10.seconds)
@@ -680,7 +685,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val sumQuery = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(DoubleMetric.name)
         .query(s"select sum(value) from ${DoubleMetric.name} group by name order by name desc")
 
       readRes = Await.result(nsdb.execute(sumQuery), 10.seconds)
@@ -701,7 +706,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(LongMetric.name)
         .query(s"select sum(value) from ${LongMetric.name} group by name order by value desc")
 
       var readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -711,6 +716,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
       val doubleQuery = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(DoubleMetric.name)
         .query(s"select sum(value) from ${DoubleMetric.name} group by name order by value desc")
 
       readRes = Await.result(nsdb.execute(doubleQuery), 10.seconds)
@@ -726,6 +732,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(AggregationLongMetric.name)
         .query(s"select count(value) from ${AggregationLongMetric.name} group by age order by value")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -743,6 +750,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(AggregationLongMetric.name)
         .query(s"select count(distinct value) from ${AggregationLongMetric.name} group by age order by value")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -760,6 +768,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(AggregationLongMetric.name)
         .query(s"select count(distinct height) from ${AggregationLongMetric.name} group by name order by name")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -781,6 +790,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(AggregationLongMetric.name)
         .query(s"select count(distinct name) from ${AggregationLongMetric.name} group by age order by age")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -801,6 +811,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(AggregationLongMetric.name)
         .query(s"select sum(value) from ${AggregationLongMetric.name} group by age order by age")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -821,6 +832,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
       val maxQuery = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(AggregationLongMetric.name)
         .query(s"select max(value) from ${AggregationLongMetric.name} group by age order by age")
 
       val maxResponse = Await.result(nsdb.execute(maxQuery), 10.seconds)
@@ -834,7 +846,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val minQuery = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationLongMetric.name)
         .query(s"select min(value) from ${AggregationLongMetric.name} group by age order by age")
 
       val minResponse = Await.result(nsdb.execute(minQuery), 10.seconds)
@@ -854,7 +866,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val firstQuery = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationLongMetric.name)
         .query(s"select first(value) from ${AggregationLongMetric.name} group by age order by age")
 
       val firstResponse = Await.result(nsdb.execute(firstQuery), 10.seconds)
@@ -868,7 +880,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val lastQuery = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationLongMetric.name)
         .query(s"select last(value) from ${AggregationLongMetric.name} group by age order by age")
 
       val lastResponse = Await.result(nsdb.execute(lastQuery), 10.seconds)
@@ -888,7 +900,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationLongMetric.name)
         .query(s"select count(value) from ${AggregationLongMetric.name} group by height order by value desc")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -908,7 +920,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationLongMetric.name)
         .query(s"select count(distinct value) from ${AggregationLongMetric.name} group by height order by value desc")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -928,7 +940,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
         Await.result(NSDB.connect(host = n.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationLongMetric.name)
         .query(s"select sum(value) from ${AggregationLongMetric.name} group by height order by height")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -949,7 +961,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val maxRequest = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationLongMetric.name)
         .query(s"select max(value) from ${AggregationLongMetric.name} group by height order by height")
 
       val maxResponse = Await.result(nsdb.execute(maxRequest), 10.seconds)
@@ -963,7 +975,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val minRequest = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationLongMetric.name)
         .query(s"select min(value) from ${AggregationLongMetric.name} group by height order by height")
 
       val minResponse = Await.result(nsdb.execute(minRequest), 10.seconds)
@@ -984,7 +996,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val firstRequest = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationLongMetric.name)
         .query(s"select first(value) from ${AggregationLongMetric.name} group by height order by height")
 
       val firstResponse = Await.result(nsdb.execute(firstRequest), 10.seconds)
@@ -998,7 +1010,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val lastRequest = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationLongMetric.name)
         .query(s"select last(value) from ${AggregationLongMetric.name} group by height order by height")
 
       val lastResponse = Await.result(nsdb.execute(lastRequest), 10.seconds)
@@ -1019,7 +1031,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val avgDoubleRequest = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationLongMetric.name)
         .query(s"select avg(*) from ${AggregationLongMetric.name} group by height order by height")
 
       val firstResponse = Await.result(nsdb.execute(avgDoubleRequest), 10.seconds)
@@ -1033,7 +1045,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val avgLongRequest = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationLongMetric.name)
         .query(s"select avg(value) from ${AggregationLongMetric.name} group by age order by age")
 
       val lastResponse = Await.result(nsdb.execute(avgLongRequest), 10.seconds)
@@ -1046,7 +1058,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationLongMetric.name)
         .query(s"select avg(value) from ${AggregationLongMetric.name} where timestamp >= 3 group by name order by name")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)
@@ -1068,7 +1080,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val avgDoubleRequest = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationDoubleMetric.name)
         .query(s"select avg(*) from ${AggregationDoubleMetric.name} group by height order by height")
 
       val firstResponse = Await.result(nsdb.execute(avgDoubleRequest), 10.seconds)
@@ -1082,7 +1094,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val avgLongRequest = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationDoubleMetric.name)
         .query(s"select avg(value) from ${AggregationDoubleMetric.name} group by age order by age")
 
       val lastResponse = Await.result(nsdb.execute(avgLongRequest), 10.seconds)
@@ -1095,7 +1107,7 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(AggregationDoubleMetric.name)
         .query(s"select avg(value) from ${AggregationDoubleMetric.name} where timestamp >= 3 group by name order by name")
 
       val readRes = Await.result(nsdb.execute(query), 10.seconds)

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/TemporalReadCoordinatorSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/TemporalReadCoordinatorSpec.scala
@@ -70,6 +70,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
       val query = nsdb
         .db(db)
         .namespace(namespace)
+        .metric(TemporalLongMetric.name)
         .query(s"select count(*) from ${TemporalLongMetric.name} group by interval 30s")
 
       eventually {
@@ -96,7 +97,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select count(*) from ${TemporalLongMetric.name} where timestamp > 200000 group by interval 30s")
 
       eventually {
@@ -116,7 +117,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select count(*) from ${TemporalLongMetric.name} where timestamp > 100000 group by interval 30s")
 
       eventually {
@@ -139,7 +140,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select count(*) from ${TemporalLongMetric.name} group by interval 30s limit 2")
 
       eventually {
@@ -162,7 +163,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select count(*) from ${TemporalLongMetric.name} group by interval 30s order by timestamp desc")
 
       eventually {
@@ -189,7 +190,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select count(*) from ${TemporalLongMetric.name} group by interval 60s")
 
       eventually {
@@ -213,7 +214,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select count(*) from ${TemporalDoubleMetric.name} group by interval 30s")
 
       eventually {
@@ -239,7 +240,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select count(*) from ${TemporalDoubleMetric.name} group by interval 60s")
 
       eventually {
@@ -263,7 +264,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select count(*) from ${TemporalDoubleMetric.name} group by interval 100s")
 
       eventually {
@@ -287,7 +288,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select count(*) from ${TemporalDoubleMetric.name} where timestamp >= 60000 group by interval 100s")
 
       eventually {
@@ -312,7 +313,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
         val query = nsdb
           .db(db)
-          .namespace(namespace)
+          .namespace(namespace).metric(TemporalLongMetric.name)
           .query(s"select sum(*) from ${TemporalDoubleMetric.name} group by interval 30s")
 
         eventually {
@@ -339,7 +340,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select max(*) from ${TemporalLongMetric.name} group by interval 30s")
 
       eventually {
@@ -366,7 +367,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select max(*) from ${TemporalDoubleMetric.name} group by interval 30s")
 
       eventually {
@@ -393,7 +394,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select min(*) from ${TemporalLongMetric.name} group by interval 30s")
 
       eventually {
@@ -420,7 +421,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select min(*) from ${TemporalDoubleMetric.name} group by interval 30s")
 
       eventually {
@@ -448,7 +449,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select avg(*) from ${TemporalLongMetric.name} group by interval 50s")
 
       eventually {
@@ -474,7 +475,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select avg(*) from ${TemporalDoubleMetric.name} group by interval 30s")
 
       eventually {
@@ -501,7 +502,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select count( distinct *) from ${TemporalLongMetric.name} group by interval 50s")
 
       eventually {
@@ -526,7 +527,7 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
       val query = nsdb
         .db(db)
-        .namespace(namespace)
+        .namespace(namespace).metric(TemporalLongMetric.name)
         .query(s"select count( distinct height) from ${TemporalLongMetric.name} group by interval 30s order by timestamp desc")
 
       eventually {

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/WriteCoordinatorClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/WriteCoordinatorClusterSpec.scala
@@ -62,6 +62,7 @@ class WriteCoordinatorClusterSpec extends MiniClusterSpec {
     val query = nsdb
       .db("root")
       .namespace("registry")
+      .metric("people")
       .query("select * from people limit 1")
 
     eventually {
@@ -99,6 +100,7 @@ class WriteCoordinatorClusterSpec extends MiniClusterSpec {
     val query = nsdb
       .db("root")
       .namespace("registry")
+      .metric("people")
       .query("select * from people limit 2")
 
     eventually {

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/NSDB.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/NSDB.java
@@ -448,7 +448,7 @@ public class NSDB {
      */
     public CompletableFuture<QueryResult> executeStatement(SQLStatement sqlStatement) {
         SQLRequestStatement sqlStatementRequest = new SQLRequestStatement(sqlStatement.db, sqlStatement.namespace, sqlStatement.metric, sqlStatement.sQLStatement, scalapb.UnknownFieldSet.empty());
-        return toJava(client.executeSQLStatement(sqlStatementRequest, "")).toCompletableFuture().thenApply(QueryResult::new);
+        return toJava(client.executeSQLStatement(sqlStatementRequest)).toCompletableFuture().thenApply(QueryResult::new);
     }
 
     /**

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/NSDB.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/NSDB.java
@@ -63,7 +63,7 @@ public class NSDB {
         }
 
         /**
-         * defines the namespace used to build the bit or the query
+         * defines the namespace used to build the namespace
          *
          * @param namespace the db name
          * @return
@@ -78,11 +78,37 @@ public class NSDB {
      */
     public static class Namespace {
         private String db;
-        private String name;
+        private String namespace;
 
-        private Namespace(String db, String name) {
+        private Namespace(String db, String namespace) {
             this.db = db;
-            this.name = name;
+            this.namespace = namespace;
+        }
+
+        /**
+         * defines the Metric to be inserted
+         *
+         * @param metric the db name
+         * @return the Bit
+         */
+        public Metric metric(String metric) {
+            return new Metric(this.db, this.namespace, metric);
+        }
+
+        public Bit bit(String metric) {
+            return new Bit(this.db, this.namespace, metric);
+        }
+    }
+
+    public static class Metric {
+        private String db;
+        private String namespace;
+        private String metric;
+
+        private Metric(String db, String namespace, String metric) {
+            this.db = db;
+            this.namespace = namespace;
+            this.metric = metric;
         }
 
         /**
@@ -92,17 +118,7 @@ public class NSDB {
          * @return the sql statement to execute
          */
         public SQLStatement query(String queryString) {
-            return new SQLStatement(this.db, this.name, queryString);
-        }
-
-        /**
-         * defines the Bit to be inserted
-         *
-         * @param metric the db name
-         * @return the Bit 
-         */
-        public Bit bit(String metric) {
-            return new Bit(db, name, metric);
+            return new SQLStatement(this.db, this.namespace, this.metric, queryString);
         }
     }
 
@@ -112,11 +128,13 @@ public class NSDB {
     public static class SQLStatement {
         private String db;
         private String namespace;
+        private String metric;
         private String sQLStatement;
 
-        private SQLStatement(String db, String namespace, String sqlStatement) {
+        private SQLStatement(String db, String namespace, String metric, String sqlStatement) {
             this.db = db;
             this.namespace = namespace;
+            this.metric = metric;
             this.sQLStatement = sqlStatement;
         }
     }
@@ -429,8 +447,8 @@ public class NSDB {
      * @return a CompletableFuture of the result of the operation. See {@link QueryResult}
      */
     public CompletableFuture<QueryResult> executeStatement(SQLStatement sqlStatement) {
-        SQLRequestStatement sqlStatementRequest = new SQLRequestStatement(sqlStatement.db, sqlStatement.namespace, sqlStatement.sQLStatement, scalapb.UnknownFieldSet.empty());
-        return toJava(client.executeSQLStatement(sqlStatementRequest)).toCompletableFuture().thenApply(QueryResult::new);
+        SQLRequestStatement sqlStatementRequest = new SQLRequestStatement(sqlStatement.db, sqlStatement.namespace, sqlStatement.metric, sqlStatement.sQLStatement, scalapb.UnknownFieldSet.empty());
+        return toJava(client.executeSQLStatement(sqlStatementRequest, "")).toCompletableFuture().thenApply(QueryResult::new);
     }
 
     /**

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/NSDB.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/NSDB.java
@@ -413,8 +413,8 @@ public class NSDB {
      * Creates a NSDb Connection with a Jwt token.
      * @param token the Jwt token that will be provided in the low level client.
      */
-    public CompletableFuture<NSDB> withJwtToken(String token) {
-        return CompletableFuture.supplyAsync(() -> new NSDB(this.client.host(), this.client.port(), TokenAppliers.JWT(token)));
+    public NSDB withJwtToken(String token) {
+        return new NSDB(this.client.host(), this.client.port(), TokenAppliers.JWT(token));
     }
 
     /**
@@ -422,8 +422,8 @@ public class NSDB {
      * @param tokenName name of the token.
      * @param tokenValue value of the token.
      */
-    public CompletableFuture<NSDB> withCustomToken(String tokenName, String tokenValue) {
-        return CompletableFuture.supplyAsync(() -> new NSDB(this.client.host(), this.client.port(), TokenAppliers.Custom(tokenName, tokenValue)));
+    public NSDB withCustomToken(String tokenName, String tokenValue) {
+        return new NSDB(this.client.host(), this.client.port(), TokenAppliers.Custom(tokenName, tokenValue));
     }
 
     /**

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/NSDB.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/NSDB.java
@@ -429,7 +429,7 @@ public class NSDB {
      * @return a CompletableFuture of the result of the operation. See {@link QueryResult}
      */
     public CompletableFuture<QueryResult> executeStatement(SQLStatement sqlStatement) {
-        SQLRequestStatement sqlStatementRequest = new SQLRequestStatement(sqlStatement.db, sqlStatement.namespace, sqlStatement.sQLStatement);
+        SQLRequestStatement sqlStatementRequest = new SQLRequestStatement(sqlStatement.db, sqlStatement.namespace, sqlStatement.sQLStatement, scalapb.UnknownFieldSet.empty());
         return toJava(client.executeSQLStatement(sqlStatementRequest)).toCompletableFuture().thenApply(QueryResult::new);
     }
 
@@ -442,18 +442,18 @@ public class NSDB {
     public CompletableFuture<InsertResult> write(Bit bit) {
         return toJava(client.write(
                 new RPCInsert(bit.db, bit.namespace, bit.metric,
-                        bit.timestamp, ScalaUtils.convertMap(bit.dimensions), ScalaUtils.convertMap(bit.tags), bit.value))).toCompletableFuture().thenApply(InsertResult::new);
+                        bit.timestamp, bit.value, ScalaUtils.convertMap(bit.dimensions), ScalaUtils.convertMap(bit.tags), scalapb.UnknownFieldSet.empty()))).toCompletableFuture().thenApply(InsertResult::new);
     }
 
 
     public CompletableFuture<InitMetricResult> initMetric(MetricInfo metricInfo) {
         return toJava(client.initMetric(
-                new InitMetricRequest(metricInfo.db, metricInfo.namespace, metricInfo.metric, metricInfo.shardInterval, metricInfo.retention))).toCompletableFuture().thenApply(InitMetricResult::new);
+                new InitMetricRequest(metricInfo.db, metricInfo.namespace, metricInfo.metric, metricInfo.shardInterval, metricInfo.retention, scalapb.UnknownFieldSet.empty()))).toCompletableFuture().thenApply(InitMetricResult::new);
     }
 
     public CompletableFuture<DescribeMetricResult> describe(Bit bit) {
         return toJava(client.describeMetric(
-                new DescribeMetric(bit.db, bit.namespace, bit.metric))).toCompletableFuture().thenApply(DescribeMetricResult::new);
+                new DescribeMetric(bit.db, bit.namespace, bit.metric, scalapb.UnknownFieldSet.empty()))).toCompletableFuture().thenApply(DescribeMetricResult::new);
     }
 
 

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/example/NSDBRead.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/example/NSDBRead.java
@@ -25,7 +25,7 @@ public class NSDBRead {
     public static void main(String[] args) throws Exception {
         NSDB nsdb = NSDB.connect("127.0.0.1", 7817).get();
 
-        NSDB.SQLStatement statement = nsdb.db("root").namespace("registry").query("select * from people limit 1");
+        NSDB.SQLStatement statement = nsdb.db("root").namespace("registry").metric("people").query("select * from people limit 1");
 
         QueryResult result = nsdb.executeStatement(statement).get();
 

--- a/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/example/NSDBSecureRead.java
+++ b/nsdb-java-api/src/main/java/io/radicalbit/nsdb/api/java/example/NSDBSecureRead.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.api.java.example;
+import io.radicalbit.nsdb.api.java.NSDB;
+import io.radicalbit.nsdb.api.java.QueryResult;
+
+/**
+ * This class is meant to be an example of a call to the execute Statement Apis.
+ */
+public class NSDBSecureRead {
+    public static void main(String[] args) throws Exception {
+        NSDB nsdb = NSDB.connect("127.0.0.1", 7817).get();
+
+        NSDB.SQLStatement statement = nsdb.withJwtToken("jwt token")
+                .db("root").namespace("registry").metric("people").query("select * from people limit 1");
+
+        QueryResult result = nsdb.executeStatement(statement).get();
+
+        if (result.isCompletedSuccessfully()) {
+            System.out.println("db " + result.getDb());
+            System.out.println("namespace " + result.getNamespace());
+            System.out.println("metric " + result.getMetric());
+            System.out.println("bits " + result.getRecords());
+        } else {
+            System.out.println("reason " + result.getReason());
+        }
+    }
+}

--- a/nsdb-rpc/src/main/java/io/radicalbit/nsdb/client/rpc/TokenApplier.java
+++ b/nsdb-rpc/src/main/java/io/radicalbit/nsdb/client/rpc/TokenApplier.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.client.rpc;
+
+import io.grpc.CallCredentials;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+/**
+ * Implements a Grpc {@link CallCredentials} in order to perform an authorized call.
+ * An authorization header is set from a {@link TokenApplier#token} inside method {@link CallCredentials#applyRequestMetadata}
+ */
+public abstract class TokenApplier extends CallCredentials {
+
+    private final Logger log = LoggerFactory.getLogger(TokenApplier.class);
+
+    /**
+     * The token to use to set the authorization header.
+     */
+    protected String token;
+
+    abstract Map<String, String> formatToken(String token);
+
+
+    @Override
+    public void applyRequestMetadata(RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {
+        appExecutor.execute(() -> {
+            if (token == null || "".equals(token)) {
+                applier.fail(Status.UNAUTHENTICATED.withDescription("Empty token provided"));
+            } else {
+                Map<String, String> rawHeaders = formatToken(token);
+                if (rawHeaders.size() > 1) {
+                    applier.fail(Status.UNAUTHENTICATED.withDescription("Token format function must return a 1-size map"));
+                } else {
+                    try {
+                        Metadata metadata = new Metadata();
+                        Map.Entry<String, String> rawHeader = rawHeaders.entrySet().iterator().next();
+                        metadata.put(Metadata.Key.of(rawHeader.getKey(), Metadata.ASCII_STRING_MARSHALLER), rawHeader.getValue());
+                        applier.apply(metadata);
+                    } catch (Throwable t) {
+                        String errorMsg = "An exception when obtaining JWT token";
+                        log.error(errorMsg, t);
+                        applier.fail(Status.UNAUTHENTICATED.withDescription(errorMsg).withCause(t));
+                    }
+                }
+            }
+        });
+    }
+
+    @Override
+    public void thisUsesUnstableApi() {
+    }
+}

--- a/nsdb-rpc/src/main/java/io/radicalbit/nsdb/client/rpc/TokenAppliers.java
+++ b/nsdb-rpc/src/main/java/io/radicalbit/nsdb/client/rpc/TokenAppliers.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.client.rpc;
+
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Contains factory methods to create most common instances of {@link TokenApplier}
+ */
+public class TokenAppliers {
+
+    private static class JwtTokenApplier extends TokenApplier {
+
+        public JwtTokenApplier(String token) {
+            this.token = token;
+        }
+
+        @Override
+        Map<String, String> formatToken(String token) {
+            return new HashMap<String, String>() {{
+                put("Authorization", MessageFormat.format("Bearer {0}", token));
+            }};
+        }
+
+    }
+
+    public static TokenApplier JWT(String token) {
+        return new JwtTokenApplier(token);
+    }
+
+    public static TokenApplier Custom(String name, String value) {
+        return new TokenApplier() {
+            @Override
+            Map<String, String> formatToken(String token) {
+                return new HashMap<String, String>() {{
+                    put(name, value);
+                }};
+            }
+        };
+    }
+}

--- a/nsdb-rpc/src/main/protobuf/init.proto
+++ b/nsdb-rpc/src/main/protobuf/init.proto
@@ -17,24 +17,26 @@
 syntax = "proto3";
 
 package io.radicalbit.nsdb.rpc;
+import "security.proto";
 
 message InitMetricRequest {
-  string db = 1;
-  string namespace = 2;
-  string metric = 3;
+  string db = 1 [(AuthorizationField) = DB];
+  string namespace = 2 [(AuthorizationField) = NAMESPACE];
+  string metric = 3 [(AuthorizationField) = METRIC];
   string shardInterval = 4;
   string retention = 5;
 }
 
 message InitMetricResponse {
-  string db = 1;
-  string namespace = 2;
-  string metric = 3;
+  string db = 1 [(AuthorizationField) = DB];
+  string namespace = 2 [(AuthorizationField) = NAMESPACE];
+  string metric = 3 [(AuthorizationField) = METRIC];
   bool completedSuccessfully = 4;
   string errorMsg = 5;
 }
 
 service InitMetric {
+  option (isAuthorized) = true;
   rpc InitMetric(InitMetricRequest) returns (InitMetricResponse);
 }
 

--- a/nsdb-rpc/src/main/protobuf/request.proto
+++ b/nsdb-rpc/src/main/protobuf/request.proto
@@ -19,11 +19,12 @@ syntax = "proto3";
 package io.radicalbit.nsdb.rpc;
 
 import "common.proto";
+import "security.proto";
 
 message RPCInsert {
-    string database = 1;
-    string namespace = 2;
-    string metric = 3;
+    string database = 1 [(AuthorizationField) = DB];
+    string namespace = 2 [(AuthorizationField) = NAMESPACE];
+    string metric = 3 [(AuthorizationField) = METRIC];
     int64 timestamp = 4;
     oneof value {
         double decimalValue = 5;

--- a/nsdb-rpc/src/main/protobuf/request.proto
+++ b/nsdb-rpc/src/main/protobuf/request.proto
@@ -18,7 +18,6 @@ syntax = "proto3";
 
 package io.radicalbit.nsdb.rpc;
 
-import "google/protobuf/any.proto";
 import "common.proto";
 
 message RPCInsert {

--- a/nsdb-rpc/src/main/protobuf/requestCommand.proto
+++ b/nsdb-rpc/src/main/protobuf/requestCommand.proto
@@ -17,18 +17,19 @@
 syntax = "proto3";
 
 package io.radicalbit.nsdb.rpc;
+import "security.proto";
 
 message ShowMetrics{
-    string db = 1;
-    string namespace = 2;
+    string db = 1 [(AuthorizationField) = DB];
+    string namespace = 2 [(AuthorizationField) = NAMESPACE];
 }
 
 message DescribeMetric{
-    string db = 1;
-    string namespace = 2;
-    string metric = 3;
+    string db = 1 [(AuthorizationField) = DB];
+    string namespace = 2 [(AuthorizationField) = NAMESPACE];
+    string metric = 3 [(AuthorizationField) = METRIC];
 }
 
 message ShowNamespaces{
-    string db = 1;
+    string db = 1 [(AuthorizationField) = DB];
 }

--- a/nsdb-rpc/src/main/protobuf/requestSQL.proto
+++ b/nsdb-rpc/src/main/protobuf/requestSQL.proto
@@ -17,9 +17,11 @@
 syntax = "proto3";
 
 package io.radicalbit.nsdb.rpc;
+import "security.proto";
 
 message SQLRequestStatement{
-    string db = 1;
-    string namespace = 2;
-    string statement = 3;
+    string db = 1 [(AuthorizationField) = DB];
+    string namespace = 2 [(AuthorizationField) = NAMESPACE];
+    string metric = 3 [(AuthorizationField) = METRIC];
+    string statement = 4;
 }

--- a/nsdb-rpc/src/main/protobuf/security.proto
+++ b/nsdb-rpc/src/main/protobuf/security.proto
@@ -5,9 +5,10 @@ package io.radicalbit.nsdb.rpc;
 import "google/protobuf/descriptor.proto";
 
 enum AuthorizationLevel {
-  DB = 0;
-  NAMESPACE = 1;
-  METRIC = 2;
+  NONE = 0;
+  DB = 1;
+  NAMESPACE = 2;
+  METRIC = 3;
 }
 
 extend google.protobuf.ServiceOptions {

--- a/nsdb-rpc/src/main/protobuf/security.proto
+++ b/nsdb-rpc/src/main/protobuf/security.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package io.radicalbit.nsdb.rpc;
+
+import "google/protobuf/descriptor.proto";
+
+enum AuthorizationLevel {
+  DB = 0;
+  NAMESPACE = 1;
+  METRIC = 2;
+}
+
+extend google.protobuf.ServiceOptions {
+  bool isAuthorized = 50000;
+}
+
+extend google.protobuf.FieldOptions {
+    AuthorizationLevel AuthorizationField = 50001;
+}

--- a/nsdb-rpc/src/main/protobuf/service.proto
+++ b/nsdb-rpc/src/main/protobuf/service.proto
@@ -24,13 +24,16 @@ import "requestSQL.proto";
 import "requestCommand.proto";
 import "responseSQL.proto";
 import "responseCommand.proto";
+import "security.proto";
 
 service NSDBServiceSQL {
+    option (isAuthorized) = true;
     rpc InsertBit (io.radicalbit.nsdb.rpc.RPCInsert) returns (io.radicalbit.nsdb.rpc.RPCInsertResult) {}
     rpc executeSQLStatement(io.radicalbit.nsdb.rpc.SQLRequestStatement) returns (io.radicalbit.nsdb.rpc.SQLStatementResponse) {}
 }
 
 service NSDBServiceCommand {
+    option (isAuthorized) = true;
     rpc showNamespaces (io.radicalbit.nsdb.rpc.ShowNamespaces) returns (io.radicalbit.nsdb.rpc.Namespaces) {}
     rpc showMetrics (io.radicalbit.nsdb.rpc.ShowMetrics) returns (io.radicalbit.nsdb.rpc.MetricsGot) {}
     rpc describeMetric (io.radicalbit.nsdb.rpc.DescribeMetric) returns (io.radicalbit.nsdb.rpc.DescribeMetricResponse) {}

--- a/nsdb-rpc/src/main/protobuf/service.proto
+++ b/nsdb-rpc/src/main/protobuf/service.proto
@@ -18,7 +18,6 @@ syntax = "proto3";
 
 package io.radicalbit.nsdb.rpc;
 
-import "health.proto";
 import "request.proto";
 import "response.proto";
 import "requestSQL.proto";

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/client/rpc/GRPCClient.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/client/rpc/GRPCClient.scala
@@ -39,7 +39,7 @@ import scala.concurrent.Future
   * @param port GRPC server port.
   * @param tokenApplier implementation of [[TokenApplier]] that contains authorization token management logic.
   */
-class GRPCClient(host: String, port: Int, tokenApplier: TokenApplier) {
+class GRPCClient(val host: String, val port: Int, val tokenApplier: TokenApplier) {
 
   def this(host: String, port: Int) = this(host, port, null)
 

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/GRPCServer.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/GRPCServer.scala
@@ -61,7 +61,8 @@ trait GRPCServer {
 
   protected[this] def authorizationProvider: NSDbAuthorizationProvider
 
-  protected[this] def interceptors: List[ServerInterceptor] = List(new GrpcAuthInterceptor(authorizationProvider))
+  protected[this] def interceptors: List[ServerInterceptor] =
+    if (!authorizationProvider.isEmpty) List(new GrpcAuthInterceptor(authorizationProvider)) else List.empty
 
   sys.addShutdownHook {
     if (!server.isTerminated) {

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/GRPCServer.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/GRPCServer.scala
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package io.radicalbit.nsdb.client.rpc
-
-import java.net.InetSocketAddress
+package io.radicalbit.nsdb.rpc.server
 
 import com.google.common.net.InetAddresses
-import io.grpc.Server
 import io.grpc.netty.NettyServerBuilder
+import io.grpc.protobuf.services.ProtoReflectionService
+import io.grpc.{Server, ServerInterceptor, ServerInterceptors}
 import io.radicalbit.nsdb.rpc.health.HealthGrpc
 import io.radicalbit.nsdb.rpc.health.HealthGrpc.Health
 import io.radicalbit.nsdb.rpc.init.InitMetricGrpc
@@ -30,9 +29,10 @@ import io.radicalbit.nsdb.rpc.restore.RestoreGrpc.Restore
 import io.radicalbit.nsdb.rpc.service.NSDBServiceCommandGrpc.NSDBServiceCommand
 import io.radicalbit.nsdb.rpc.service.NSDBServiceSQLGrpc.NSDBServiceSQL
 import io.radicalbit.nsdb.rpc.service.{NSDBServiceCommandGrpc, NSDBServiceSQLGrpc}
+import io.radicalbit.nsdb.security.NSDbAuthorizationProvider
 import io.radicalbit.nsdb.sql.parser.SQLStatementParser
-import io.grpc.protobuf.services.ProtoReflectionService
 
+import java.net.InetSocketAddress
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
@@ -59,6 +59,10 @@ trait GRPCServer {
 
   protected[this] def parserSQL: SQLStatementParser
 
+  protected[this] def authorizationProvider: NSDbAuthorizationProvider
+
+  protected[this] def interceptors: List[ServerInterceptor] = List(new GrpcAuthInterceptor(authorizationProvider))
+
   sys.addShutdownHook {
     if (!server.isTerminated) {
       System.err.println(s"Shutting down gRPC server at interface $interface and port $port since JVM is shutting down")
@@ -69,11 +73,16 @@ trait GRPCServer {
 
   lazy val server: Server = NettyServerBuilder
     .forAddress(new InetSocketAddress(InetAddresses.forString(interface), port))
-    .addService(NSDBServiceSQLGrpc.bindService(serviceSQL, executionContextExecutor))
-    .addService(NSDBServiceCommandGrpc.bindService(serviceCommand, executionContextExecutor))
-    .addService(InitMetricGrpc.bindService(initMetricService, executionContextExecutor))
+    .addService(ServerInterceptors.intercept(NSDBServiceSQLGrpc.bindService(serviceSQL, executionContextExecutor),
+                                             interceptors: _*))
+    .addService(
+      ServerInterceptors.intercept(NSDBServiceCommandGrpc.bindService(serviceCommand, executionContextExecutor),
+                                   interceptors: _*))
+    .addService(ServerInterceptors.intercept(InitMetricGrpc.bindService(initMetricService, executionContextExecutor),
+                                             interceptors: _*))
+    .addService(ServerInterceptors.intercept(RestoreGrpc.bindService(restore, executionContextExecutor),
+                                             interceptors: _*))
     .addService(HealthGrpc.bindService(health, executionContextExecutor))
-    .addService(RestoreGrpc.bindService(restore, executionContextExecutor))
     .addService(ProtoReflectionService.newInstance())
     .build
 

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/GRPCService.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/GRPCService.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.rpc.server
+
+import io.radicalbit.nsdb.rpc.security.SecurityProto
+import scalapb.descriptors.ServiceDescriptor
+
+trait GRPCService { this: _root_.scalapb.grpc.AbstractService =>
+
+  def serviceDescriptor: ServiceDescriptor
+
+  def isAuthorized: Boolean = serviceDescriptor.getOptions.extension(SecurityProto.isAuthorized)
+
+}

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/GrpcAuthInterceptor.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/GrpcAuthInterceptor.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.rpc.server
+
+import io.grpc._
+import io.radicalbit.nsdb.rpc.security.{AuthorizationLevel, SecurityProto}
+import io.radicalbit.nsdb.rpc.server.GrpcAuthInterceptor.{AuthInfo, DbAuthInto, MetricAuthInto, NamespaceAuthInto}
+import io.radicalbit.nsdb.security.NSDbAuthorizationProvider
+import io.radicalbit.nsdb.security.NSDbAuthorizationProvider.AuthorizationResponse
+import scalapb.GeneratedMessage
+import scalapb.descriptors.{FieldDescriptor, PValue}
+
+class GrpcAuthInterceptor(authProvider: NSDbAuthorizationProvider) extends ServerInterceptor {
+
+  override def interceptCall[ReqT, RespT](call: ServerCall[ReqT, RespT],
+                                          headers: Metadata,
+                                          next: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
+
+    val securityPayload = headers.get(Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER))
+
+    new ForwardingServerCallListener.SimpleForwardingServerCallListener[ReqT](next.startCall(call, headers)) {
+      override def onMessage(request: ReqT): Unit = {
+
+        request match {
+          case message: GeneratedMessage =>
+            val authorizationLevel: Map[AuthorizationLevel, String] = message.toPMessage.value.collect {
+              case (fieldDescriptor: FieldDescriptor, fieldValue: PValue)
+                  if !fieldDescriptor.getOptions.extension(SecurityProto.authorizationField).isUnrecognized =>
+                fieldDescriptor.getOptions.extension(SecurityProto.authorizationField) -> fieldValue.as[String]
+            }
+
+            val authorizationResponse = AuthInfo.validate(authorizationLevel) match {
+              case Right(DbAuthInto(db)) =>
+                authProvider.checkDbAuth(db, securityPayload, true)
+              case Right(NamespaceAuthInto(db, namespace)) =>
+                authProvider.checkNamespaceAuth(db, namespace, securityPayload, true)
+              case Right(MetricAuthInto(db, namespace, metric)) =>
+                authProvider.checkMetricAuth(db, namespace, metric, securityPayload, true)
+              case Left(error) =>
+                new AuthorizationResponse(false, error)
+            }
+
+            if (authorizationResponse.isSuccess) super.onMessage(request)
+            else
+              call.close(Status.PERMISSION_DENIED.withDescription(""), new Metadata)
+          case _ =>
+            call.close(Status.FAILED_PRECONDITION.withDescription(""), new Metadata)
+        }
+      }
+    }
+
+  }
+}
+
+object GrpcAuthInterceptor {
+
+  sealed trait AuthInfo
+  private case class DbAuthInto private (db: String)                                        extends AuthInfo
+  private case class NamespaceAuthInto private (db: String, namespace: String)              extends AuthInfo
+  private case class MetricAuthInto private (db: String, namespace: String, metric: String) extends AuthInfo
+
+//  private (db: Option[String], namespace: Option[String], metric: Option[String])
+
+  object AuthInfo {
+    def validate(map: Map[AuthorizationLevel, String]): Either[String, AuthInfo] = {
+      (map.get(AuthorizationLevel.DB), map.get(AuthorizationLevel.NAMESPACE), map.get(AuthorizationLevel.METRIC)) match {
+        case (Some(db), None, None) =>
+          Right(DbAuthInto(db))
+        case (Some(db), Some(namespace), None) =>
+          Right(NamespaceAuthInto(db, namespace))
+        case (Some(db), Some(namespace), Some(metric)) =>
+          Right(MetricAuthInto(db, namespace, metric))
+        case _ =>
+          Left("auth info not valid")
+      }
+    }
+  }
+
+}

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/GrpcAuthInterceptor.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/GrpcAuthInterceptor.scala
@@ -17,7 +17,6 @@
 package io.radicalbit.nsdb.rpc.server
 
 import io.grpc._
-import io.radicalbit.nsdb.client.rpc.JwtTokenApplier
 import io.radicalbit.nsdb.rpc.security.{AuthorizationLevel, SecurityProto}
 import io.radicalbit.nsdb.rpc.server.GrpcAuthInterceptor.{AuthInfo, DbAuthInto, MetricAuthInto, NamespaceAuthInto}
 import io.radicalbit.nsdb.security.NSDbAuthorizationProvider
@@ -34,7 +33,8 @@ class GrpcAuthInterceptor(authProvider: NSDbAuthorizationProvider) extends Serve
                                           headers: Metadata,
                                           next: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
 
-    val securityPayload = headers.get(Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER))
+    val securityPayload =
+      headers.get(Metadata.Key.of(authProvider.getGrpcSecurityHeader(), Metadata.ASCII_STRING_MARSHALLER))
 
     new ForwardingServerCallListener.SimpleForwardingServerCallListener[ReqT](next.startCall(call, headers)) {
       override def onMessage(request: ReqT): Unit = {

--- a/nsdb-rpc/src/test/protobuf/securityTest.proto
+++ b/nsdb-rpc/src/test/protobuf/securityTest.proto
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package io.radicalbit.nsdb.rpc.test;
+
+import "security.proto";
+
+message DummySecureRequest {
+  string db = 1 [(AuthorizationField) = DB];
+  string namespace = 2 [(AuthorizationField) = NAMESPACE];
+  string metric = 3 [(AuthorizationField) = METRIC];
+}
+
+message DummyResponse {
+  string headerName = 1;
+}
+
+service DummySecureService {
+  option (isAuthorized) = true;
+  rpc dummySecure(io.radicalbit.nsdb.rpc.test.DummySecureRequest) returns (io.radicalbit.nsdb.rpc.test.DummyResponse) {}
+}

--- a/nsdb-rpc/src/test/scala/GrpcAuthInterceptorTest.scala
+++ b/nsdb-rpc/src/test/scala/GrpcAuthInterceptorTest.scala
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
+import io.grpc.{ManagedChannel, Server, ServerInterceptors, Status, StatusRuntimeException}
+import io.radicalbit.nsdb.client.rpc.TokenAppliers
+import io.radicalbit.nsdb.rpc.server.GrpcAuthInterceptor
+import io.radicalbit.nsdb.rpc.test.DummyServiceGrpc.DummySecureServiceGrpc
+import io.radicalbit.nsdb.rpc.test.securityTest.{DummyResponse, DummySecureRequest, DummySecureServiceGrpc}
+import io.radicalbit.nsdb.security.NSDbAuthorizationProvider
+import io.radicalbit.nsdb.security.NSDbAuthorizationProvider.AuthorizationResponse
+import io.radicalbit.nsdb.test.NSDbSpec
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+
+import java.util
+import java.util.concurrent.TimeUnit
+import scala.concurrent.ExecutionContext
+
+class GrpcAuthInterceptorTest extends NSDbSpec with BeforeAndAfterAll with BeforeAndAfterEach with ScalaFutures {
+
+  implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  val channelName: String           = InProcessServerBuilder.generateName
+  var clientChannel: ManagedChannel = _
+  var server: Server                = _
+
+  val testAuthProvider: NSDbAuthorizationProvider = new NSDbAuthorizationProvider {
+    override def extractHttpSecurityPayload(rawHeaders: util.Map[String, String]): String = ""
+
+    override def extractWsSecurityPayload(subProtocols: util.List[String]): String = ""
+
+    override def getGrpcSecurityHeader: String = "Authorization"
+
+    override def checkDbAuth(db: String,
+                             payload: String,
+                             writePermission: Boolean): NSDbAuthorizationProvider.AuthorizationResponse =
+      if (payload == "Bearer allowed" && db == "allowedDb") new AuthorizationResponse(true)
+      else new AuthorizationResponse(false, "Not Allowed")
+
+    override def checkNamespaceAuth(db: String,
+                                    namespace: String,
+                                    payload: String,
+                                    writePermission: Boolean): NSDbAuthorizationProvider.AuthorizationResponse =
+      if (payload == "Bearer allowed" && db == "allowedDb" && namespace == "allowedNamespace")
+        new AuthorizationResponse(true)
+      else new AuthorizationResponse(false, "Not Allowed")
+
+    override def checkMetricAuth(db: String,
+                                 namespace: String,
+                                 metric: String,
+                                 payload: String,
+                                 writePermission: Boolean): NSDbAuthorizationProvider.AuthorizationResponse =
+      if (payload == "Bearer allowed" && db == "allowedDb" && namespace == "allowedNamespace" && metric == "allowedMetric")
+        new AuthorizationResponse(true)
+      else new AuthorizationResponse(false, "Not Allowed")
+  }
+
+  val grpcAuthProvider = new GrpcAuthInterceptor(testAuthProvider)
+
+  implicit val defaultPatience =
+    PatienceConfig(timeout = Span(1, Seconds), interval = Span(500, Millis))
+
+  override def beforeAll: Unit = {
+    val dummySecureService = new DummySecureServiceGrpc
+    server = InProcessServerBuilder
+      .forName(channelName)
+      .addService(
+        ServerInterceptors.intercept(DummySecureServiceGrpc.bindService(dummySecureService, ec), grpcAuthProvider))
+      .build
+      .start
+  }
+
+  override def beforeEach(): Unit =
+    clientChannel = InProcessChannelBuilder.forName(channelName).usePlaintext.build
+
+  override def afterEach(): Unit = {
+    Option(clientChannel).foreach(_.shutdownNow())
+    Option(clientChannel).foreach(_.awaitTermination(1, TimeUnit.SECONDS))
+  }
+
+  override def afterAll(): Unit =
+    Option(server).foreach(_.shutdownNow())
+  Option(server).foreach(_.awaitTermination())
+
+  "GrpcAuthInterceptor" should {
+    "Deny a call without a token provided" in {
+      val dummyServiceSecureClient = DummySecureServiceGrpc.stub(clientChannel)
+
+      whenReady(dummyServiceSecureClient.dummySecure(DummySecureRequest("db", "namespace", "metric")).failed) {
+        throwable =>
+          throwable shouldBe an[StatusRuntimeException]
+          throwable.asInstanceOf[StatusRuntimeException].getStatus.getCode shouldBe Status.UNAUTHENTICATED.getCode
+          throwable
+            .asInstanceOf[StatusRuntimeException]
+            .getStatus
+            .getDescription shouldBe GrpcAuthInterceptor.EmptyToken
+      }
+    }
+  }
+
+  "Deny a call with a wrong token provided" in {
+    val dummyServiceSecureClient =
+      DummySecureServiceGrpc.stub(clientChannel).withCallCredentials(TokenAppliers.JWT("wrongToken"))
+
+    whenReady(dummyServiceSecureClient.dummySecure(DummySecureRequest("db", "namespace", "metric")).failed) {
+      throwable =>
+        throwable shouldBe an[StatusRuntimeException]
+        throwable.asInstanceOf[StatusRuntimeException].getStatus.getCode shouldBe Status.PERMISSION_DENIED.getCode
+        throwable.asInstanceOf[StatusRuntimeException].getStatus.getDescription shouldBe "Not Allowed"
+    }
+  }
+
+  "Deny a call with the right token but not authorized command" in {
+    val dummyServiceSecureClient =
+      DummySecureServiceGrpc.stub(clientChannel).withCallCredentials(TokenAppliers.JWT("allowed"))
+
+    whenReady(dummyServiceSecureClient.dummySecure(DummySecureRequest("db", "namespace", "metric")).failed) {
+      throwable =>
+        throwable shouldBe an[StatusRuntimeException]
+        throwable.asInstanceOf[StatusRuntimeException].getStatus.getCode shouldBe Status.PERMISSION_DENIED.getCode
+        throwable
+          .asInstanceOf[StatusRuntimeException]
+          .getStatus
+          .getDescription shouldBe "Not Allowed"
+    }
+  }
+
+  "Allow a call with the right token and an authorized command" in {
+    val dummyServiceSecureClient =
+      DummySecureServiceGrpc.stub(clientChannel).withCallCredentials(TokenAppliers.JWT("allowed"))
+
+    whenReady(
+      dummyServiceSecureClient.dummySecure(DummySecureRequest("allowedDb", "allowedNamespace", "allowedMetric"))) {
+      response =>
+        response shouldBe DummyResponse("allowedDb-allowedNamespace-allowedMetric")
+    }
+  }
+}

--- a/nsdb-rpc/src/test/scala/io/radicalbit/nsdb/rpc/test/DummyServiceGrpc.scala
+++ b/nsdb-rpc/src/test/scala/io/radicalbit/nsdb/rpc/test/DummyServiceGrpc.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.rpc.test
+
+import io.radicalbit.nsdb.rpc.test.securityTest.DummySecureServiceGrpc.DummySecureService
+import io.radicalbit.nsdb.rpc.test.securityTest.{DummyResponse, DummySecureRequest}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object DummyServiceGrpc {
+
+  class DummySecureServiceGrpc(implicit executionContext: ExecutionContext) extends DummySecureService {
+    override def dummySecure(request: DummySecureRequest): Future[DummyResponse] = {
+      Future(DummyResponse(s"${request.db}-${request.namespace}-${request.metric}"))
+    }
+  }
+
+}

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDB.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDB.scala
@@ -19,7 +19,6 @@ package io.radicalbit.nsdb.api.scala
 import io.radicalbit.nsdb.api.scala.NSDB._
 import io.radicalbit.nsdb.client.rpc.{GRPCClient, TokenApplier, TokenAppliers}
 import io.radicalbit.nsdb.rpc.common.{Dimension, Tag}
-import io.radicalbit.nsdb.rpc.health.HealthCheckResponse
 import io.radicalbit.nsdb.rpc.request.RPCInsert
 import io.radicalbit.nsdb.rpc.requestSQL.SQLRequestStatement
 import io.radicalbit.nsdb.rpc.response.RPCInsertResult
@@ -110,8 +109,9 @@ class NSDB private (host: String, port: Int, tokenApplier: Option[TokenApplier] 
 
   /**
     * Checks if a connection is healthy.
+    * @return the connection instance.
     */
-  def check: Future[HealthCheckResponse] = client.checkConnection()
+  def check: Future[NSDB] = client.checkConnection().map(_ => this)
 
   /**
     * Writes a bit into Nsdb using the current openend connection.

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDB.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDB.scala
@@ -44,8 +44,9 @@ object NSDB {
     * @param executionContextExecutor implicit execution context.
     * @return a Future of a nsdb connection.
     */
-  def connect(host: String, port: Int)(implicit executionContextExecutor: ExecutionContext): Future[NSDB] = {
-    val connection = new NSDB(host = host, port = port)
+  def connect(host: String, port: Int, token: Option[String] = None)(
+      implicit executionContextExecutor: ExecutionContext): Future[NSDB] = {
+    val connection = new NSDB(host = host, port = port, token = token)
     connection.check.map(_ => connection)
   }
 
@@ -79,7 +80,8 @@ object NSDB {
   * @param port Nsdb port
   * @param executionContextExecutor implicit execution context to handle asynchronous methods
   */
-case class NSDB(host: String, port: Int)(implicit executionContextExecutor: ExecutionContext) {
+case class NSDB(host: String, port: Int, token: Option[String] = None)(
+    implicit executionContextExecutor: ExecutionContext) {
 
   /**
     * Inner Grpc client.
@@ -132,7 +134,7 @@ case class NSDB(host: String, port: Int)(implicit executionContextExecutor: Exec
       SQLRequestStatement(db = sqlStatement.db,
                           namespace = sqlStatement.namespace,
                           statement = sqlStatement.sQLStatement)
-    client.executeSQLStatement(sqlStatementRequest)
+    client.executeSQLStatement(sqlStatementRequest, token.getOrElse(""))
   }
 
   /**

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDB.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDB.scala
@@ -133,6 +133,7 @@ case class NSDB(host: String, port: Int, token: Option[String] = None)(
     val sqlStatementRequest =
       SQLRequestStatement(db = sqlStatement.db,
                           namespace = sqlStatement.namespace,
+                          metric = sqlStatement.metric,
                           statement = sqlStatement.sQLStatement)
     client.executeSQLStatement(sqlStatementRequest, token.getOrElse(""))
   }
@@ -171,17 +172,9 @@ case class Namespace(db: String, name: String) {
     * @return a bit with empty dimensions and value.
     */
   def metric(metric: String): Bit = Bit(db = db, namespace = name, metric = metric)
-
-  /**
-    * Builds the query to be executed.
-    * @param queryString raw query.
-    * @return auxiliary [[SQLStatement]] case class.
-    */
-  def query(queryString: String): SQLStatement = SQLStatement(db = db, namespace = name, sQLStatement = queryString)
-
 }
 
-case class SQLStatement(db: String, namespace: String, sQLStatement: String)
+case class SQLStatement(db: String, namespace: String, metric: String, sQLStatement: String)
 
 /**
   * Auxiliary case class useful to define a bit to be inserted.
@@ -199,6 +192,14 @@ case class Bit protected (db: String,
                           value: RPCInsert.Value = RPCInsert.Value.Empty,
                           dimensions: ListBuffer[DimensionAPI] = ListBuffer.empty[DimensionAPI],
                           tags: ListBuffer[TagAPI] = ListBuffer.empty[TagAPI]) {
+
+  /**
+    * Builds the query to be executed.
+    * @param queryString raw query.
+    * @return auxiliary [[SQLStatement]] case class.
+    */
+  def query(queryString: String): SQLStatement =
+    SQLStatement(db = db, namespace = namespace, metric = metric, sQLStatement = queryString)
 
   /**
     * Builds [[MetricInfo]] from an existing bit providing a shard interval

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
@@ -51,9 +51,7 @@ object NSDBMainWrite extends App {
   */
 object NSDBMainRead extends App {
 
-  val nsdb = Await.result(
-    NSDB.connect(host = "127.0.0.1", port = 7817, token = Some("testToken"))(ExecutionContext.global),
-    10.seconds)
+  val nsdb = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817)(ExecutionContext.global), 10.seconds)
 
   val query = nsdb
     .db("root")

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
@@ -90,3 +90,22 @@ object NSDBInitRead extends App {
   val describeRes = nsdb.describe(metricToDescribe)
   println(Await.result(describeRes, 10.seconds))
 }
+
+/**
+  * Example App for executing a query in a secure environment.
+  */
+object NSDBMainSecureRead extends App {
+
+  val nsdb = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817)(ExecutionContext.global), 10.seconds)
+
+  val query = nsdb
+    .withJwtToken("jwt token")
+    .db("root")
+    .namespace("registry")
+    .metric("people")
+    .query("select * from people limit 1")
+
+  val readRes: Future[SQLStatementResponse] = nsdb.execute(query)
+
+  println(Await.result(readRes, 10.seconds))
+}

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
@@ -51,7 +51,9 @@ object NSDBMainWrite extends App {
   */
 object NSDBMainRead extends App {
 
-  val nsdb = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817)(ExecutionContext.global), 10.seconds)
+  val nsdb = Await.result(
+    NSDB.connect(host = "127.0.0.1", port = 7817, token = Some("testToken"))(ExecutionContext.global),
+    10.seconds)
 
   val query = nsdb
     .db("root")

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
@@ -58,6 +58,7 @@ object NSDBMainRead extends App {
   val query = nsdb
     .db("root")
     .namespace("registry")
+    .metric("people")
     .query("select * from people limit 1")
 
   val readRes: Future[SQLStatementResponse] = nsdb.execute(query)

--- a/nsdb-security/src/main/java/io/radicalbit/nsdb/security/EmptyNSDbAuthorizationProvider.java
+++ b/nsdb-security/src/main/java/io/radicalbit/nsdb/security/EmptyNSDbAuthorizationProvider.java
@@ -36,6 +36,11 @@ public class EmptyNSDbAuthorizationProvider implements NSDbAuthorizationProvider
     }
 
     @Override
+    public String getGrpcSecurityHeader() {
+        return "dummyHeader";
+    }
+
+    @Override
     public AuthorizationResponse checkDbAuth(String db, String payload, boolean writePermission) {
         return new AuthorizationResponse(true);
     }

--- a/nsdb-security/src/main/java/io/radicalbit/nsdb/security/NSDbAuthorizationProvider.java
+++ b/nsdb-security/src/main/java/io/radicalbit/nsdb/security/NSDbAuthorizationProvider.java
@@ -60,6 +60,10 @@ public interface NSDbAuthorizationProvider {
         return new EmptyNSDbAuthorizationProvider();
     }
 
+    default boolean isEmpty() {
+        return this instanceof EmptyNSDbAuthorizationProvider;
+    }
+
     /**
      * Extract the security info from Http headers.
      * @param rawHeaders Http headers in an agnostic format.

--- a/nsdb-security/src/main/java/io/radicalbit/nsdb/security/NSDbAuthorizationProvider.java
+++ b/nsdb-security/src/main/java/io/radicalbit/nsdb/security/NSDbAuthorizationProvider.java
@@ -75,6 +75,11 @@ public interface NSDbAuthorizationProvider {
     String extractWsSecurityPayload(List<String> subProtocols);
 
     /**
+     * @return the header name that will be used to extract grpc security payload
+     */
+    String getGrpcSecurityHeader();
+
+    /**
      * Checks if a request against a Db is authorized.
      * @param db the db to check.
      * @param payload the security payload gathered from request.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -240,7 +240,8 @@ object Dependencies {
       gRPC.`grpc-netty`,
       gRPC.`grpc-services`,
       scalaPB.`runtime`,
-      scalaPB.`runtime-grpc`
+      scalaPB.`runtime-grpc`,
+      scalatest.core % Test
     )
   }
 

--- a/project/dependencies.sbt
+++ b/project/dependencies.sbt
@@ -1,4 +1,3 @@
 libraryDependencies ++= Seq(
-  "com.typesafe"         % "config"          % "1.2.1",
-  "com.thesamet.scalapb" %% "compilerplugin" % "0.9.0"
+  "com.thesamet.scalapb" %% "compilerplugin" % "0.10.10"
 )

--- a/project/protoc.sbt
+++ b/project/protoc.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.34")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.0")


### PR DESCRIPTION
This PR adds security to the gRpc Server  and to the gRpc client.

**Server side**

A `GrpcAuthInterceptor` has been added and applied to all the secured grpc services.
It has got the authorization provider as a dependency in order to check if a token is valid and if  a message is authorized against it.
In order to make a message compliant to the authorization mechanism, grpc options have been leveraged; a field option called `AuthorizationField` can be added to a message field with the purpose to describe which enclosing entity it represent (db, namespace or metric) 
e.g.

```
message SQLRequestStatement{
    string db = 1 [(AuthorizationField) = DB];
    string namespace = 2 [(AuthorizationField) = NAMESPACE];
    string metric = 3 [(AuthorizationField) = METRIC];
    string statement = 4;
}
```
 in this message it's straightforward that the db field represents the DB and so on... This information is used by the interceptor to extract the parameters to pass to the authorization provider. 

***Client Side***

A `TokenApplier`, that extends grpc `CallCredentials` entity has been added.
The general purpose of such an object is to extends the grpc request by adding a custom header.
In our case that header contains the security information.
The token applier can be passed as a `GRPCClient` class parameter.
From the apis, the builder patter used to create a connection has been enriched by adding a new method to specify a Jwt token applier or a custom token applier

e.g.
```
nsdbClientConnection.withJwtToken("jwt token")
nsdbClientConnection.withCustomToken("token name", "token value")
