### PR TITLE
Grpc Streaming Service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ lazy val `nsdb-rpc` = project
   )
   .settings(LicenseHeader.settings: _*)
   .enablePlugins(AutomateHeaderPlugin)
-  .dependsOn(`nsdb-sql`, `nsdb-security`, `nsdb-common` % "compile->compile;test->test")
+  .dependsOn(`nsdb-sql`, `nsdb-security`, `nsdb-core`, `nsdb-common` % "compile->compile;test->test")
 lazy val `nsdb-cluster` = project
   .settings(Commons.settings: _*)
   .settings(PublishSettings.dontPublish: _*)

--- a/nsdb-cluster/src/main/resources/nsdb.conf
+++ b/nsdb-cluster/src/main/resources/nsdb.conf
@@ -151,13 +151,13 @@ nsdb {
   stream.timeout = 30 seconds
   stream.timeout = ${?STREAM_TIMEOUT}
 
-  websocket {
-    // Websocket publish period expressed in milliseconds
+  streaming {
+    // Streaming publish period expressed in milliseconds
     refresh-period = 100
-    refresh-period = ${?WS_REFRESH_PERIOD}
-    //Websocket retention size
+    refresh-period = ${?STREAMING_REFRESH_PERIOD}
+    // Streaming retention size
     retention-size = 10
-    retention-size = ${?WS_RETENTION_SIZE}
+    retention-size = ${?STREAMING_RETENTION_SIZE}
   }
 
   retry-policy {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
@@ -17,7 +17,6 @@
 package io.radicalbit.nsdb.cluster
 
 import java.util.concurrent.TimeUnit
-
 import akka.actor._
 import akka.cluster.Cluster
 import akka.cluster.ddata.DistributedData
@@ -29,7 +28,7 @@ import io.radicalbit.nsdb.cluster.actor._
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.globalTimeout
 
 /**
-  * Creates the top level actor [[DatabaseActorsGuardian]] and grpc endpoint [[io.radicalbit.nsdb.cluster.endpoint.GrpcEndpoint]] based on coordinators
+  * Creates top level actors.
   */
 trait NSDbActors {
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NsdbNodeEndpoint.scala
@@ -75,6 +75,7 @@ class NsdbNodeEndpoint(nodeId: String,
         readCoordinator = readCoordinator,
         writeCoordinator = writeCoordinator,
         metadataCoordinator = metadataCoordinator,
+        publisherActor = publisher,
         authorizationProvider = provider
       )
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
@@ -35,8 +35,9 @@ import io.radicalbit.nsdb.rpc.init.{InitMetricRequest, InitMetricResponse}
 import io.radicalbit.nsdb.rpc.restore.RestoreGrpc.Restore
 import io.radicalbit.nsdb.rpc.restore.{RestoreRequest, RestoreResponse}
 import io.radicalbit.nsdb.rpc.server.GRPCServer
-import io.radicalbit.nsdb.rpc.server.endpoint.{GrpcEndpointServiceCommand, GrpcEndpointServiceSQL}
+import io.radicalbit.nsdb.rpc.server.endpoint.{GrpcEndpointServiceCommand, GrpcEndpointServiceSQL, GrpcNSDbStreaming}
 import io.radicalbit.nsdb.rpc.service.NSDBServiceCommandGrpc.NSDBServiceCommand
+import io.radicalbit.nsdb.rpc.streaming.NSDbStreamingGrpc.NSDbStreaming
 import io.radicalbit.nsdb.security.NSDbAuthorizationProvider
 import io.radicalbit.nsdb.sql.parser.SQLStatementParser
 import org.slf4j.LoggerFactory
@@ -56,6 +57,7 @@ class GrpcEndpoint(nodeId: String,
                    readCoordinator: ActorRef,
                    writeCoordinator: ActorRef,
                    metadataCoordinator: ActorRef,
+                   publisherActor: ActorRef,
                    override val authorizationProvider: NSDbAuthorizationProvider)(implicit system: ActorSystem)
     extends GRPCServer {
 
@@ -78,6 +80,8 @@ class GrpcEndpoint(nodeId: String,
   override protected[this] lazy val health: Health = GrpcEndpointServiceHealth
 
   override protected[this] lazy val restore: Restore = GrpcEndpointServiceRestore
+
+  override protected[this] lazy val streamingService: NSDbStreaming = new GrpcNSDbStreaming(publisherActor)
 
   override protected[this] val interface: String = system.settings.config.getString(GrpcInterface)
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcEndpoint.scala
@@ -35,6 +35,7 @@ import io.radicalbit.nsdb.rpc.init.{InitMetricRequest, InitMetricResponse}
 import io.radicalbit.nsdb.rpc.restore.RestoreGrpc.Restore
 import io.radicalbit.nsdb.rpc.restore.{RestoreRequest, RestoreResponse}
 import io.radicalbit.nsdb.rpc.server.GRPCServer
+import io.radicalbit.nsdb.rpc.server.endpoint.{GrpcEndpointServiceCommand, GrpcEndpointServiceSQL}
 import io.radicalbit.nsdb.rpc.service.NSDBServiceCommandGrpc.NSDBServiceCommand
 import io.radicalbit.nsdb.security.NSDbAuthorizationProvider
 import io.radicalbit.nsdb.sql.parser.SQLStatementParser

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcNSDbStreaming.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcNSDbStreaming.scala
@@ -22,12 +22,10 @@ import io.radicalbit.nsdb.rpc.requestSQL.SQLRequestStatement
 import io.radicalbit.nsdb.rpc.streaming.NSDbStreamingGrpc.NSDbStreaming
 import io.radicalbit.nsdb.rpc.streaming.SQLStreamingResponse
 
-class ObserverActor(publisherActor: ActorRef) extends Actor {
-  override def receive: Receive =
-}
+//class ObserverActor(publisherActor: ActorRef) extends Actor {
+//  override def receive: Receive =
+//}
 
 class GrpcNSDbStreaming(publisherActor: ActorRef) extends NSDbStreaming {
-  override def streamSQL(request: SQLRequestStatement, responseObserver: StreamObserver[SQLStreamingResponse]): Unit = {
-
-  }
+  override def streamSQL(request: SQLRequestStatement, responseObserver: StreamObserver[SQLStreamingResponse]): Unit = {}
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcNSDbStreaming.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/endpoint/GrpcNSDbStreaming.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster.endpoint
+
+import akka.actor.{Actor, ActorRef}
+import io.grpc.stub.StreamObserver
+import io.radicalbit.nsdb.rpc.requestSQL.SQLRequestStatement
+import io.radicalbit.nsdb.rpc.streaming.NSDbStreamingGrpc.NSDbStreaming
+import io.radicalbit.nsdb.rpc.streaming.SQLStreamingResponse
+
+class ObserverActor(publisherActor: ActorRef) extends Actor {
+  override def receive: Receive =
+}
+
+class GrpcNSDbStreaming(publisherActor: ActorRef) extends NSDbStreaming {
+  override def streamSQL(request: SQLRequestStatement, responseObserver: StreamObserver[SQLStreamingResponse]): Unit = {
+
+  }
+}

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -22,7 +22,7 @@ import akka.actor.{Actor, Props}
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import io.radicalbit.nsdb.actors.PublisherActor
 import io.radicalbit.nsdb.actors.PublisherActor.Commands.SubscribeBySqlStatement
-import io.radicalbit.nsdb.actors.RealTimeProtocol.Events.{RecordsPublished, SubscribedByQueryString}
+import io.radicalbit.nsdb.protocol.RealTimeProtocol.Events.{RecordsPublished, SubscribedByQueryString}
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.GetLocations
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.LocationsGot

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -43,7 +43,7 @@ import scala.concurrent.duration._
 class TestSubscriber extends Actor {
   var receivedMessages = 0
   def receive: Receive = {
-    case RecordsPublished(_, _, _) =>
+    case RecordsPublished(_, _, _, _, _) =>
       receivedMessages += 1
   }
 }

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/configuration/NSDbConfig.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/configuration/NSDbConfig.scala
@@ -52,6 +52,9 @@ object NSDbConfig {
     final val globalTimeout = "nsdb.global.timeout"
 
     final val precision = "nsdb.math.precision"
+
+    final val StreamingRefreshPeriod = "nsdb.streaming.refresh-period"
+    final val StreamingRetentionSize = "nsdb.streaming.retention-size"
   }
 
   object LowLevel {

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActor.scala
@@ -205,7 +205,7 @@ class MetricAccumulatorActor(val basePath: String,
     case ExecuteDeleteStatementInShards(statement, schema, keys) =>
       implicit val timeContext: TimeContext = TimeContext()
       StatementParser.parseStatement(statement, schema) match {
-        case Right(ParsedDeleteQuery(ns, metric, q)) =>
+        case Right(ParsedDeleteQuery(_, ns, metric, q)) =>
           keys.foreach { key =>
             opBufferMap += (UUID.randomUUID().toString -> DeleteShardQueryOperation(ns, key, statement, schema))
           }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
@@ -135,7 +135,7 @@ class MetricPerformerActor(val basePath: String,
           facetsIndexWriter.close()
       }
 
-      val persistedBits = performedBitOperations
+      val persistedBits = performedBitOperations.toSeq
       context.parent ! Refresh(opBufferMap.keys.toSeq, groupedByKey.keys.toSeq)
       (localCommitLogCoordinator ? PersistedBits(persistedBits)).recover {
         case _ => localCommitLogCoordinator ! PersistedBits(persistedBits)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
@@ -27,7 +27,7 @@ import akka.util.Timeout
 import io.radicalbit.nsdb.actors.PublisherActor.Commands._
 import io.radicalbit.nsdb.actors.PublisherActor.Events.Unsubscribed
 import io.radicalbit.nsdb.actors.PublisherActor.{LateTemporalBucketKey, NSDbQuery, TemporalBucket}
-import io.radicalbit.nsdb.actors.RealTimeProtocol.Events.{
+import io.radicalbit.nsdb.protocol.RealTimeProtocol.Events.{
   RecordsPublished,
   SubscribedByQueryString,
   SubscriptionByQueryStringFailed

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
@@ -401,7 +401,7 @@ object PublisherActor {
   /**
     * Defines a sequence of partial results delimited by a time interval.
     */
-  case class TemporalBucket(lowerBound: Long, upperBound: Long, bits: Seq[Bit]) {
+  case class TemporalBucket(lowerBound: Long, upperBound: Long, bits: ListBuffer[Bit]) {
     def contains(timestamp: Long): Boolean = timestamp <= upperBound && timestamp >= lowerBound
   }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/RollingCommitLogFileChecker.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/commit_log/RollingCommitLogFileChecker.scala
@@ -82,7 +82,7 @@ class RollingCommitLogFileChecker(db: String, namespace: String, metric: String)
 
         pendingOutdatedEntries.get(fileName) match {
           case None =>
-            pendingOutdatedEntries += (fileName -> (pendingEntries.to[ListBuffer], closedEntries.to[ListBuffer]))
+            pendingOutdatedEntries += fileName -> ((ListBuffer(pendingEntries: _*), ListBuffer(closedEntries: _*)))
           case Some(_) =>
         }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AbstractStructuredIndex.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/AbstractStructuredIndex.scala
@@ -269,7 +269,7 @@ abstract class AbstractStructuredIndex extends Index[Bit] with TypeSupport {
           }
         }
 
-        buffer
+        buffer.toSeq
 
       case None =>
         Seq.empty
@@ -340,7 +340,7 @@ abstract class AbstractStructuredIndex extends Index[Bit] with TypeSupport {
           }
         }
 
-        buffer
+        buffer.toSeq
 
       case None =>
         Seq.empty

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/TypeSupport.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/index/TypeSupport.scala
@@ -41,7 +41,7 @@ trait TypeSupport {
   def validateSchemaTypeSupport(bit: Bit): Try[Map[String, TypedField]] = {
     val x = bit.fields
       .map { case (n, (v, t)) => n -> IndexType.fromRawField(RawField(n, t, v)) }
-    Try(x.mapValues(f => f.get).map(identity))
+    Try(x.mapValues(f => f.get).toMap)
   }
 }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/model/Schema.scala
@@ -100,11 +100,9 @@ object Schema extends TypeSupport {
     */
   def apply(metric: String, bit: Bit): Schema =
     validateSchemaTypeSupport(bit)
-      .map(
-        fieldsMap =>
-          new Schema(
-            metric,
-            fieldsMap.mapValues(field => SchemaField(field.name, field.fieldClassType, field.indexType)).map(identity)))
+      .map(fieldsMap =>
+        new Schema(metric,
+                   fieldsMap.mapValues(field => SchemaField(field.name, field.fieldClassType, field.indexType)).toMap))
       .get
 
   /**

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/RealTimeProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/RealTimeProtocol.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.radicalbit.nsdb.actors
+package io.radicalbit.nsdb.protocol
 
 import akka.dispatch.ControlMessage
 import io.radicalbit.nsdb.common.protocol.{Bit, NSDbSerializable}

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/RealTimeProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/RealTimeProtocol.scala
@@ -40,7 +40,8 @@ object RealTimeProtocol {
         extends ControlMessage
         with RealTimeOutGoingMessage
 
-    case class RecordsPublished(quid: String, metric: String, records: Seq[Bit]) extends RealTimeOutGoingMessage
+    case class RecordsPublished(quid: String, db: String, namespace: String, metric: String, records: Seq[Bit])
+        extends RealTimeOutGoingMessage
 
     case class ErrorResponse(error: String) extends RealTimeOutGoingMessage
   }

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -519,7 +519,7 @@ class PublisherActorSpec
       }
 
       val recordPublished = probe.expectMsgType[RecordsPublished]
-      recordPublished.metric shouldBe "people"
+      recordPublished.metric shouldBe "metric"
       recordPublished.records shouldBe Seq(
         Bit(eventStartTime + 10,
             10L,
@@ -590,7 +590,7 @@ class PublisherActorSpec
       }
 
       val recordPublished = probe.expectMsgType[RecordsPublished]
-      recordPublished.metric shouldBe "people"
+      recordPublished.metric shouldBe "metric"
       recordPublished.records shouldBe Seq(
         Bit(eventStartTime + 10,
             10L,
@@ -618,7 +618,7 @@ class PublisherActorSpec
         Seq(Bit(eventStartTime, 25L, Map.empty, Map("name" -> "john"))))
 
       val lateRecordPublished = probe.expectMsgType[RecordsPublished]
-      lateRecordPublished.metric shouldBe "people"
+      lateRecordPublished.metric shouldBe "metric"
       lateRecordPublished.records shouldBe Seq(
         Bit(eventStartTime + 10,
             11L,
@@ -641,7 +641,7 @@ class PublisherActorSpec
       }
 
       val multipleLateRecordPublished = probe.expectMsgType[RecordsPublished]
-      multipleLateRecordPublished.metric shouldBe "people"
+      multipleLateRecordPublished.metric shouldBe "metric"
       multipleLateRecordPublished.records shouldBe Seq(
         Bit(eventStartTime + 10,
             21L,

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/PublisherActorSpec.scala
@@ -20,7 +20,7 @@ import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import io.radicalbit.nsdb.actors.PublisherActor.Commands.{SubscribeBySqlStatement, Unsubscribe}
 import io.radicalbit.nsdb.actors.PublisherActor.Events.Unsubscribed
-import io.radicalbit.nsdb.actors.RealTimeProtocol.Events.{RecordsPublished, SubscribedByQueryString}
+import io.radicalbit.nsdb.protocol.RealTimeProtocol.Events.{RecordsPublished, SubscribedByQueryString}
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.model.{Schema, TimeContext}

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserAggregationsSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserAggregationsSpec.scala
@@ -58,6 +58,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedGlobalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -85,6 +86,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedGlobalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -109,6 +111,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedGlobalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -133,6 +136,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedGlobalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -157,6 +161,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedGlobalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -188,6 +193,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedGlobalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -236,6 +242,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedGlobalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -260,6 +267,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedGlobalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -284,6 +292,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedGlobalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -308,6 +317,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedGlobalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -339,6 +349,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedAggregatedQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
@@ -365,6 +376,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedAggregatedQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
@@ -391,6 +403,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedAggregatedQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
@@ -417,6 +430,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedAggregatedQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
@@ -443,6 +457,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedAggregatedQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
@@ -469,6 +484,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedAggregatedQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
@@ -495,6 +511,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedAggregatedQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
@@ -526,6 +543,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedAggregatedQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2L, 4L),
@@ -554,6 +572,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedAggregatedQuery(
+              "db",
               "registry",
               "people",
               new BooleanQuery.Builder()
@@ -624,6 +643,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedTemporalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -650,6 +670,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedTemporalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -676,6 +697,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedTemporalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -702,6 +724,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedTemporalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -728,6 +751,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) shouldBe
           Right(
             ParsedTemporalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -750,6 +774,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
           schema
         ) shouldBe Right(
           ParsedTemporalAggregatedQuery(
+            "db",
             "registry",
             "people",
             new MatchAllDocsQuery(),
@@ -808,6 +833,7 @@ class StatementParserAggregationsSpec extends NSDbSpec {
         ) shouldBe
           Right(
             ParsedTemporalAggregatedQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserRelativeTimeSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserRelativeTimeSpec.scala
@@ -62,6 +62,7 @@ class StatementParserRelativeTimeSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, timeContext.currentTime + Duration("4 min").toMillis),
@@ -90,6 +91,7 @@ class StatementParserRelativeTimeSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp",
@@ -123,6 +125,7 @@ class StatementParserRelativeTimeSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", timeContext.currentTime - Duration("10 s").toMillis, Long.MaxValue),
@@ -158,6 +161,7 @@ class StatementParserRelativeTimeSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new BooleanQuery.Builder()

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/statement/StatementParserSpec.scala
@@ -53,6 +53,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -106,6 +107,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -132,6 +134,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -177,6 +180,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2, 4),
@@ -205,6 +209,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newExactQuery("timestamp", 10L),
@@ -230,6 +235,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new TermQuery(new Term("name", "TestString")),
@@ -254,6 +260,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               DoublePoint.newExactQuery("amount", 0),
@@ -293,6 +300,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new TermQuery(new Term("name", "0")),
@@ -324,6 +332,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 10L, Long.MaxValue),
@@ -352,6 +361,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               DoublePoint.newRangeQuery("amount", 10.0, Double.MaxValue),
@@ -402,6 +412,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new BooleanQuery.Builder()
@@ -444,6 +455,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new BooleanQuery.Builder()
@@ -491,6 +503,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new BooleanQuery.Builder()
@@ -538,6 +551,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new BooleanQuery.Builder()
@@ -573,6 +587,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -599,6 +614,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new MatchAllDocsQuery(),
@@ -632,6 +648,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               LongPoint.newRangeQuery("timestamp", 2L, 4L),
@@ -653,7 +670,7 @@ class StatementParserSpec extends NSDbSpec {
                                                           fields = AllFields()),
                                        schema) should be(
           Right(
-            ParsedSimpleQuery("registry", "people", new MatchAllDocsQuery(), false, Int.MaxValue)
+            ParsedSimpleQuery("db", "registry", "people", new MatchAllDocsQuery(), false, Int.MaxValue)
           )
         )
       }
@@ -675,6 +692,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new BooleanQuery.Builder()
@@ -710,6 +728,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new BooleanQuery.Builder()
@@ -739,6 +758,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new BooleanQuery.Builder()
@@ -775,6 +795,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new BooleanQuery.Builder()
@@ -804,6 +825,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new BooleanQuery.Builder()
@@ -840,6 +862,7 @@ class StatementParserSpec extends NSDbSpec {
         ) should be(
           Right(
             ParsedSimpleQuery(
+              "db",
               "registry",
               "people",
               new BooleanQuery.Builder()

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJson.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJson.scala
@@ -17,8 +17,8 @@
 package io.radicalbit.nsdb.web
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import io.radicalbit.nsdb.actors.RealTimeProtocol.Events._
-import io.radicalbit.nsdb.actors.RealTimeProtocol.RealTimeOutGoingMessage
+import io.radicalbit.nsdb.protocol.RealTimeProtocol.Events._
+import io.radicalbit.nsdb.protocol.RealTimeProtocol.RealTimeOutGoingMessage
 import io.radicalbit.nsdb.common._
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.web.Filters._

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJson.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/NSDbJson.scala
@@ -126,7 +126,7 @@ object NSDbJson extends DefaultJsonProtocol with SprayJsonSupport {
       SubscribedByQueryString.apply)
     implicit val SubscriptionByQueryStringFailedFormat: RootJsonFormat[SubscriptionByQueryStringFailed] = jsonFormat5(
       SubscriptionByQueryStringFailed.apply)
-    implicit val recordsPublishedFormat: RootJsonFormat[RecordsPublished] = jsonFormat3(RecordsPublished.apply)
+    implicit val recordsPublishedFormat: RootJsonFormat[RecordsPublished] = jsonFormat5(RecordsPublished.apply)
     implicit val errorResponseFormat: RootJsonFormat[ErrorResponse]       = jsonFormat1(ErrorResponse.apply)
 
     def write(a: RealTimeOutGoingMessage): JsValue = a match {

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
@@ -100,7 +100,6 @@ trait WsResources {
                                                   s"unauthorized ${authorizationResult.getFailReason}")
               case None => s"Message $text not handled by receiver"
             }
-//            text.parseJson.convertOpt[RegisterQuery] getOrElse
           case _ => "Message not handled by receiver"
         }
         .to(Sink.actorRef(connectedWsActor, Terminate, _.getMessage))

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
@@ -26,6 +26,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.{Flow, Sink, Source}
+import io.radicalbit.nsdb.common.configuration.NSDbConfig
 import io.radicalbit.nsdb.protocol.RealTimeProtocol.Events.SubscriptionByQueryStringFailed
 import io.radicalbit.nsdb.security.NSDbAuthorizationProvider
 import io.radicalbit.nsdb.web.NSDbJson._
@@ -42,12 +43,12 @@ trait WsResources {
   def logger: LoggingAdapter
 
   /** Publish refresh period default value , also considered as the min value */
-  private val refreshPeriod = system.settings.config.getInt("nsdb.websocket.refresh-period")
+  private val refreshPeriod = system.settings.config.getInt(NSDbConfig.HighLevel.StreamingRefreshPeriod)
 
   /** Number of messages that can be retained before being published,
     * if the buffered messages exceed this threshold, they will be discarded
     **/
-  private val retentionSize = system.settings.config.getInt("nsdb.websocket.retention-size")
+  private val retentionSize = system.settings.config.getInt(NSDbConfig.HighLevel.StreamingRetentionSize)
 
   /**
     * Akka stream Flow used to define the webSocket behaviour.

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/WsResources.scala
@@ -21,11 +21,12 @@ import akka.actor.{ActorRef, ActorSystem}
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.RemoteAddress
 import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.model.ws.{Message, TextMessage, UpgradeToWebSocket}
+import akka.http.scaladsl.model.ws.{Message, TextMessage, WebSocketUpgrade}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.{Flow, Sink, Source}
+import io.radicalbit.nsdb.protocol.RealTimeProtocol.Events.SubscriptionByQueryStringFailed
 import io.radicalbit.nsdb.security.NSDbAuthorizationProvider
 import io.radicalbit.nsdb.web.NSDbJson._
 import io.radicalbit.nsdb.web.actor.StreamActor
@@ -71,7 +72,7 @@ trait WsResources {
       */
     val connectedWsActor = system.actorOf(
       StreamActor
-        .props(clientAddress, publisherActor, refreshPeriod, wsSubProtocols, authProvider)
+        .props(clientAddress, publisherActor, refreshPeriod)
         .withDispatcher("akka.actor.control-aware-dispatcher"))
 
     /**
@@ -81,10 +82,28 @@ trait WsResources {
       Flow[Message]
         .map {
           case TextMessage.Strict(text) =>
-            text.parseJson.convertOpt[RegisterQuery] getOrElse s"Message $text not handled by receiver"
+            text.parseJson.convertOpt[RegisterQuery] match {
+              case Some(registerQuery: RegisterQuery) =>
+                val securityPayload = authProvider.extractWsSecurityPayload(wsSubProtocols.asJava)
+                val authorizationResult = authProvider.checkMetricAuth(registerQuery.db,
+                                                                       registerQuery.namespace,
+                                                                       registerQuery.metric,
+                                                                       securityPayload,
+                                                                       false)
+                if (authorizationResult.isSuccess)
+                  registerQuery
+                else
+                  SubscriptionByQueryStringFailed(registerQuery.db,
+                                                  registerQuery.namespace,
+                                                  registerQuery.metric,
+                                                  registerQuery.queryString,
+                                                  s"unauthorized ${authorizationResult.getFailReason}")
+              case None => s"Message $text not handled by receiver"
+            }
+//            text.parseJson.convertOpt[RegisterQuery] getOrElse
           case _ => "Message not handled by receiver"
         }
-        .to(Sink.actorRef(connectedWsActor, Terminate))
+        .to(Sink.actorRef(connectedWsActor, Terminate, _.getMessage))
 
     /**
       * Messages from the backend to the Ws.
@@ -120,7 +139,7 @@ trait WsResources {
       extractClientIP { remoteAddress: RemoteAddress =>
         parameter('refresh_period ? refreshPeriod, 'retention_size ? retentionSize) {
           case (period, retention) if period >= refreshPeriod =>
-            extractUpgradeToWebSocket { u: UpgradeToWebSocket =>
+            extractWebSocketUpgrade { u: WebSocketUpgrade =>
               val subProtocols = u.getRequestedProtocols().iterator().asScala.toSeq
               logger.debug("found sub protocols in ws request {}", subProtocols)
 

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/actor/StreamActor.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/actor/StreamActor.scala
@@ -43,10 +43,7 @@ import scala.collection.mutable
   * @param publisher             global Publisher Actor.
   * @param publishInterval       publish to web socket interval.
   */
-class StreamActor(clientAddress: String,
-                  publisher: ActorRef,
-                  publishInterval: Int)
-    extends ActorPathLogging {
+class StreamActor(clientAddress: String, publisher: ActorRef, publishInterval: Int) extends ActorPathLogging {
 
   implicit val timeout: Timeout =
     Timeout(context.system.settings.config.getDuration("nsdb.stream.timeout", TimeUnit.SECONDS), TimeUnit.SECONDS)
@@ -104,7 +101,7 @@ class StreamActor(clientAddress: String,
     case msg: SubscribedByQueryString =>
       wsActor ! OutgoingMessage(msg)
     case msg: SubscriptionByQueryStringFailed => wsActor ! OutgoingMessage(msg)
-    case msg @ RecordsPublished(_, _, _) =>
+    case msg @ RecordsPublished(_, _, _, _, _) =>
       buffer += msg
     case Terminate =>
       log.info("closing web socket connection from address {}", clientAddress)
@@ -132,8 +129,6 @@ object StreamActor {
                            filters: Option[Seq[Filter]] = None)
       extends NSDbSerializable
 
-  def props(clientAddress: String,
-            publisherActor: ActorRef,
-            refreshPeriod: Int) =
+  def props(clientAddress: String, publisherActor: ActorRef, refreshPeriod: Int) =
     Props(new StreamActor(clientAddress: String, publisherActor, refreshPeriod))
 }

--- a/nsdb-http/src/test/resources/application.conf
+++ b/nsdb-http/src/test/resources/application.conf
@@ -29,10 +29,10 @@ nsdb{
   publisher.timeout = 10 seconds
   publisher.scheduler.interval = 5 seconds
 
-  websocket {
-    // Websocket publish period expressed in milliseconds
+  streaming {
+    // Streaming publish period expressed in milliseconds
     refresh-period = 100
-    //Websocket retention size
+    // Streaming retention size
     retention-size = 100
   }
 }

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeApiSpec.scala
@@ -20,7 +20,7 @@ import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.testkit.{ScalatestRouteTest, WSProbe}
-import io.radicalbit.nsdb.actors.RealTimeProtocol.Events.{SubscribedByQueryString, SubscriptionByQueryStringFailed}
+import io.radicalbit.nsdb.protocol.RealTimeProtocol.Events.{SubscribedByQueryString, SubscriptionByQueryStringFailed}
 import io.radicalbit.nsdb.actors.{EmptyReadCoordinator, PublisherActor}
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Schema

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeFiltersSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/RealTimeFiltersSpec.scala
@@ -21,7 +21,7 @@ import akka.event.LoggingAdapter
 import akka.http.scaladsl.testkit.{ScalatestRouteTest, WSProbe}
 import io.radicalbit.nsdb.actor.FakeReadCoordinator
 import io.radicalbit.nsdb.actors.PublisherActor
-import io.radicalbit.nsdb.actors.RealTimeProtocol.Events.{
+import io.radicalbit.nsdb.protocol.RealTimeProtocol.Events.{
   RecordsPublished,
   SubscribedByQueryString,
   SubscriptionByQueryStringFailed

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/PublishSubscribeGrpcClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/PublishSubscribeGrpcClusterSpec.scala
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.cluster
+
+import akka.util.Timeout
+import io.radicalbit.nsdb.api.scala.NSDB
+import io.radicalbit.nsdb.api.scala.streaming.NSDbStreaming._
+import io.radicalbit.nsdb.common.protocol.Bit
+import io.radicalbit.nsdb.minicluster.converters.BitConverters.BitConverter
+import io.radicalbit.nsdb.rpc.streaming.SQLStreamingResponse
+import io.radicalbit.nsdb.test.MiniClusterSpec
+
+import java.util.concurrent.TimeUnit
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+class PublishSubscribeGrpcClusterSpec extends MiniClusterSpec {
+
+  implicit val timeout: Timeout = Timeout(5, TimeUnit.SECONDS)
+
+  lazy val bit: Bit = Bit(timestamp = System.currentTimeMillis(),
+                          dimensions = Map("city" -> "Mouseton", "gender" -> "F"),
+                          value = 2,
+                          tags = Map.empty)
+
+  test("subscribe to a query and receive real time updates") {
+    val nsdbFirstNodeConnection =
+      eventually {
+        Await.result(NSDB.connect(host = firstNode.hostname, port = 7817), 10.seconds)
+      }
+    val nsdbLastNodeConnection =
+      eventually {
+        Await.result(NSDB.connect(host = lastNode.hostname, port = 7817), 10.seconds)
+      }
+
+    eventually {
+      assert(
+        Await
+          .result(nsdbFirstNodeConnection.write(bit.asApiBit("db", "namespace", "metric1")), 10.seconds)
+          .completedSuccessfully)
+    }
+    eventually {
+      assert(
+        Await
+          .result(nsdbFirstNodeConnection.write(bit.asApiBit("db", "namespace", "metric2")), 10.seconds)
+          .completedSuccessfully)
+    }
+
+    waitIndexing()
+
+    val firstNodeSubscriptionBuffer = ListBuffer.empty[SQLStreamingResponse]
+    nsdbFirstNodeConnection.subscribe(
+      nsdbFirstNodeConnection.db("db").namespace("namespace").metric("metric1").query("select * from metric1 limit 1")) {
+      firstNodeSubscriptionBuffer += _
+    }
+
+    val lastNodeSubscriptionBuffer = ListBuffer.empty[SQLStreamingResponse]
+    nsdbLastNodeConnection.subscribe(
+      nsdbLastNodeConnection.db("db").namespace("namespace").metric("metric2").query("select * from metric2 limit 1")) {
+      lastNodeSubscriptionBuffer += _
+    }
+
+    //subscription phase
+    eventually{
+      firstNodeSubscriptionBuffer.size == 1
+      firstNodeSubscriptionBuffer.head.db == "db"
+      firstNodeSubscriptionBuffer.head.namespace == "namespace"
+      firstNodeSubscriptionBuffer.head.metric == "metric1"
+      firstNodeSubscriptionBuffer.head.payload.isSubscribedByQueryString
+      firstNodeSubscriptionBuffer.head.payload.subscribedByQueryString.get.records.size == 1
+      firstNodeSubscriptionBuffer.head.payload.subscribedByQueryString.get.quid
+    }
+
+    eventually{
+      lastNodeSubscriptionBuffer.size == 1
+      lastNodeSubscriptionBuffer.head.db == "db"
+      lastNodeSubscriptionBuffer.head.namespace == "namespace"
+      lastNodeSubscriptionBuffer.head.metric == "metric2"
+      lastNodeSubscriptionBuffer.head.payload.isSubscribedByQueryString
+      lastNodeSubscriptionBuffer.head.payload.subscribedByQueryString.get.records.size == 1
+      lastNodeSubscriptionBuffer.head.payload.subscribedByQueryString.get.quid
+    }
+
+
+    //streaming phase
+    firstNodeSubscriptionBuffer.clear()
+    lastNodeSubscriptionBuffer.clear()
+
+    eventually {
+      assert(
+        Await
+          .result(nsdbFirstNodeConnection.write(bit.asApiBit("db", "namespace", "metric1")), 10.seconds)
+          .completedSuccessfully)
+    }
+
+    eventually {
+      assert(
+        Await
+          .result(nsdbLastNodeConnection.write(bit.asApiBit("db", "namespace", "metric2")), 10.seconds)
+          .completedSuccessfully)
+    }
+
+    eventually{
+      firstNodeSubscriptionBuffer.size == 1
+      firstNodeSubscriptionBuffer.head.db == "db"
+      firstNodeSubscriptionBuffer.head.namespace == "namespace"
+      firstNodeSubscriptionBuffer.head.metric == "metric1"
+      firstNodeSubscriptionBuffer.head.payload.isRecordsPublished
+      firstNodeSubscriptionBuffer.head.payload.recordsPublished.get.records.size == 1
+    }
+
+    eventually{
+      lastNodeSubscriptionBuffer.size == 1
+      lastNodeSubscriptionBuffer.head.db == "db"
+      lastNodeSubscriptionBuffer.head.namespace == "namespace"
+      lastNodeSubscriptionBuffer.head.metric == "metric2"
+      lastNodeSubscriptionBuffer.head.payload.isRecordsPublished
+      lastNodeSubscriptionBuffer.head.payload.recordsPublished.get.records.size == 1
+    }
+
+  }
+
+
+  test("support cross-node subscription and publishing") {
+
+    val nsdbFirstNodeConnection =
+      eventually {
+        Await.result(NSDB.connect(host = firstNode.hostname, port = 7817), 10.seconds)
+      }
+    val nsdbLastNodeConnection =
+      eventually {
+        Await.result(NSDB.connect(host = lastNode.hostname, port = 7817), 10.seconds)
+      }
+
+    val firstNodeSubscriptionBuffer = ListBuffer.empty[SQLStreamingResponse]
+    nsdbFirstNodeConnection.subscribe(
+      nsdbFirstNodeConnection.db("db").namespace("namespace").metric("metric1").query("select * from metric1 limit 1")) {
+      firstNodeSubscriptionBuffer += _
+    }
+
+    val lastNodeSubscriptionBuffer = ListBuffer.empty[SQLStreamingResponse]
+    nsdbLastNodeConnection.subscribe(
+      nsdbLastNodeConnection.db("db").namespace("namespace").metric("metric2").query("select * from metric2 limit 1")) {
+      lastNodeSubscriptionBuffer += _
+    }
+
+    //subscription phase
+    eventually{
+      firstNodeSubscriptionBuffer.size == 1
+      firstNodeSubscriptionBuffer.head.db == "db"
+      firstNodeSubscriptionBuffer.head.namespace == "namespace"
+      firstNodeSubscriptionBuffer.head.metric == "metric1"
+      firstNodeSubscriptionBuffer.head.payload.isSubscribedByQueryString
+      firstNodeSubscriptionBuffer.head.payload.subscribedByQueryString.get.records.size == 1
+      firstNodeSubscriptionBuffer.head.payload.subscribedByQueryString.get.quid
+    }
+
+    eventually{
+      lastNodeSubscriptionBuffer.size == 1
+      lastNodeSubscriptionBuffer.head.db == "db"
+      lastNodeSubscriptionBuffer.head.namespace == "namespace"
+      lastNodeSubscriptionBuffer.head.metric == "metric2"
+      lastNodeSubscriptionBuffer.head.payload.isSubscribedByQueryString
+      lastNodeSubscriptionBuffer.head.payload.subscribedByQueryString.get.records.size == 1
+      lastNodeSubscriptionBuffer.head.payload.subscribedByQueryString.get.quid
+    }
+
+    //streaming phase: write request comes from different node than the subscribed ones
+    firstNodeSubscriptionBuffer.clear()
+    lastNodeSubscriptionBuffer.clear()
+
+    eventually {
+      assert(
+        Await
+          .result(nsdbLastNodeConnection.write(bit.asApiBit("db", "namespace", "metric1")), 10.seconds)
+          .completedSuccessfully)
+    }
+    eventually {
+      assert(
+        Await
+          .result(nsdbFirstNodeConnection.write(bit.asApiBit("db", "namespace", "metric2")), 10.seconds)
+          .completedSuccessfully)
+    }
+
+    eventually{
+      firstNodeSubscriptionBuffer.size == 1
+      firstNodeSubscriptionBuffer.head.db == "db"
+      firstNodeSubscriptionBuffer.head.namespace == "namespace"
+      firstNodeSubscriptionBuffer.head.metric == "metric1"
+      firstNodeSubscriptionBuffer.head.payload.isRecordsPublished
+      firstNodeSubscriptionBuffer.head.payload.recordsPublished.get.records.size == 1
+    }
+
+    eventually{
+      lastNodeSubscriptionBuffer.size == 1
+      lastNodeSubscriptionBuffer.head.db == "db"
+      lastNodeSubscriptionBuffer.head.namespace == "namespace"
+      lastNodeSubscriptionBuffer.head.metric == "metric2"
+      lastNodeSubscriptionBuffer.head.payload.isRecordsPublished
+      lastNodeSubscriptionBuffer.head.payload.recordsPublished.get.records.size == 1
+    }
+  }
+
+}

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/PublishSubscribeWsClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/cluster/PublishSubscribeWsClusterSpec.scala
@@ -46,7 +46,7 @@ import org.json4s.jackson.JsonMethods._
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}
 
-class PublishSubscribeClusterSpec extends MiniClusterSpec {
+class PublishSubscribeWsClusterSpec extends MiniClusterSpec {
 
   implicit val timeout: Timeout = Timeout(5, TimeUnit.SECONDS)
 

--- a/nsdb-it/src/it/scala/io/radicalbit/nsdb/test/MiniClusterSpec.scala
+++ b/nsdb-it/src/it/scala/io/radicalbit/nsdb/test/MiniClusterSpec.scala
@@ -52,6 +52,7 @@ trait MiniClusterSpec extends AnyFunSuite with BeforeAndAfterAll with Eventually
   }
 
   lazy val firstNode: NSDbMiniClusterNode = nodes.head
+  lazy val lastNode: NSDbMiniClusterNode = nodes.last
 
   protected lazy val indexingTime: Long =
     nodes.head.system.settings.config.getDuration("nsdb.write.scheduler.interval").toMillis

--- a/nsdb-minicluster/src/main/resources/nsdb-minicluster.conf
+++ b/nsdb-minicluster/src/main/resources/nsdb-minicluster.conf
@@ -129,10 +129,10 @@ nsdb {
   stream.timeout = 30 seconds
   stream.timeout = ${?STREAM_TIMEOUT}
 
-  websocket {
-    // Websocket publish period expressed in milliseconds
+  streaming {
+    // Streaming publish period expressed in milliseconds
     refresh-period = 100
-    //Websocket retention size
+    // Streaming retention size
     retention-size = 10
   }
 

--- a/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/converters/BitConverters.scala
+++ b/nsdb-minicluster/src/main/scala/io/radicalbit/nsdb/minicluster/converters/BitConverters.scala
@@ -16,7 +16,7 @@
 
 package io.radicalbit.nsdb.minicluster.converters
 
-import io.radicalbit.nsdb.api.scala.{Db, Bit => ApiBit}
+import io.radicalbit.nsdb.api.scala.{Namespace, Bit => ApiBit}
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.common._
 import io.radicalbit.nsdb.rpc.common.{Dimension, Tag}
@@ -30,7 +30,7 @@ object BitConverters {
   implicit class BitConverter(bit: Bit) {
 
     def asApiBit(db: String, namespace: String, metric: String): ApiBit = {
-      val initialBit = Db(db).namespace(namespace).metric(metric).timestamp(bit.timestamp)
+      val initialBit = Namespace(db, namespace).metric(metric).timestamp(bit.timestamp)
       val apiBit = bit.value match {
         case NSDbLongType(v)   => initialBit.value(v)
         case NSDbDoubleType(v) => initialBit.value(v)

--- a/nsdb-rpc/src/main/protobuf/streaming.proto
+++ b/nsdb-rpc/src/main/protobuf/streaming.proto
@@ -19,18 +19,38 @@ syntax = "proto3";
 package io.radicalbit.nsdb.rpc;
 import "requestSQL.proto";
 import "common.proto";
+import "security.proto";
+
+message SubscribedByQueryString {
+  string quid = 1;
+  repeated Bit records = 2;
+}
+
+message SubscriptionByQueryStringFailed {
+  string queryString = 1;
+  string reason = 2;
+  string message = 3;
+}
+
+message RecordsPublished {
+  string quid = 1;
+  repeated Bit records = 2;
+}
+
 
 message SQLStreamingResponse{
   string db = 1;
   string namespace = 2;
   string metric = 3;
-  bool completedSuccessfully = 4;
-  string reason = 5;
-  string message = 6;
-  Bit records = 7;
+  oneof payload {
+    SubscribedByQueryString subscribedByQueryString = 4;
+    SubscriptionByQueryStringFailed subscriptionByQueryStringFailed = 5;
+    RecordsPublished recordsPublished = 6;
+  }
 }
 
 
 service NSDbStreaming {
+  option (isAuthorized) = true;
   rpc streamSQL(io.radicalbit.nsdb.rpc.SQLRequestStatement) returns (stream io.radicalbit.nsdb.rpc.SQLStreamingResponse) {}
 }

--- a/nsdb-rpc/src/main/protobuf/streaming.proto
+++ b/nsdb-rpc/src/main/protobuf/streaming.proto
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package io.radicalbit.nsdb.rpc;
+import "requestSQL.proto";
+import "common.proto";
+
+message SQLStreamingResponse{
+  string db = 1;
+  string namespace = 2;
+  string metric = 3;
+  bool completedSuccessfully = 4;
+  string reason = 5;
+  string message = 6;
+  Bit records = 7;
+}
+
+
+service NSDbStreaming {
+  rpc streamSQL(io.radicalbit.nsdb.rpc.SQLRequestStatement) returns (stream io.radicalbit.nsdb.rpc.SQLStreamingResponse) {}
+}

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/GRPCServer.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/GRPCServer.scala
@@ -29,6 +29,8 @@ import io.radicalbit.nsdb.rpc.restore.RestoreGrpc.Restore
 import io.radicalbit.nsdb.rpc.service.NSDBServiceCommandGrpc.NSDBServiceCommand
 import io.radicalbit.nsdb.rpc.service.NSDBServiceSQLGrpc.NSDBServiceSQL
 import io.radicalbit.nsdb.rpc.service.{NSDBServiceCommandGrpc, NSDBServiceSQLGrpc}
+import io.radicalbit.nsdb.rpc.streaming.NSDbStreamingGrpc
+import io.radicalbit.nsdb.rpc.streaming.NSDbStreamingGrpc.NSDbStreaming
 import io.radicalbit.nsdb.security.NSDbAuthorizationProvider
 import io.radicalbit.nsdb.sql.parser.SQLStatementParser
 
@@ -57,6 +59,8 @@ trait GRPCServer {
 
   protected[this] def restore: Restore
 
+  protected[this] def streamingService: NSDbStreaming
+
   protected[this] def parserSQL: SQLStatementParser
 
   protected[this] def authorizationProvider: NSDbAuthorizationProvider
@@ -83,6 +87,7 @@ trait GRPCServer {
                                              interceptors: _*))
     .addService(ServerInterceptors.intercept(RestoreGrpc.bindService(restore, executionContextExecutor),
                                              interceptors: _*))
+    .addService(NSDbStreamingGrpc.bindService(streamingService, executionContextExecutor))
     .addService(HealthGrpc.bindService(health, executionContextExecutor))
     .addService(ProtoReflectionService.newInstance())
     .build

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/actor/StreamActor.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/actor/StreamActor.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.rpc.server.actor
+
+import akka.actor.{ActorRef, PoisonPill, Props}
+import akka.pattern.ask
+import akka.util.Timeout
+import io.grpc.stub.StreamObserver
+import io.radicalbit.nsdb.actors.PublisherActor.Commands._
+import io.radicalbit.nsdb.client.rpc.converter.GrpcBitConverters.BitConverter
+import io.radicalbit.nsdb.common.protocol.NSDbSerializable
+import io.radicalbit.nsdb.common.statement.SelectSQLStatement
+import io.radicalbit.nsdb.monitoring.NSDbMonitoring
+import io.radicalbit.nsdb.protocol.RealTimeProtocol.Events.{
+  RecordsPublished,
+  SubscribedByQueryString,
+  SubscriptionByQueryStringFailed
+}
+import io.radicalbit.nsdb.rpc.server.actor.StreamActor.{RegisterQuery, Terminate}
+import io.radicalbit.nsdb.rpc.streaming.SQLStreamingResponse.Payload
+import io.radicalbit.nsdb.rpc.streaming.{
+  SQLStreamingResponse,
+  RecordsPublished => RecordsPublishedGrpc,
+  SubscribedByQueryString => SubscribedByQueryStringGrpc,
+  SubscriptionByQueryStringFailed => SubscriptionByQueryStringFailedGrpc
+}
+import io.radicalbit.nsdb.sql.parser.SQLStatementParser
+import io.radicalbit.nsdb.sql.parser.StatementParserResult._
+import io.radicalbit.nsdb.util.ActorPathLogging
+import kamon.Kamon
+
+import java.util.concurrent.TimeUnit
+import scala.collection.mutable
+import scala.concurrent.duration._
+
+/**
+  * Bridge actor between [[io.radicalbit.nsdb.actors.PublisherActor]] and the Grpc Stream endpoint.
+  *
+  * @param clientAddress         the client address that established the connection (for logging and monitoring purposes).
+  * @param publisher             global Publisher Actor.
+  * @param publishInterval       publish to web socket interval.
+  */
+class StreamActor(clientAddress: String,
+                  publisher: ActorRef,
+                  publishInterval: Int,
+                  observer: StreamObserver[SQLStreamingResponse])
+    extends ActorPathLogging {
+
+  implicit val timeout: Timeout =
+    Timeout(context.system.settings.config.getDuration("nsdb.stream.timeout", TimeUnit.SECONDS), TimeUnit.SECONDS)
+  import context.dispatcher
+
+  private val buffer: mutable.Queue[SQLStreamingResponse] = mutable.Queue.empty
+
+  lazy val kamonMetric = Kamon.gauge(NSDbMonitoring.NSDbWsConnectionsTotal).withoutTags()
+
+  override def preStart(): Unit = {
+    kamonMetric.increment()
+
+    context.system.scheduler.schedule(0.seconds, publishInterval.millis) {
+      while (buffer.nonEmpty) observer.onNext(buffer.dequeue())
+    }
+  }
+
+  override def postStop(): Unit = {
+    kamonMetric.decrement()
+  }
+
+  def receive: Receive = {
+    case RegisterQuery(db, namespace, metric, inputQueryString) =>
+      new SQLStatementParser().parse(db, namespace, inputQueryString) match {
+        case SqlStatementParserSuccess(queryString, statement: SelectSQLStatement) =>
+          publisher ! SubscribeBySqlStatement(self, db, namespace, metric, queryString, statement)
+        case SqlStatementParserSuccess(_, _) =>
+          observer.onNext(
+            SQLStreamingResponse(db,
+                                 namespace,
+                                 metric,
+                                 Payload.SubscriptionByQueryStringFailed(
+                                   SubscriptionByQueryStringFailedGrpc(inputQueryString, "not a select statement"))))
+        case SqlStatementParserFailure(_, error) =>
+          observer.onNext(
+            SQLStreamingResponse(
+              db,
+              namespace,
+              metric,
+              Payload.SubscriptionByQueryStringFailed(SubscriptionByQueryStringFailedGrpc(inputQueryString, error))))
+      }
+    case SubscribedByQueryString(db, namespace, metric, _, quid, records) =>
+      observer.onNext(
+        SQLStreamingResponse(
+          db,
+          namespace,
+          metric,
+          Payload.SubscribedByQueryString(SubscribedByQueryStringGrpc(quid, records.map(_.asGrpcBit)))))
+    case SubscriptionByQueryStringFailed(db, namespace, metric, queryString, reason) =>
+      observer.onNext(
+        SQLStreamingResponse(
+          db,
+          namespace,
+          metric,
+          Payload.SubscriptionByQueryStringFailed(SubscriptionByQueryStringFailedGrpc(queryString, reason))))
+    case RecordsPublished(quid, db, namespace, metric, records) =>
+      buffer += SQLStreamingResponse(db,
+                                     namespace,
+                                     metric,
+                                     Payload.RecordsPublished(RecordsPublishedGrpc(quid, records.map(_.asGrpcBit))))
+    case Terminate =>
+      log.info("closing web socket connection from address {}", clientAddress)
+      (publisher ? Unsubscribe(self)).foreach { _ =>
+        self ! PoisonPill
+        observer.onCompleted()
+      }
+    case msg @ _ =>
+      log.error(s"Unexpected message in ws : $msg")
+  }
+}
+
+object StreamActor {
+  case class Connect(outgoing: ActorRef) extends NSDbSerializable
+
+  case object Terminate
+  case class RegisterQuery(db: String, namespace: String, metric: String, queryString: String) extends NSDbSerializable
+
+  def props(clientAddress: String,
+            publisherActor: ActorRef,
+            refreshPeriod: Int,
+            observer: StreamObserver[SQLStreamingResponse]) =
+    Props(new StreamActor(clientAddress: String, publisherActor, refreshPeriod, observer))
+}

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/actor/StreamActor.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/actor/StreamActor.scala
@@ -69,7 +69,7 @@ class StreamActor(clientAddress: String,
   lazy val kamonMetric = Kamon.gauge(NSDbMonitoring.NSDbWsConnectionsTotal).withoutTags()
 
   override def preStart(): Unit = {
-    kamonMetric.increment()
+//    kamonMetric.increment()
 
     context.system.scheduler.schedule(0.seconds, publishInterval.millis) {
       while (buffer.nonEmpty) observer.onNext(buffer.dequeue())
@@ -77,7 +77,7 @@ class StreamActor(clientAddress: String,
   }
 
   override def postStop(): Unit = {
-    kamonMetric.decrement()
+//    kamonMetric.decrement()
   }
 
   def receive: Receive = {

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/endpoint/GrpcEndpointServiceCommand.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/endpoint/GrpcEndpointServiceCommand.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.radicalbit.nsdb.cluster.endpoint
+package io.radicalbit.nsdb.rpc.server.endpoint
 
 import akka.actor.ActorRef
 import akka.pattern.ask
@@ -41,7 +41,7 @@ import scala.concurrent.{ExecutionContext, Future}
 /**
   * Concrete implementation of the command Grpc service
   */
-private[endpoint] class GrpcEndpointServiceCommand(metadataCoordinator: ActorRef, readCoordinator: ActorRef)(
+class GrpcEndpointServiceCommand(metadataCoordinator: ActorRef, readCoordinator: ActorRef)(
     implicit timeout: Timeout,
     executionContext: ExecutionContext)
     extends NSDBServiceCommand

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/endpoint/GrpcEndpointServiceSQL.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/endpoint/GrpcEndpointServiceSQL.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.radicalbit.nsdb.cluster.endpoint
+package io.radicalbit.nsdb.rpc.server.endpoint
 
 import akka.actor.ActorRef
 import akka.pattern.ask

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/endpoint/GrpcNSDbStreaming.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/endpoint/GrpcNSDbStreaming.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package io.radicalbit.nsdb.cluster.endpoint
+package io.radicalbit.nsdb.rpc.server.endpoint
 
-import akka.actor.{Actor, ActorRef}
+import akka.actor.ActorRef
 import io.grpc.stub.StreamObserver
 import io.radicalbit.nsdb.rpc.requestSQL.SQLRequestStatement
 import io.radicalbit.nsdb.rpc.streaming.NSDbStreamingGrpc.NSDbStreaming

--- a/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/endpoint/GrpcNSDbStreaming.scala
+++ b/nsdb-rpc/src/main/scala/io/radicalbit/nsdb/rpc/server/endpoint/GrpcNSDbStreaming.scala
@@ -16,16 +16,17 @@
 
 package io.radicalbit.nsdb.rpc.server.endpoint
 
-import akka.actor.ActorRef
+import akka.actor.{ActorRef, ActorSystem}
 import io.grpc.stub.StreamObserver
 import io.radicalbit.nsdb.rpc.requestSQL.SQLRequestStatement
+import io.radicalbit.nsdb.rpc.server.actor.StreamActor
+import io.radicalbit.nsdb.rpc.server.actor.StreamActor.RegisterQuery
 import io.radicalbit.nsdb.rpc.streaming.NSDbStreamingGrpc.NSDbStreaming
 import io.radicalbit.nsdb.rpc.streaming.SQLStreamingResponse
 
-//class ObserverActor(publisherActor: ActorRef) extends Actor {
-//  override def receive: Receive =
-//}
-
-class GrpcNSDbStreaming(publisherActor: ActorRef) extends NSDbStreaming {
-  override def streamSQL(request: SQLRequestStatement, responseObserver: StreamObserver[SQLStreamingResponse]): Unit = {}
+class GrpcNSDbStreaming(publisherActor: ActorRef)(implicit system: ActorSystem) extends NSDbStreaming {
+  override def streamSQL(request: SQLRequestStatement, responseObserver: StreamObserver[SQLStreamingResponse]): Unit = {
+    val actor = system.actorOf(StreamActor.props("", publisherActor, 500, responseObserver))
+    actor ! RegisterQuery(request.db, request.namespace, request.metric, request.statement)
+  }
 }

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDB.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/NSDB.scala
@@ -43,8 +43,9 @@ object NSDB {
     * @param executionContextExecutor implicit execution context.
     * @return a Future of a nsdb connection.
     */
-  def connect(host: String, port: Int)(implicit executionContextExecutor: ExecutionContext): Future[NSDB] = {
-    val connection = new NSDB(host = host, port = port)
+  def connect(host: String, port: Int, db: String)(
+      implicit executionContextExecutor: ExecutionContext): Future[NSDB] = {
+    val connection = new NSDB(host = host, port = port, db: String)
     connection.check.map(_ => connection)
   }
 
@@ -79,7 +80,7 @@ object NSDB {
   * @param tokenApplier implementation of [[TokenApplier]] that contains authorization token management logic.
   * @param executionContextExecutor implicit execution context to handle asynchronous methods
   */
-class NSDB private (host: String, port: Int, tokenApplier: Option[TokenApplier] = None)(
+class NSDB private (host: String, port: Int, db: String, tokenApplier: Option[TokenApplier] = None)(
     implicit executionContextExecutor: ExecutionContext) {
 
   /**
@@ -91,7 +92,7 @@ class NSDB private (host: String, port: Int, tokenApplier: Option[TokenApplier] 
     * Create a new instance of [[NSDB]] with a Jwt token.
     * @param token Jwt Authorization token.
     */
-  def withJwtToken(token: String): NSDB = new NSDB(host, port, Some(TokenAppliers.JWT(token)))
+  def withJwtToken(token: String): NSDB = new NSDB(host, port, db, Some(TokenAppliers.JWT(token)))
 
   /**
     * Create a new instance of [[NSDB]] with a custom token.
@@ -99,13 +100,15 @@ class NSDB private (host: String, port: Int, tokenApplier: Option[TokenApplier] 
     * @param tokenValue value of the token.
     */
   def withCustomToken(tokenName: String, tokenValue: String): NSDB =
-    new NSDB(host, port, Some(TokenAppliers.Custom(tokenName, tokenValue)))
+    new NSDB(host, port, db, Some(TokenAppliers.Custom(tokenName, tokenValue)))
 
   /**
     * Defines the db used to build the bit or the query.
-    * @param name the db name
+    * Defines the namespace for the builder.
+    * @param namespace namespace name.
+    * @return auxiliary namespace instance.
     */
-  def db(name: String): Db = Db(name)
+  def namespace(namespace: String): Namespace = Namespace(db, namespace)
 
   /**
     * Checks if a connection is healthy.
@@ -128,7 +131,8 @@ class NSDB private (host: String, port: Int, tokenApplier: Option[TokenApplier] 
         value = bit.value,
         dimensions = bit.dimensions.toMap,
         tags = bit.tags.toMap
-      ))
+      )
+    )
 
   /**
     * Writes a list of bits into NSdb using the current openend connection.
@@ -156,21 +160,6 @@ class NSDB private (host: String, port: Int, tokenApplier: Option[TokenApplier] 
     * Closes the connection. Here any allocated resources must be released.
     */
   def close(): Unit = client.close()
-}
-
-/**
-  * Auxiliary case class used to define the Db for the builder.
-  * @param name db name.
-  */
-case class Db(name: String) {
-
-  /**
-    * Defines the namespace for the builder.
-    * @param namespace namespace name.
-    * @return auxiliary namespace instance.
-    */
-  def namespace(namespace: String): Namespace = Namespace(name, namespace)
-
 }
 
 /**

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
@@ -29,10 +29,10 @@ import scala.concurrent.duration._
   */
 object NSDBMainWrite extends App {
 
-  val nsdb = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817)(ExecutionContext.global), 10.seconds)
+  val nsdb =
+    Await.result(NSDB.connect(host = "127.0.0.1", port = 7817, db = "root")(ExecutionContext.global), 10.seconds)
 
   val series = nsdb
-    .db("root")
     .namespace("registry")
     .metric("people")
     .value(new java.math.BigDecimal("13.5"))
@@ -51,10 +51,10 @@ object NSDBMainWrite extends App {
   */
 object NSDBMainRead extends App {
 
-  val nsdb = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817)(ExecutionContext.global), 10.seconds)
+  val nsdb =
+    Await.result(NSDB.connect(host = "127.0.0.1", port = 7817, db = "root")(ExecutionContext.global), 10.seconds)
 
   val query = nsdb
-    .db("root")
     .namespace("registry")
     .metric("people")
     .query("select * from people limit 1")
@@ -69,10 +69,10 @@ object NSDBMainRead extends App {
   */
 object NSDBInitRead extends App {
 
-  val nsdb: NSDB = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817)(ExecutionContext.global), 10.seconds)
+  val nsdb: NSDB =
+    Await.result(NSDB.connect(host = "127.0.0.1", port = 7817, db = "root")(ExecutionContext.global), 10.seconds)
 
   val init = nsdb
-    .db("root")
     .namespace("registry")
     .metric("people")
     .shardInterval("2d")
@@ -83,7 +83,6 @@ object NSDBInitRead extends App {
   println(Await.result(readRes, 10.seconds))
 
   val metricToDescribe = nsdb
-    .db("root")
     .namespace("registry")
     .metric("people")
 
@@ -96,11 +95,11 @@ object NSDBInitRead extends App {
   */
 object NSDBMainSecureRead extends App {
 
-  val nsdb = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817)(ExecutionContext.global), 10.seconds)
+  val nsdb =
+    Await.result(NSDB.connect(host = "127.0.0.1", port = 7817, db = "root")(ExecutionContext.global), 10.seconds)
 
   val query = nsdb
     .withJwtToken("jwt token")
-    .db("root")
     .namespace("registry")
     .metric("people")
     .query("select * from people limit 1")

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDBMain.scala
@@ -29,10 +29,10 @@ import scala.concurrent.duration._
   */
 object NSDBMainWrite extends App {
 
-  val nsdb =
-    Await.result(NSDB.connect(host = "127.0.0.1", port = 7817, db = "root")(ExecutionContext.global), 10.seconds)
+  val nsdb = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817)(ExecutionContext.global), 10.seconds)
 
   val series = nsdb
+    .db("root")
     .namespace("registry")
     .metric("people")
     .value(new java.math.BigDecimal("13.5"))
@@ -51,10 +51,10 @@ object NSDBMainWrite extends App {
   */
 object NSDBMainRead extends App {
 
-  val nsdb =
-    Await.result(NSDB.connect(host = "127.0.0.1", port = 7817, db = "root")(ExecutionContext.global), 10.seconds)
+  val nsdb = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817)(ExecutionContext.global), 10.seconds)
 
   val query = nsdb
+    .db("root")
     .namespace("registry")
     .metric("people")
     .query("select * from people limit 1")
@@ -69,10 +69,10 @@ object NSDBMainRead extends App {
   */
 object NSDBInitRead extends App {
 
-  val nsdb: NSDB =
-    Await.result(NSDB.connect(host = "127.0.0.1", port = 7817, db = "root")(ExecutionContext.global), 10.seconds)
+  val nsdb = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817)(ExecutionContext.global), 10.seconds)
 
   val init = nsdb
+    .db("root")
     .namespace("registry")
     .metric("people")
     .shardInterval("2d")
@@ -83,6 +83,7 @@ object NSDBInitRead extends App {
   println(Await.result(readRes, 10.seconds))
 
   val metricToDescribe = nsdb
+    .db("root")
     .namespace("registry")
     .metric("people")
 
@@ -95,11 +96,11 @@ object NSDBInitRead extends App {
   */
 object NSDBMainSecureRead extends App {
 
-  val nsdb =
-    Await.result(NSDB.connect(host = "127.0.0.1", port = 7817, db = "root")(ExecutionContext.global), 10.seconds)
+  val nsdb = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817)(ExecutionContext.global), 10.seconds)
 
   val query = nsdb
     .withJwtToken("jwt token")
+    .db("root")
     .namespace("registry")
     .metric("people")
     .query("select * from people limit 1")

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDbStreamingMain.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDbStreamingMain.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.api.scala.example
+
+import akka.actor.ActorSystem
+import io.radicalbit.nsdb.api.scala.{Bit, NSDB}
+import io.radicalbit.nsdb.rpc.response.RPCInsertResult
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
+
+object NSDBPusher extends App {
+
+  val system = ActorSystem("pusher")
+  import system.dispatcher
+  val connection = Await.result(NSDB.connect(
+                                  host = "127.0.0.1",
+                                  port = 7817,
+                                  db = "radicalbit"
+                                ),
+                                10.seconds)
+  system.scheduler.scheduleAtFixedRate(0.seconds, 1.second) { () =>
+    val series: Bit = connection
+      .namespace("channel")
+      .metric("event")
+      .value(new java.math.BigDecimal("13.5"))
+      .dimension("city", "Milano")
+      .tag("gender", "M")
+      .dimension("bigDecimalLong", new java.math.BigDecimal("12"))
+      .dimension("bigDecimalDouble", new java.math.BigDecimal("12.5"))
+
+    val res: Future[RPCInsertResult] = connection.write(series)
+
+    println(Await.result(res, 10.seconds))
+
+  }
+
+}
+
+object NSDbStreamingMain extends App {
+
+  import io.radicalbit.nsdb.api.scala.streaming.NSDbStreaming._
+
+  implicit val executionContext: ExecutionContextExecutor = ExecutionContext.global
+
+  val nsdb = Await.result(NSDB.connect(
+                            host = "127.0.0.1",
+                            port = 7817,
+                            db = "radicalbit"
+                          ),
+                          10 seconds)
+
+  val query = nsdb
+    .namespace("registry")
+    .metric("people")
+    .query("select * from people limit 1")
+
+  nsdb.subscribe(query) { response =>
+    println(response)
+  }
+
+  Await.result(Future.never, Duration.Inf)
+}

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDbStreamingMain.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/example/NSDbStreamingMain.scala
@@ -27,14 +27,10 @@ object NSDBPusher extends App {
 
   val system = ActorSystem("pusher")
   import system.dispatcher
-  val connection = Await.result(NSDB.connect(
-                                  host = "127.0.0.1",
-                                  port = 7817,
-                                  db = "radicalbit"
-                                ),
-                                10.seconds)
+  val connection = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817), 10.seconds)
   system.scheduler.scheduleAtFixedRate(0.seconds, 1.second) { () =>
     val series: Bit = connection
+      .db("radicalbit")
       .namespace("channel")
       .metric("event")
       .value(new java.math.BigDecimal("13.5"))
@@ -57,14 +53,10 @@ object NSDbStreamingMain extends App {
 
   implicit val executionContext: ExecutionContextExecutor = ExecutionContext.global
 
-  val nsdb = Await.result(NSDB.connect(
-                            host = "127.0.0.1",
-                            port = 7817,
-                            db = "radicalbit"
-                          ),
-                          10 seconds)
+  val nsdb = Await.result(NSDB.connect(host = "127.0.0.1", port = 7817), 10 seconds)
 
   val query = nsdb
+    .db("radicalbit")
     .namespace("registry")
     .metric("people")
     .query("select * from people limit 1")

--- a/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/streaming/NSDbStreaming.scala
+++ b/nsdb-scala-api/src/main/scala/io/radicalbit/nsdb/api/scala/streaming/NSDbStreaming.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.api.scala.streaming
+
+import io.grpc.stub.StreamObserver
+import io.radicalbit.nsdb.api.scala.{NSDB, SQLStatement}
+import io.radicalbit.nsdb.rpc.requestSQL.SQLRequestStatement
+import io.radicalbit.nsdb.rpc.streaming.SQLStreamingResponse
+
+import scala.concurrent.ExecutionContext
+
+object NSDbStreaming {
+
+  implicit class toNSDbStreaming(nsdb: NSDB) {
+
+    def subscribe(statement: SQLStatement)(
+        callBack: SQLStreamingResponse => Unit,
+        errorCallBack: Throwable => Unit = _ => ())(implicit ec: ExecutionContext) = {
+      nsdb.client.subscribe(
+        SQLRequestStatement(statement.db, statement.namespace, statement.metric, statement.sQLStatement),
+        new StreamObserver[SQLStreamingResponse] {
+          override def onNext(value: SQLStreamingResponse): Unit = callBack(value)
+          override def onError(t: Throwable): Unit               = errorCallBack(t)
+          override def onCompleted(): Unit                       = {}
+        }
+      )
+    }
+
+  }
+}


### PR DESCRIPTION
This PR has the purpose to introduce a new Grpc Service, the streaming service.
This service can be seen as a new endpoint of the publish subscribe mechanism that, so far, is exposed only via web-socket.
In fact, the inner actors involved in this feature will remain untouched. Only a small refactor of the model objects was necessary. Also, a new `StreamActor` has been added. It acts as a bridge between the grpc endpoint and the inner actors (`PublisherActor`).

The flow and the events semantic are essentially the same of the web-socket endpoint.
Users are able to subscribe to a metric by passing a query  and a callback function that will process any incoming event that is pushed from the inner actors.
```
val query = nsdb
    .db("radicalbit")
    .namespace("registry")
    .metric("people")
    .query("select * from people limit 1")

  nsdb.subscribe(query) { event: SQLStreamingResponse =>
    println(event)
  }
```

the  polymorphism of the `SQLStreamingResponse` is expressed by the `payload` field, which can be of type:

- `SubscribedByQueryString`: the first event that is pushed after a successful subscription. It contains the results of the provided query that has been executed against historical data
- `SubscriptionByQueryStringFailed`: the first event sent if any error occurs during subscription phase
- `RecordsPublished`: event that is pushed consequently to a write operation that is performed to NSDb that fulfils the provided query





