### PR TITLE
Reinforce Test To Make CI More stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,19 @@ jobs:
         uses: coursier/cache-action@v5
       - name: Code Style Check
         run: sbt fixCheck scalafmtCheck test:scalafmtCheck multi-jvm:scalafmtCheck
+  cross-scala-compilation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: "adopt@1.8"
+      - name: Coursier cache
+        uses: coursier/cache-action@v5
+      - name: Cross Compilation
+        run: sbt +compile
   test:
     runs-on: ubuntu-latest
     steps:
@@ -56,6 +69,7 @@ jobs:
   publish-test:
     needs:
       - code-style
+      - cross-scala-compilation
       - test
     runs-on: ubuntu-latest
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -268,4 +268,3 @@ lazy val `nsdb-it` = (project in file("nsdb-it"))
 scalafmtOnCompile in ThisBuild := true
 // make run command include the provided dependencies
 run in Compile := Defaults.runTask(fullClasspath in Compile, mainClass in (Compile, run), runner in (Compile, run))
-fork in test := false

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
@@ -155,7 +155,7 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
 
   def receive: Receive = {
     case MemberUp(member) if member == cluster.selfMember =>
-      log.info("Member is Up: {}", member.address)
+      log.error("Member is Up: {}", member.address)
 
       val nodeActorsGuardian = createNodeActorsGuardian()
 
@@ -204,8 +204,8 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
       NSDbClusterSnapshot(context.system).addNode(address, nodeId)
     case UnreachableMember(member) =>
       log.info("Member detected as unreachable: {}", member)
-    case MemberRemoved(member, previousStatus) =>
-      log.info("{} Member is Removed: {} after {}", selfNodeName, member.address, previousStatus)
+    case MemberRemoved(member, previousStatus) if member != cluster.selfMember =>
+      log.error("{} Member is Removed: {} after {}", selfNodeName, member.address, previousStatus)
 
       val nodeName = createNodeName(member)
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
@@ -155,7 +155,7 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
 
   def receive: Receive = {
     case MemberUp(member) if member == cluster.selfMember =>
-      log.error("Member is Up: {}", member.address)
+      log.info("Member is Up: {}", member.address)
 
       val nodeActorsGuardian = createNodeActorsGuardian()
 
@@ -205,7 +205,7 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
     case UnreachableMember(member) =>
       log.info("Member detected as unreachable: {}", member)
     case MemberRemoved(member, previousStatus) if member != cluster.selfMember =>
-      log.error("{} Member is Removed: {} after {}", selfNodeName, member.address, previousStatus)
+      log.warning("{} Member is Removed: {} after {}", selfNodeName, member.address, previousStatus)
 
       val nodeName = createNodeName(member)
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -447,7 +447,7 @@ class MetadataCoordinator(clusterListener: ActorRef,
         .pipeTo(sender())
     case GetWriteLocations(db, namespace, metric, timestamp) =>
       val clusterAliveMembers = nsdbClusterSnapshot.nodes
-      log.error(s"cluster alive members $clusterAliveMembers")
+      log.debug(s"cluster alive members $clusterAliveMembers")
       if (clusterAliveMembers.size < replicationFactor)
         sender ! GetWriteLocationsFailed(
           db,
@@ -459,7 +459,7 @@ class MetadataCoordinator(clusterListener: ActorRef,
         val currentTime = System.currentTimeMillis()
         getMetricInfo(db, namespace, metric) { metricInfo =>
           val retention = metricInfo.retention
-          log.error(
+          log.debug(
             s"checking if timestamp $timestamp for coordinates ($db, $namespace, $metric) is beyond retention $retention at time $currentTime")
           if (retention > 0 && (timestamp < currentTime - retention || timestamp > currentTime + retention))
             Future(GetWriteLocationsBeyondRetention(db, namespace, metric, timestamp, metricInfo.retention))
@@ -555,7 +555,6 @@ class MetadataCoordinator(clusterListener: ActorRef,
       (temporaryDurableStoreActor ? LoadAll)
         .map {
           case LoadData(data) =>
-            log.error(s"restoring $data")
             log.info(s"restoring ${data.size} metadata entries")
 
             data.foreach {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -319,6 +319,10 @@ class MetadataCoordinator(clusterListener: ActorRef,
                 log.debug(s"checking locations $locations at time ${timeContext.currentTime} and retention $retention")
                 val (locationsToFullyEvict, locationsToPartiallyEvict) =
                   TimeRangeManager.getLocationsToEvict(locations, retention)
+                log.debug(
+                  s"found locations to fully evict $locationsToFullyEvict at time ${timeContext.currentTime} and retention $retention")
+                log.debug(
+                  s"found locations to partially evict $locationsToPartiallyEvict at time ${timeContext.currentTime} and retention $retention")
 
                 val cacheResponses = Future
                   .sequence(locationsToFullyEvict.map { location =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
@@ -469,8 +469,7 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
         _ <- schemaCoordinator ? msg
       } yield NamespaceDeleted(db, namespace)
 
-      import io.radicalbit.nsdb.util.PipeableFutureWithSideEffect._
-      chain.pipeTo(sender())
+      sequential { chain }.pipeTo(sender())
     case msg @ ExecuteDeleteStatement(statement @ DeleteSQLStatement(db, namespace, metric, _)) =>
       //FIXME add cluster aware deletion
       sequential {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/extension/NSDbClusterSnapshot.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/extension/NSDbClusterSnapshot.scala
@@ -46,7 +46,7 @@ class NSDbClusterSnapshotExtension(system: ExtendedActorSystem) extends Extensio
     * @param address the actual node address.
     */
   def removeNode(address: String): String = {
-    system.log.debug(s"removing node with address $address from $threadSafeMap")
+    system.log.warning(s"removing node with address $address from $threadSafeMap")
     threadSafeMap.remove(address)
   }
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/extension/NSDbClusterSnapshot.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/extension/NSDbClusterSnapshot.scala
@@ -36,13 +36,19 @@ class NSDbClusterSnapshotExtension(system: ExtendedActorSystem) extends Extensio
     * @param address the actual address of the node.
     * @param nodeId the node unique identifier.
     */
-  def addNode(address: String, nodeId: String): String = threadSafeMap.put(address, nodeId)
+  def addNode(address: String, nodeId: String): String = {
+    system.log.error(s"adding node with address $address to $threadSafeMap")
+    threadSafeMap.put(address, nodeId)
+  }
 
   /**
     * Removes a node.
     * @param address the actual node address.
     */
-  def removeNode(address: String): String = threadSafeMap.remove(address)
+  def removeNode(address: String): String = {
+    system.log.error(s"removing node with address $address from $threadSafeMap")
+    threadSafeMap.remove(address)
+  }
 
   /**
     * Returns the current active nodes

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/extension/NSDbClusterSnapshot.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/extension/NSDbClusterSnapshot.scala
@@ -37,7 +37,7 @@ class NSDbClusterSnapshotExtension(system: ExtendedActorSystem) extends Extensio
     * @param nodeId the node unique identifier.
     */
   def addNode(address: String, nodeId: String): String = {
-    system.log.error(s"adding node with address $address to $threadSafeMap")
+    system.log.debug(s"adding node with address $address to $threadSafeMap")
     threadSafeMap.put(address, nodeId)
   }
 
@@ -46,7 +46,7 @@ class NSDbClusterSnapshotExtension(system: ExtendedActorSystem) extends Extensio
     * @param address the actual node address.
     */
   def removeNode(address: String): String = {
-    system.log.error(s"removing node with address $address from $threadSafeMap")
+    system.log.debug(s"removing node with address $address from $threadSafeMap")
     threadSafeMap.remove(address)
   }
 

--- a/nsdb-cluster/src/multi-jvm/resources/application.conf
+++ b/nsdb-cluster/src/multi-jvm/resources/application.conf
@@ -76,7 +76,7 @@ nsdb {
 
   heartbeat.interval = 1 second
 
-  websocket {
+  streaming {
     refresh-period = 100
     retention-size = 10
   }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
@@ -3,13 +3,10 @@ package io.radicalbit.nsdb.cluster.actor
 import akka.actor.{ActorRef, Props}
 import akka.cluster.Member
 import akka.cluster.pubsub.DistributedPubSubMediator.SubscribeAck
-import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.actor.ClusterListenerTestActor._
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{NodeMetadataRemoved, RemoveNodeMetadataFailed}
 import io.radicalbit.nsdb.model.{Location, LocationWithCoordinates}
-
-import scala.concurrent.duration._
 
 abstract class ClusterListenerTestActor
   extends AbstractClusterListener {
@@ -21,13 +18,11 @@ abstract class ClusterListenerTestActor
 
   override protected lazy val nodeId: String = selfNodeName
 
-  override val defaultTimeout = Timeout(1.seconds)
-
   override def receive: Receive = super.receive orElse {
     case SubscribeAck(subscribe) => log.info("subscribe {}", subscribe)
   }
 
-  override def retrieveLocationsToAdd(): List[LocationWithCoordinates] = testType match {
+  override def retrieveLocationsToAdd: List[LocationWithCoordinates] = testType match {
     case SuccessTest =>
       List.empty
     case FailureTest =>
@@ -37,13 +32,9 @@ abstract class ClusterListenerTestActor
   override def onSuccessBehaviour(readCoordinator: ActorRef,
                                   writeCoordinator: ActorRef,
                                   metadataCoordinator: ActorRef,
-                                  publisherActor: ActorRef): Unit = {
-//    resultActor ! "Success"
-  }
+                                  publisherActor: ActorRef): Unit = ()
 
-  override protected def onFailureBehaviour(member: Member, error: Any): Unit = {
-//    resultActor ! "Failure"
-  }
+  override protected def onFailureBehaviour(member: Member, error: Any): Unit = ()
 
   override protected def onRemoveNodeMetadataResponse: events.RemoveNodeMetadataResponse => Unit = {
     case NodeMetadataRemoved(_)      => //ignore

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
@@ -38,11 +38,11 @@ abstract class ClusterListenerTestActor
                                   writeCoordinator: ActorRef,
                                   metadataCoordinator: ActorRef,
                                   publisherActor: ActorRef): Unit = {
-    resultActor ! "Success"
+//    resultActor ! "Success"
   }
 
   override protected def onFailureBehaviour(member: Member, error: Any): Unit = {
-    resultActor ! "Failure"
+//    resultActor ! "Failure"
   }
 
   override protected def onRemoveNodeMetadataResponse: events.RemoveNodeMetadataResponse => Unit = {

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/split_brain/ClusterSingletonWithSplitBrainSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/split_brain/ClusterSingletonWithSplitBrainSpec.scala
@@ -92,7 +92,7 @@ abstract class ClusterSingletonWithSplitBrainSpec
       enterBarrier("node-5-up")
     }
 
-    "demonstrate that after cluster partition two cluster singletons exists" in within(1 minutes) {
+    "demonstrate that after cluster partition two cluster singletons exists" in within(2 minutes) {
       runOn(node1) {
         for (role1 <- side1; role2 <- side2) switchOffConnection(role1, role2)
       }

--- a/nsdb-cluster/src/test/resources/application.conf
+++ b/nsdb-cluster/src/test/resources/application.conf
@@ -30,6 +30,11 @@ akka.test.timefactor = 5
 
 nsdb {
 
+  grpc {
+    interface = "0.0.0.0"
+    port = 7817
+  }
+
   global.timeout = 30 seconds
 
   write.scheduler.interval = 5 seconds
@@ -77,10 +82,21 @@ nsdb {
     n-retries = 2
   }
 
+  security {
+    enabled = false
+    auth-provider-class = ""
+  }
+
+  websocket {
+    refresh-period = 100
+    retention-size = 100
+  }
+
   math {
     precision = 10
   }
 
+  rpc-endpoint.timeout = 30 seconds
   read-coordinator.timeout = 30 seconds
   metadata-coordinator.timeout = 30 seconds
   write-coordinator.timeout = 30 seconds

--- a/nsdb-cluster/src/test/resources/application.conf
+++ b/nsdb-cluster/src/test/resources/application.conf
@@ -87,7 +87,7 @@ nsdb {
     auth-provider-class = ""
   }
 
-  websocket {
+  streaming {
     refresh-period = 100
     retention-size = 100
   }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -74,14 +74,11 @@ trait WriteCoordinatorBehaviour { this: TestKit with NSDbSpecLike =>
 
   lazy val commitLogCoordinator = system.actorOf(Props[FakeCommitLogCoordinator], "commitLogCoordinator")
   lazy val schemaCache          = system.actorOf(Props[FakeSchemaCache], "schemaCache")
-  lazy val schemaCoordinator =
-    TestActorRef[SchemaCoordinator](SchemaCoordinator.props(schemaCache), "schemaCoordinator")
-  lazy val subscriber = TestActorRef[TestSubscriber](Props[TestSubscriber], "testSubscriber")
+  lazy val schemaCoordinator    = system.actorOf(SchemaCoordinator.props(schemaCache), "schemaCoordinator")
+  lazy val subscriber           = TestActorRef[TestSubscriber](Props[TestSubscriber], "testSubscriber")
   lazy val publisherActor =
     TestActorRef[PublisherActor](PublisherActor.props(system.actorOf(Props[FakeReadCoordinatorActor])),
                                  "publisherActor")
-//  lazy val fakeMetadataCoordinator =
-//    system.actorOf(LocalMetadataCoordinator.props(system.actorOf(Props[LocalMetadataCache])))
   lazy val metadataCoordinator = system.actorOf(
     MetadataCoordinator.props(system.actorOf(Props[MockedClusterListener]),
                               system.actorOf(Props[LocalMetadataCache]),

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -87,7 +87,7 @@ trait WriteCoordinatorBehaviour { this: TestKit with NSDbSpecLike =>
     Bit(System.currentTimeMillis, 2, Map("content" -> s"content", "content2" -> s"content2"), Map.empty)
 
   def defaultBehaviour {
-    "write records" in within(5.seconds) {
+    "write records" in {
       val record1 = Bit(System.currentTimeMillis, 1, Map("content" -> s"content"), Map.empty)
       val record2 =
         Bit(System.currentTimeMillis, 2, Map("content" -> s"content", "content2" -> s"content2"), Map.empty)
@@ -119,7 +119,7 @@ trait WriteCoordinatorBehaviour { this: TestKit with NSDbSpecLike =>
 
     }
 
-    "write records and publish event to its subscriber" in within(5.seconds) {
+    "write records and publish event to its subscriber" in {
       val testRecordSatisfy = Bit(100, 1, Map("name" -> "john"), Map.empty)
 
       val testSqlStatement = SelectSQLStatement(
@@ -176,7 +176,7 @@ trait WriteCoordinatorBehaviour { this: TestKit with NSDbSpecLike =>
       result.namespaces.exists(_.contains(namespace)) shouldBe false
     }
 
-    "delete entries" in within(5.seconds) {
+    "delete entries" in {
 
       val records: Seq[Bit] = Seq(
         Bit(2, 1, Map("name"  -> "John", "surname"  -> "Doe", "creationDate" -> System.currentTimeMillis()), Map.empty),
@@ -216,7 +216,7 @@ trait WriteCoordinatorBehaviour { this: TestKit with NSDbSpecLike =>
 
     }
 
-    "drop a metric" in within(5.seconds) {
+    "drop a metric" in {
       probe.send(writeCoordinatorActor, MapInput(System.currentTimeMillis, db, namespace, "testMetric", record1))
       probe.send(writeCoordinatorActor, MapInput(System.currentTimeMillis, db, namespace, "testMetric", record2))
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
@@ -27,6 +27,7 @@ import io.radicalbit.nsdb.cluster.actor.MetricsDataActor
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{GetLocations, GetWriteLocations}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{LocationsGot, WriteLocationsGot}
 import io.radicalbit.nsdb.cluster.coordinator.mockedActors._
+import io.radicalbit.nsdb.cluster.extension.NSDbClusterSnapshot
 import io.radicalbit.nsdb.commit_log.CommitLogWriterActor.{RejectedEntryAction, WriteToCommitLog}
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Location
@@ -115,6 +116,10 @@ class WriteCoordinatorErrorsSpec
   val record2 = Bit(System.currentTimeMillis, 2, Map("dimension2" -> "dimension2"), Map("tag2" -> "tag2"))
 
   override def beforeAll: Unit = {
+
+    NSDbClusterSnapshot(system).addNode("localhost_2552", "node1")
+    NSDbClusterSnapshot(system).addNode("localhost_2553", "node2")
+
     Await.result(writeCoordinatorActor ? SubscribeCommitLogCoordinator(successfulCommitLogCoordinator, node1),
                  10 seconds)
     Await.result(writeCoordinatorActor ? SubscribeCommitLogCoordinator(failingCommitLogCoordinator, node2), 10 seconds)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
@@ -17,7 +17,6 @@
 package io.radicalbit.nsdb.cluster.coordinator
 
 import java.util.concurrent.TimeUnit
-
 import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
 import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
@@ -36,6 +35,7 @@ import io.radicalbit.nsdb.protocol.MessageProtocol.Events.RecordRejected
 import io.radicalbit.nsdb.test.NSDbSpecLike
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
+import java.util.UUID
 import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -70,7 +70,7 @@ class WriteCoordinatorErrorsSpec
     with BeforeAndAfter
     with BeforeAndAfterAll {
 
-  lazy val basePath = "target/test_index/WriteCoordinatorErrorsSpec"
+  lazy val basePath = s"target/test_index/WriteCoordinatorErrorsSpec/${UUID.randomUUID}"
 
   val db        = "writeCoordinatorSpecDB"
   val namespace = "namespace"
@@ -130,7 +130,7 @@ class WriteCoordinatorErrorsSpec
   }
 
   "WriteCoordinator" should {
-    "handle failures during commit log writes" in within(5.seconds) {
+    "handle failures during commit log writes" in {
 
       callingProbe.send(writeCoordinatorActor, MapInput(System.currentTimeMillis, db, namespace, metric1, record1))
 
@@ -152,7 +152,7 @@ class WriteCoordinatorErrorsSpec
         callingProbe.expectMsgType[RecordRejected]
       }
     }
-    "handle failures during accumulation" in within(5.seconds) {
+    "handle failures during accumulation" in {
 
       callingProbe.send(writeCoordinatorActor, MapInput(System.currentTimeMillis, db, namespace, metric2, record2))
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
@@ -69,37 +69,4 @@ class WriteCoordinatorSpec
 
   "WriteCoordinator" should behave.like(defaultBehaviour)
 
-  //  "WriteCoordinator" should {
-//    "write records" in {
-//      val record1 = Bit(System.currentTimeMillis, 1, Map("content" -> s"content"), Map.empty)
-//      val record2 =
-//        Bit(System.currentTimeMillis, 2, Map("content" -> s"content", "content2" -> s"content2"), Map.empty)
-//      val incompatibleRecord =
-//        Bit(System.currentTimeMillis, 3, Map("content" -> 1, "content2" -> s"content2"), Map.empty)
-//
-//      probe.send(writeCoordinatorActor, MapInput(System.currentTimeMillis, db, namespace, "testMetric", record1))
-//
-//      val expectedAdd = awaitAssert {
-//        probe.expectMsgType[InputMapped]
-//      }
-//      expectedAdd.metric shouldBe "testMetric"
-//      expectedAdd.record shouldBe record1
-//
-//      probe.send(writeCoordinatorActor, MapInput(System.currentTimeMillis, db, namespace, "testMetric", record2))
-//
-//      val expectedAdd2 = awaitAssert {
-//        probe.expectMsgType[InputMapped]
-//      }
-//      expectedAdd2.metric shouldBe "testMetric"
-//      expectedAdd2.record shouldBe record2
-//
-//      probe.send(writeCoordinatorActor,
-//        MapInput(System.currentTimeMillis, db, namespace, "testMetric", incompatibleRecord))
-//
-//      awaitAssert {
-//        probe.expectMsgType[RecordRejected]
-//      }
-//
-//    }
-//  }
 }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
@@ -46,17 +46,17 @@ class WriteCoordinatorSpec
   val namespace = "namespace"
 
   override def beforeAll: Unit = {
-    probe.send(writeCoordinatorActor, SubscribeCommitLogCoordinator(commitLogCoordinator, "localhost"))
+    probe.send(writeCoordinatorActor, SubscribeCommitLogCoordinator(commitLogCoordinator, "nodeId"))
     awaitAssert {
       probe.expectMsgType[CommitLogCoordinatorSubscribed]
     }
 
-    probe.send(writeCoordinatorActor, SubscribeMetricsDataActor(metricsDataActor, "localhost"))
+    probe.send(writeCoordinatorActor, SubscribeMetricsDataActor(metricsDataActor, "nodeId"))
     awaitAssert {
       probe.expectMsgType[MetricsDataActorSubscribed]
     }
 
-    probe.send(writeCoordinatorActor, SubscribePublisher(publisherActor, "localhost"))
+    probe.send(writeCoordinatorActor, SubscribePublisher(publisherActor, "nodeId"))
     awaitAssert {
       probe.expectMsgType[PublisherSubscribed]
     }
@@ -68,4 +68,38 @@ class WriteCoordinatorSpec
   }
 
   "WriteCoordinator" should behave.like(defaultBehaviour)
+
+  //  "WriteCoordinator" should {
+//    "write records" in {
+//      val record1 = Bit(System.currentTimeMillis, 1, Map("content" -> s"content"), Map.empty)
+//      val record2 =
+//        Bit(System.currentTimeMillis, 2, Map("content" -> s"content", "content2" -> s"content2"), Map.empty)
+//      val incompatibleRecord =
+//        Bit(System.currentTimeMillis, 3, Map("content" -> 1, "content2" -> s"content2"), Map.empty)
+//
+//      probe.send(writeCoordinatorActor, MapInput(System.currentTimeMillis, db, namespace, "testMetric", record1))
+//
+//      val expectedAdd = awaitAssert {
+//        probe.expectMsgType[InputMapped]
+//      }
+//      expectedAdd.metric shouldBe "testMetric"
+//      expectedAdd.record shouldBe record1
+//
+//      probe.send(writeCoordinatorActor, MapInput(System.currentTimeMillis, db, namespace, "testMetric", record2))
+//
+//      val expectedAdd2 = awaitAssert {
+//        probe.expectMsgType[InputMapped]
+//      }
+//      expectedAdd2.metric shouldBe "testMetric"
+//      expectedAdd2.record shouldBe record2
+//
+//      probe.send(writeCoordinatorActor,
+//        MapInput(System.currentTimeMillis, db, namespace, "testMetric", incompatibleRecord))
+//
+//      awaitAssert {
+//        probe.expectMsgType[RecordRejected]
+//      }
+//
+//    }
+//  }
 }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorSpec.scala
@@ -17,16 +17,14 @@
 package io.radicalbit.nsdb.cluster.coordinator
 
 import akka.actor.ActorSystem
-import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit}
-import akka.util.Timeout
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.test.NSDbSpecLike
 import org.scalatest._
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
+import java.util.UUID
 
 class WriteCoordinatorSpec
     extends TestKit(
@@ -42,19 +40,31 @@ class WriteCoordinatorSpec
     with BeforeAndAfterAll
     with WriteCoordinatorBehaviour {
 
-  lazy val basePath = "target/test_index/WriteCoordinatorSpec"
+  lazy val basePath = s"target/test_index/WriteCoordinatorSpec/${UUID.randomUUID}"
 
   val db        = "writeCoordinatorSpecDB"
   val namespace = "namespace"
 
-  implicit val timeout = Timeout(10 seconds)
-
   override def beforeAll: Unit = {
-    Await.result(writeCoordinatorActor ? SubscribeCommitLogCoordinator(commitLogCoordinator, "localhost"), 10 seconds)
-    Await.result(writeCoordinatorActor ? SubscribeMetricsDataActor(metricsDataActor, "localhost"), 10 seconds)
-    Await.result(writeCoordinatorActor ? SubscribePublisher(publisherActor, "localhost"), 10 seconds)
-    Await.result(writeCoordinatorActor ? DeleteNamespace(db, namespace), 10 seconds)
-    Await.result(schemaCoordinator ? UpdateSchemaFromRecord(db, namespace, "testMetric", record1), 10 seconds)
+    probe.send(writeCoordinatorActor, SubscribeCommitLogCoordinator(commitLogCoordinator, "localhost"))
+    awaitAssert {
+      probe.expectMsgType[CommitLogCoordinatorSubscribed]
+    }
+
+    probe.send(writeCoordinatorActor, SubscribeMetricsDataActor(metricsDataActor, "localhost"))
+    awaitAssert {
+      probe.expectMsgType[MetricsDataActorSubscribed]
+    }
+
+    probe.send(writeCoordinatorActor, SubscribePublisher(publisherActor, "localhost"))
+    awaitAssert {
+      probe.expectMsgType[PublisherSubscribed]
+    }
+
+    probe.send(schemaCoordinator, UpdateSchemaFromRecord(db, namespace, "testMetric", record1))
+    awaitAssert {
+      probe.expectMsgType[SchemaUpdated]
+    }
   }
 
   "WriteCoordinator" should behave.like(defaultBehaviour)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/MockedClusterListener.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/MockedClusterListener.scala
@@ -16,15 +16,12 @@
 
 package io.radicalbit.nsdb.cluster.coordinator.mockedActors
 
-import akka.actor.{Actor, ActorLogging}
-import io.radicalbit.nsdb.commit_log.CommitLogWriterActor.{WriteToCommitLog, WriteToCommitLogSucceeded}
+import akka.actor.Actor
+import io.radicalbit.nsdb.cluster.actor.NSDbMetricsEvents.{GetNodeMetrics, NodeMetricsGot}
 
-class FakeCommitLogCoordinator extends Actor with ActorLogging {
+class MockedClusterListener extends Actor {
   override def receive: Receive = {
-    case WriteToCommitLog(db, namespace, metric, timestamp, _, location) =>
-      sender ! WriteToCommitLogSucceeded(db, namespace, timestamp, metric, location)
-    case unexpected =>
-      log.error(s"UnexpectedMessage $unexpected")
-      sender ! "UnexpectedMessage"
+    case GetNodeMetrics =>
+      sender ! NodeMetricsGot(Set.empty)
   }
 }

--- a/nsdb-common/src/test/resources/nsdb-test.conf
+++ b/nsdb-common/src/test/resources/nsdb-test.conf
@@ -108,10 +108,10 @@ nsdb {
 
   stream.timeout = 30 seconds
 
-  websocket {
-    // Websocket publish period expressed in milliseconds
+  streaming {
+    // Streaming publish period expressed in milliseconds
     refresh-period = 100
-    //Websocket retention size
+    // Streaming retention size
     retention-size = 10
   }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/PublisherActor.scala
@@ -229,7 +229,7 @@ class PublisherActor(readCoordinator: ActorRef) extends ActorPathLogging {
           case parsedTemporalAggregatedQuery: ParsedTemporalAggregatedQuery =>
             temporalBuckets.get(quid).foreach { temporalBucket =>
               reduceSingleTemporalBucket(schema, parsedTemporalAggregatedQuery.aggregation)(mathContext)(
-                temporalBucket.bits).foreach { record =>
+                temporalBucket.bits.toSeq).foreach { record =>
                 subscribedActorsByQueryId
                   .get(quid)
                   .foreach(
@@ -265,7 +265,7 @@ class PublisherActor(readCoordinator: ActorRef) extends ActorPathLogging {
                 case (Some((key, lateBucket)), lateEvents) =>
                   lateTemporalBuckets += (key -> lateBucket.copy(bits = lateBucket.bits ++ lateEvents))
                   reduceSingleTemporalBucket(schema, parsedTemporalAggregatedQuery.aggregation)(mathContext)(
-                    lateBucket.bits ++ lateEvents).foreach { record =>
+                    lateBucket.bits.toSeq ++ lateEvents).foreach { record =>
                     subscribedActorsByQueryId
                       .get(quid)
                       .foreach(

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/post_proc/package.scala
@@ -215,13 +215,6 @@ package object post_proc {
 
     res.sortBy(_.timestamp) match {
       case Nil => None
-      case head :: Nil =>
-        Some(
-          Bit(head.timestamp,
-              head.value,
-              Map(upperBoundField -> head.timestamp, lowerBoundField -> head.timestamp),
-              Map.empty)
-        )
       case bits =>
         val head = bits.head
         val last = bits.last

--- a/nsdb-core/src/test/resources/application.conf
+++ b/nsdb-core/src/test/resources/application.conf
@@ -81,7 +81,7 @@ nsdb{
     retry-attempts = 3
   }
 
-   websocket {
+   streaming {
       refresh-period = 100
       retention-size = 100
     }

--- a/nsdb-core/src/test/resources/application.conf
+++ b/nsdb-core/src/test/resources/application.conf
@@ -81,6 +81,11 @@ nsdb{
     retry-attempts = 3
   }
 
+   websocket {
+      refresh-period = 100
+      retention-size = 100
+    }
+
   math {
     precision = 10
   }

--- a/project/Commons.scala
+++ b/project/Commons.scala
@@ -43,9 +43,7 @@ object Commons {
       "Radicalbit Public Snapshots" at "https://tools.radicalbit.io/artifactory/public-snapshot/",
       Resolver.bintrayRepo("hseeberger", "maven")
     ),
-    parallelExecution in Test := false,
     parallelExecution in IntegrationTest := false,
-    concurrentRestrictions in Test += Tags.limitAll(1),
     concurrentRestrictions in IntegrationTest += Tags.limitAll(1)
   )
 


### PR DESCRIPTION
This PR aims at improving tests and CI in order to achieve more stability in the whole process.
The following criteria have been adopted:

- Cluster ActorrefProvider has been replaced by LocalActorrefProvider in tests. This has made possible by a little refactor of metadata coordinator in order to remove all the akka cluster references.
- many not useful `within` constraints have been removed.
- fix wrong usage of TestProbes 
- make the minimum usage of TestActorRef 

