### PR TITLE
Improve Integration test stability And Reliability

### DIFF
--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/GlobalAggregationReadCoordinatorSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/GlobalAggregationReadCoordinatorSpec.scala
@@ -40,22 +40,15 @@ class GlobalAggregationReadCoordinatorSpec extends MiniClusterSpec {
 
     super.beforeAll()
 
-    val firstNode = nodes.head
-
-    val nsdbConnection =
-      eventually {
-        Await.result(NSDB.connect(host = firstNode.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
-      }
-
     LongMetric.testRecords.map(_.asApiBit(db, namespace, LongMetric.name)).foreach { bit =>
       eventually {
-        assert(Await.result(nsdbConnection.write(bit), 10.seconds).completedSuccessfully)
+        assert(Await.result(withRandomNodeConnection{_.write(bit)}, 10.seconds).completedSuccessfully)
       }
     }
 
     AggregationLongMetric.testRecords.map(_.asApiBit(db, namespace, AggregationLongMetric.name)).foreach { bit =>
       eventually {
-        assert(Await.result(nsdbConnection.write(bit), 10.seconds).completedSuccessfully)
+        assert(Await.result(withRandomNodeConnection{_.write(bit)}, 10.seconds).completedSuccessfully)
       }
     }
 

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/PublishSubscribeGrpcClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/PublishSubscribeGrpcClusterSpec.scala
@@ -27,7 +27,6 @@ import io.radicalbit.nsdb.test.MiniClusterSpec
 import java.util.concurrent.TimeUnit
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Await
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class PublishSubscribeGrpcClusterSpec extends MiniClusterSpec {

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/ReadCoordinatorClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/ReadCoordinatorClusterSpec.scala
@@ -37,34 +37,27 @@ class ReadCoordinatorClusterSpec extends MiniClusterSpec {
 
     super.beforeAll()
 
-    val firstNode = nodes.head
-
-    val nsdbConnection =
-      eventually {
-        Await.result(NSDB.connect(host = firstNode.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
-      }
-
     LongMetric.testRecords.map(_.asApiBit(db, namespace, LongMetric.name)).foreach { bit =>
       eventually {
-        assert(Await.result(nsdbConnection.write(bit), 10.seconds).completedSuccessfully)
+        assert(Await.result(withRandomNodeConnection{_.write(bit)}, 10.seconds).completedSuccessfully)
       }
     }
 
     DoubleMetric.testRecords.map(_.asApiBit(db, namespace, DoubleMetric.name)).foreach { bit =>
       eventually {
-        assert(Await.result(nsdbConnection.write(bit), 10.seconds).completedSuccessfully)
+        assert(Await.result(withRandomNodeConnection{_.write(bit)}, 10.seconds).completedSuccessfully)
       }
     }
 
     AggregationLongMetric.testRecords.map(_.asApiBit(db, namespace, AggregationLongMetric.name)).foreach { bit =>
       eventually {
-        assert(Await.result(nsdbConnection.write(bit), 10.seconds).completedSuccessfully)
+        assert(Await.result(withRandomNodeConnection{_.write(bit)}, 10.seconds).completedSuccessfully)
       }
     }
 
     AggregationDoubleMetric.testRecords.map(_.asApiBit(db, namespace, AggregationDoubleMetric.name)).foreach { bit =>
       eventually {
-        assert(Await.result(nsdbConnection.write(bit), 10.seconds).completedSuccessfully)
+        assert(Await.result(withRandomNodeConnection{_.write(bit)}, 10.seconds).completedSuccessfully)
       }
     }
 

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/TemporalReadCoordinatorSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/TemporalReadCoordinatorSpec.scala
@@ -41,20 +41,15 @@ class TemporalReadCoordinatorSpec extends MiniClusterSpec {
 
     super.beforeAll()
 
-    val nsdbConnection =
-      eventually {
-        Await.result(NSDB.connect(host = firstNode.hostname, port = 7817)(ExecutionContext.global), 10.seconds)
-      }
-
     TemporalLongMetric.testRecords.map(_.asApiBit(db, namespace, TemporalLongMetric.name)).foreach { bit =>
       eventually {
-        assert(Await.result(nsdbConnection.write(bit), 10.seconds).errors == "")
+        assert(Await.result(withRandomNodeConnection{_.write(bit)}, 10.seconds).errors == "")
       }
     }
 
     TemporalDoubleMetric.testRecords.map(_.asApiBit(db, namespace, TemporalDoubleMetric.name)).foreach { bit =>
       eventually {
-        assert(Await.result(nsdbConnection.write(bit), 10.seconds).errors == "")
+        assert(Await.result(withRandomNodeConnection{_.write(bit)}, 10.seconds).errors == "")
       }
     }
 

--- a/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/NSDbMiniCluster.scala
+++ b/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/NSDbMiniCluster.scala
@@ -25,7 +25,7 @@ import org.apache.commons.io.FileUtils
 
 trait NSDbMiniCluster extends LazyLogging {
 
-  protected[this] val instanceId = { UUID.randomUUID }
+  protected[this] val instanceId: UUID = { UUID.randomUUID }
 
   protected[this] val startingHostname = "127.0.0."
 
@@ -35,8 +35,8 @@ trait NSDbMiniCluster extends LazyLogging {
   protected[this] def passivateAfter: Duration
   protected[this] def replicationFactor: Int
 
-  lazy val nodes: Set[NSDbMiniClusterNode] =
-    (for {
+  lazy val nodes: Seq[NSDbMiniClusterNode] =
+    for {
       i <- 0 until nodesNumber
     } yield
       new NSDbMiniClusterNode(
@@ -45,7 +45,7 @@ trait NSDbMiniCluster extends LazyLogging {
         shardInterval = shardInterval,
         passivateAfter = passivateAfter,
         replicationFactor = replicationFactor
-      )).toSet
+      )
 
   def start(cleanup: Boolean = false): Unit = {
     if (cleanup)


### PR DESCRIPTION
From a suggestion by @artur-rashitov, who noticed, that records in IT were inserted only on one node, a convenience method called `withRandomNodeConnection` is used for every write operation involving test data preparation. In this way we are sure that data is scattered among cluster nodes