### PR TITLE
Cluster Topology and Get Locations Http Apis

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
@@ -107,10 +107,13 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
 
   override def postStop(): Unit = cluster.unsubscribe(self)
 
+  private def createNodeActorGuardianName(nodeId: String, nodeName: String): String =
+    s"guardian_${nodeId}_${nodeName}"
+
   protected def createNodeActorsGuardian(): ActorRef = {
     context.system.actorOf(
       NodeActorsGuardian.props(self, nodeId).withDeploy(Deploy(scope = RemoteScope(cluster.selfMember.address))),
-      name = s"guardian_${nodeId}_${selfNodeName}"
+      name = createNodeActorGuardianName(nodeId, selfNodeName)
     )
   }
 
@@ -131,22 +134,22 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
       log.error(s"RemoveNodeMetadataFailed for node $nodeName")
   }
 
-  private def unsubscribeNode(nodeName: String)(implicit scheduler: Scheduler, _log: LoggingAdapter) = {
+  private def unsubscribeNode(nodeId: String)(implicit scheduler: Scheduler, _log: LoggingAdapter) = {
     (for {
       NodeChildActorsGot(metadataCoordinator, writeCoordinator, readCoordinator, _) <- (context.actorSelection(
-        s"/user/guardian_$nodeName") ? GetNodeChildActors)
+        createNodeActorGuardianName(nodeId, selfNodeName)) ? GetNodeChildActors)
         .mapTo[NodeChildActorsGot]
-      _ <- (readCoordinator ? UnsubscribeMetricsDataActor(nodeName)).mapTo[MetricsDataActorUnSubscribed]
-      _ <- (writeCoordinator ? UnSubscribeCommitLogCoordinator(nodeName))
+      _ <- (readCoordinator ? UnsubscribeMetricsDataActor(nodeId)).mapTo[MetricsDataActorUnSubscribed]
+      _ <- (writeCoordinator ? UnSubscribeCommitLogCoordinator(nodeId))
         .mapTo[CommitLogCoordinatorUnSubscribed]
-      _ <- (writeCoordinator ? UnSubscribePublisher(nodeName)).mapTo[PublisherUnSubscribed]
-      _ <- (writeCoordinator ? UnsubscribeMetricsDataActor(nodeName))
+      _ <- (writeCoordinator ? UnSubscribePublisher(nodeId)).mapTo[PublisherUnSubscribed]
+      _ <- (writeCoordinator ? UnsubscribeMetricsDataActor(nodeId))
         .mapTo[MetricsDataActorUnSubscribed]
-      _ <- (metadataCoordinator ? UnsubscribeMetricsDataActor(nodeName))
+      _ <- (metadataCoordinator ? UnsubscribeMetricsDataActor(nodeId))
         .mapTo[MetricsDataActorUnSubscribed]
-      _ <- (metadataCoordinator ? UnSubscribeCommitLogCoordinator(nodeName))
+      _ <- (metadataCoordinator ? UnSubscribeCommitLogCoordinator(nodeId))
         .mapTo[CommitLogCoordinatorUnSubscribed]
-      removeNodeMetadataResponse <- (metadataCoordinator ? RemoveNodeMetadata(nodeName))
+      removeNodeMetadataResponse <- (metadataCoordinator ? RemoveNodeMetadata(nodeId))
         .mapTo[RemoveNodeMetadataResponse]
     } yield removeNodeMetadataResponse)
       .retry(delay, retries)(_.isInstanceOf[NodeMetadataRemoved])
@@ -155,7 +158,7 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
 
   def receive: Receive = {
     case MemberUp(member) if member == cluster.selfMember =>
-      log.info("Member is Up: {}", member.address)
+      log.info("Member with nodeId {} is Up: {}", nodeId, member.address)
 
       val nodeActorsGuardian = createNodeActorsGuardian()
 
@@ -167,7 +170,7 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
 
           val locationsToAdd: Seq[LocationWithCoordinates] = retrieveLocationsToAdd.diff(outdatedLocations.locations)
 
-          log.debug(s"locations to add from node $nodeId $locationsToAdd")
+          log.info(s"locations to add from node $nodeId $locationsToAdd")
 
           val locationsGroupedBy: Map[(String, String), Seq[LocationWithCoordinates]] = locationsToAdd.groupBy {
             case LocationWithCoordinates(database, namespace, _) => (database, namespace)
@@ -207,9 +210,10 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
     case MemberRemoved(member, previousStatus) if member != cluster.selfMember =>
       log.warning("{} Member is Removed: {} after {}", selfNodeName, member.address, previousStatus)
 
-      val nodeName = createNodeName(member)
+      val nodeName       = createNodeName(member)
+      val nodeIdToRemove = NSDbClusterSnapshot(context.system).getId(nodeName)
 
-      unsubscribeNode(nodeName)
+      unsubscribeNode(nodeIdToRemove.nodeId)
 
       NSDbClusterSnapshot(context.system).removeNode(nodeName)
     case _: MemberEvent => // ignore

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
@@ -135,6 +135,7 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
   }
 
   private def unsubscribeNode(nodeId: String)(implicit scheduler: Scheduler, _log: LoggingAdapter) = {
+    log.info(s"unsubscribing node $nodeId")
     (for {
       NodeChildActorsGot(metadataCoordinator, writeCoordinator, readCoordinator, _) <- (context.actorSelection(
         createNodeActorGuardianName(nodeId, selfNodeName)) ? GetNodeChildActors)
@@ -194,7 +195,8 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
         .onComplete {
           case Success(
               (NodeChildActorsGot(metadataCoordinator, writeCoordinator, readCoordinator, publisherActor),
-               (_, failures))) if failures.isEmpty =>
+               (success, failures))) if failures.isEmpty =>
+            log.info(s"location ${success} successfully added for node $nodeId")
             val nodeName = createNodeName(member)
             mediator ! Subscribe(NODE_GUARDIANS_TOPIC, nodeActorsGuardian)
             mediator ! Publish(NSDB_LISTENERS_TOPIC, NodeAlive(nodeId, nodeName))

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
@@ -162,7 +162,7 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
 
   def receive: Receive = {
     case MemberUp(member) if member == cluster.selfMember =>
-      log.info("Member with nodeId {} is Up: {}", nodeId, member.address)
+      log.info(s"Member with nodeId $nodeId and address ${member.address} is Up")
 
       val nodeActorsGuardian = createNodeActorsGuardian()
 
@@ -174,7 +174,7 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
 
           val locationsToAdd: Seq[LocationWithCoordinates] = retrieveLocationsToAdd.diff(outdatedLocations.locations)
 
-          log.info(s"locations to add from node $nodeId $locationsToAdd")
+          log.info(s"locations to add from node $nodeId \t$locationsToAdd")
 
           val locationsGroupedBy: Map[(String, String), Seq[LocationWithCoordinates]] = locationsToAdd.groupBy {
             case LocationWithCoordinates(database, namespace, _) => (database, namespace)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
@@ -70,7 +70,7 @@ class NodeActorsGuardian(clusterListener: ActorRef, nodeId: String) extends Acto
 
   private lazy val writeNodesSelectionLogic = new CapacityWriteNodesSelectionLogic(
     CapacityWriteNodesSelectionLogic.fromConfigValue(config.getString("nsdb.cluster.metrics-selector")))
-  private lazy val readNodesSelection = new LocalityReadNodesSelection(nodeAddress)
+  private lazy val readNodesSelection = new LocalityReadNodesSelection(nodeId)
 
   private val metadataCache = context.actorOf(Props[ReplicatedMetadataCache], s"metadata-cache-$nodeId-$nodeAddress")
   private val schemaCache   = context.actorOf(Props[ReplicatedSchemaCache], s"schema-cache-$nodeId-$nodeAddress")
@@ -144,6 +144,8 @@ class NodeActorsGuardian(clusterListener: ActorRef, nodeId: String) extends Acto
     context.system.scheduler.schedule(interval, interval) {
       mediator ! Publish(NSDB_LISTENERS_TOPIC, NodeAlive(nodeId, nodeAddress))
     }
+
+    log.info(s"NodeActorGuardian is ready at ${self.path.name}")
   }
 
   def receive: Receive = {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -623,7 +623,6 @@ object MetadataCoordinator {
 
   object commands {
 
-    case class GetLocations(db: String, namespace: String, metric: String) extends NSDbSerializable
     case class GetWriteLocations(db: String, namespace: String, metric: String, timestamp: Long)
         extends NSDbSerializable
     case class AddLocations(db: String,
@@ -647,9 +646,6 @@ object MetadataCoordinator {
   }
 
   object events {
-
-    case class LocationsGot(db: String, namespace: String, metric: String, locations: Seq[Location])
-        extends NSDbSerializable
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
     @JsonSubTypes(

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -484,14 +484,12 @@ class MetadataCoordinator(clusterListener: ActorRef,
                             if (nodeMetrics.nodeMetrics.nonEmpty)
                               writeNodesSelectionLogic
                                 .selectWriteNodes(nodeMetrics.nodeMetrics, replicationFactor)
-                                .map(address => (address, nsdbClusterSnapshot.getId(address)))
+                                .map(address => nsdbClusterSnapshot.getId(address))
                             else {
                               Random.shuffle(clusterAliveMembers.toSeq).take(replicationFactor)
                             }
 
-                          val nsdbNodes = nodes.map(address => (nsdbClusterSnapshot.getId(address)))
-
-                          val locations = nsdbNodes.map { node =>
+                          val locations = nodes.map { node =>
                             Location(metric, node.nodeId, start, end)
                           }
                           performAddLocationIntoCache(db, namespace, locations, None)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/ReadCoordinator.scala
@@ -25,8 +25,6 @@ import akka.pattern.ask
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.NsdbPerfLogger
 import io.radicalbit.nsdb.cluster.PubSubTopics._
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.GetLocations
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.LocationsGot
 import io.radicalbit.nsdb.cluster.logic.ReadNodesSelection
 import io.radicalbit.nsdb.common.NSDbNumericType
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.precision

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
@@ -16,9 +16,6 @@
 
 package io.radicalbit.nsdb.cluster.coordinator
 
-import java.time.Duration
-import java.util.concurrent.TimeUnit
-
 import akka.actor.{ActorRef, Props, Stash}
 import akka.cluster.pubsub.DistributedPubSubMediator.{Publish, Subscribe}
 import akka.util.Timeout
@@ -26,10 +23,9 @@ import io.radicalbit.nsdb.cluster.NsdbPerfLogger
 import io.radicalbit.nsdb.cluster.PubSubTopics.{COORDINATORS_TOPIC, NODE_GUARDIANS_TOPIC}
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.ExecuteDeleteStatementInternalInLocations
 import io.radicalbit.nsdb.cluster.actor.SequentialFutureProcessing
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{GetLocations, GetWriteLocations}
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.GetWriteLocations
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.logic.WriteConfig
-import io.radicalbit.nsdb.util.ErrorManagementUtils._
 import io.radicalbit.nsdb.commit_log.CommitLogWriterActor._
 import io.radicalbit.nsdb.common.configuration.NSDbConfig
 import io.radicalbit.nsdb.common.protocol.Bit
@@ -39,7 +35,10 @@ import io.radicalbit.nsdb.model.{Location, Schema, TimeContext}
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.util.ActorPathLogging
+import io.radicalbit.nsdb.util.ErrorManagementUtils._
 
+import java.time.Duration
+import java.util.concurrent.TimeUnit
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinator.scala
@@ -70,8 +70,6 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
     TimeUnit.SECONDS)
   import context.dispatcher
 
-  log.info("WriteCoordinator is ready.")
-
   lazy val shardingInterval: Duration = context.system.settings.config.getDuration("nsdb.sharding.interval")
 
   override lazy val indexStorageStrategy: StorageStrategy =
@@ -374,6 +372,8 @@ class WriteCoordinator(metadataCoordinator: ActorRef, schemaCoordinator: ActorRe
       log.debug("WriteCoordinator data actor : {}", metricsDataActors.size)
       log.debug("WriteCoordinator commit log  actor : {}", commitLogCoordinators.size)
     }
+
+    log.info("WriteCoordinator is ready.")
   }
 
   override def receive: Receive = {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/extension/NSDbClusterSnapshot.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/extension/NSDbClusterSnapshot.scala
@@ -17,6 +17,7 @@
 package io.radicalbit.nsdb.cluster.extension
 
 import akka.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.NSDbNode
 
 import scala.collection.JavaConverters._
 
@@ -29,23 +30,23 @@ class NSDbClusterSnapshotExtension(system: ExtendedActorSystem) extends Extensio
 
   import java.util.concurrent.ConcurrentHashMap
 
-  private val threadSafeMap: ConcurrentHashMap[String, String] = new ConcurrentHashMap[String, String]()
+  private val threadSafeMap: ConcurrentHashMap[String, NSDbNode] = new ConcurrentHashMap[String, NSDbNode]()
 
   /**
     * Adds a node and associate it to the a unique identifier
     * @param address the actual address of the node.
     * @param nodeId the node unique identifier.
     */
-  def addNode(address: String, nodeId: String): String = {
+  def addNode(address: String, nodeId: String): NSDbNode = {
     system.log.debug(s"adding node with address $address to $threadSafeMap")
-    threadSafeMap.put(address, nodeId)
+    threadSafeMap.put(address, NSDbNode(address, nodeId))
   }
 
   /**
     * Removes a node.
     * @param address the actual node address.
     */
-  def removeNode(address: String): String = {
+  def removeNode(address: String): NSDbNode = {
     system.log.warning(s"removing node with address $address from $threadSafeMap")
     threadSafeMap.remove(address)
   }
@@ -53,9 +54,9 @@ class NSDbClusterSnapshotExtension(system: ExtendedActorSystem) extends Extensio
   /**
     * Returns the current active nodes
     */
-  def nodes: Set[(String, String)] = threadSafeMap.asScala.toSet
+  def nodes: Iterable[NSDbNode] = threadSafeMap.asScala.values
 
-  def getId(address: String): String = threadSafeMap.get(address)
+  def getId(address: String): NSDbNode = threadSafeMap.get(address)
 }
 
 object NSDbClusterSnapshot extends ExtensionId[NSDbClusterSnapshotExtension] with ExtensionIdProvider {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelection.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelection.scala
@@ -25,11 +25,12 @@ import io.radicalbit.nsdb.model.Location
 class LocalityReadNodesSelection(localNode: String) extends ReadNodesSelection {
 
   override def getDistinctLocationsByNode(locationsWithReplicas: Seq[Location]): Map[String, Seq[Location]] = {
+    assert(localNode != null)
     locationsWithReplicas
       .groupBy(l => (l.from, l.to))
       .map {
         case ((_, _), locations) if locations.size > 1 =>
-          Option(localNode).flatMap(local => locations.find(_.node == local)).getOrElse(locations.minBy(_.node))
+          locations.find(_.node == localNode).getOrElse(locations.head)
         case ((_, _), locations) => locations.minBy(_.node)
       }
       .toSeq

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelection.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelection.scala
@@ -29,7 +29,7 @@ class LocalityReadNodesSelection(localNode: String) extends ReadNodesSelection {
       .groupBy(l => (l.from, l.to))
       .map {
         case ((_, _), locations) if locations.size > 1 =>
-          locations.find(_.node == localNode).getOrElse(locations.minBy(_.node))
+          Option(localNode).flatMap(local => locations.find(_.node == local)).getOrElse(locations.minBy(_.node))
         case ((_, _), locations) => locations.minBy(_.node)
       }
       .toSeq

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -37,6 +37,7 @@ import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events.MetricInfoGot
 import io.radicalbit.nsdb.test.NSDbSpecLike
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{LocationsGot, MetricInfoGot}
 import org.scalatest._
 
 import scala.concurrent.Await

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
@@ -129,7 +129,7 @@ class RetentionSpec
     val nodesId = awaitAssert {
       val nodes = NSDbClusterSnapshot(system).nodes
       nodes.size shouldBe 1
-      nodes.head._2
+      nodes.head.nodeId
     }
 
     val metricsDataActor =

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -16,12 +16,10 @@
 
 package io.radicalbit.nsdb.cluster.coordinator
 
-import java.util.concurrent.TimeUnit
 import akka.actor.{Actor, Props}
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import io.radicalbit.nsdb.actors.PublisherActor
 import io.radicalbit.nsdb.actors.PublisherActor.Commands.SubscribeBySqlStatement
-import io.radicalbit.nsdb.protocol.RealTimeProtocol.Events.{RecordsPublished, SubscribedByQueryString}
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor
 import io.radicalbit.nsdb.cluster.coordinator.mockedActors.{
   FakeCommitLogCoordinator,
@@ -35,8 +33,8 @@ import io.radicalbit.nsdb.common.statement._
 import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
+import io.radicalbit.nsdb.protocol.RealTimeProtocol.Events.{RecordsPublished, SubscribedByQueryString}
 import io.radicalbit.nsdb.test.NSDbSpecLike
-import org.scalatest._
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -23,8 +23,6 @@ import io.radicalbit.nsdb.actors.PublisherActor
 import io.radicalbit.nsdb.actors.PublisherActor.Commands.SubscribeBySqlStatement
 import io.radicalbit.nsdb.protocol.RealTimeProtocol.Events.{RecordsPublished, SubscribedByQueryString}
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.GetLocations
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.LocationsGot
 import io.radicalbit.nsdb.cluster.coordinator.mockedActors.{
   FakeCommitLogCoordinator,
   LocalMetadataCache,
@@ -38,7 +36,9 @@ import io.radicalbit.nsdb.model.Schema
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.test.NSDbSpecLike
+import org.scalatest._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 
 class TestSubscriber extends Actor {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
@@ -16,7 +16,6 @@
 
 package io.radicalbit.nsdb.cluster.coordinator
 
-import java.util.concurrent.TimeUnit
 import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
 import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
@@ -24,19 +23,20 @@ import akka.util.Timeout
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import io.radicalbit.nsdb.actors.PublisherActor
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.{GetLocations, GetWriteLocations}
-import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.{LocationsGot, WriteLocationsGot}
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.GetWriteLocations
+import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.WriteLocationsGot
 import io.radicalbit.nsdb.cluster.coordinator.mockedActors._
 import io.radicalbit.nsdb.cluster.extension.NSDbClusterSnapshot
 import io.radicalbit.nsdb.commit_log.CommitLogWriterActor.{RejectedEntryAction, WriteToCommitLog}
 import io.radicalbit.nsdb.common.protocol.Bit
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
-import io.radicalbit.nsdb.protocol.MessageProtocol.Events.RecordRejected
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{LocationsGot, RecordRejected}
 import io.radicalbit.nsdb.test.NSDbSpecLike
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.duration._

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -33,10 +33,12 @@ object MessageProtocol {
     * commands executed among NSDb actors.
     */
   object Commands {
-    case object GetDbs                                                  extends ControlMessage with NSDbSerializable
-    case class GetNamespaces(db: String)                                extends ControlMessage with NSDbSerializable
-    case class GetMetrics(db: String, namespace: String)                extends ControlMessage with NSDbSerializable
-    case class GetSchema(db: String, namespace: String, metric: String) extends NSDbSerializable
+    case object GetTopology                                                extends NSDbSerializable
+    case class GetLocations(db: String, namespace: String, metric: String) extends NSDbSerializable
+    case object GetDbs                                                     extends ControlMessage with NSDbSerializable
+    case class GetNamespaces(db: String)                                   extends ControlMessage with NSDbSerializable
+    case class GetMetrics(db: String, namespace: String)                   extends ControlMessage with NSDbSerializable
+    case class GetSchema(db: String, namespace: String, metric: String)    extends NSDbSerializable
 
     case class GetMetricInfo(db: String, namespace: String, metric: String) extends NSDbSerializable
 
@@ -107,13 +109,15 @@ object MessageProtocol {
 
     case class NodeAlive(nodeId: String, nodeAddress: String) extends NSDbSerializable
 
-    case object GetTopology extends NSDbSerializable
   }
 
   /**
     * events received from nsdb actors.
     */
   object Events {
+
+    case class LocationsGot(db: String, namespace: String, metric: String, locations: Seq[Location])
+        extends NSDbSerializable
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
     @JsonSubTypes(

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -106,6 +106,8 @@ object MessageProtocol {
     case object GetPublishers            extends NSDbSerializable
 
     case class NodeAlive(nodeId: String, nodeAddress: String) extends NSDbSerializable
+
+    case object GetTopology extends NSDbSerializable
   }
 
   /**
@@ -231,6 +233,9 @@ object MessageProtocol {
     case class PublisherUnSubscribed(nodeName: String)            extends NSDbSerializable
 
     case class MigrationStarted(inputPath: String) extends NSDbSerializable
+
+    case class NSDbNode(address: String, nodeId: String) extends NSDbSerializable
+    case class TopologyGot(nodes: Set[NSDbNode])         extends NSDbSerializable
   }
 
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/FileUtils.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/FileUtils.scala
@@ -33,7 +33,7 @@ import scala.collection.JavaConverters._
   */
 object FileUtils {
 
-  private val NODE_ID_EXTENSION = ".name"
+  private val NODE_ID_EXTENSION = "name"
   private val NODE_ID_LENGTH    = 10
   private val BUFFER_SIZE       = 4096
   private val buffer            = new Array[Byte](BUFFER_SIZE)

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/ApiResources.scala
@@ -35,7 +35,7 @@ class ApiResources(val publisherActor: ActorRef,
                    val writeCoordinator: ActorRef,
                    val metadataCoordinator: ActorRef,
                    val authorizationProvider: NSDbAuthorizationProvider)(override implicit val timeout: Timeout,
-                                                                         implicit val logger: LoggingAdapter,
+                                                                         override implicit val logger: LoggingAdapter,
                                                                          override implicit val ec: ExecutionContext,
                                                                          override implicit val formats: Formats)
     extends CommandApi

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
@@ -17,6 +17,7 @@
 package io.radicalbit.nsdb.web.routes
 
 import akka.actor.ActorRef
+import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.StatusCodes.{InternalServerError, NotFound}
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
 import akka.http.scaladsl.server.Directives._
@@ -52,6 +53,7 @@ trait CommandApi {
   implicit val timeout: Timeout
   implicit val formats: Formats
   implicit val ec: ExecutionContext
+  def logger: LoggingAdapter
 
   case class CommandRequestDatabase(db: String)
   case class CommandRequestNamespace(db: String, namespace: String)
@@ -82,8 +84,12 @@ trait CommandApi {
         onComplete(metadataCoordinator ? GetTopology) {
           case Success(topology: TopologyGot) =>
             complete(HttpEntity(ContentTypes.`application/json`, write(topology)))
-          case Success(_)  => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-          case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
+          case Success(wrongResponse) =>
+            logger.error(s"received unexpected response $wrongResponse")
+            complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+          case Failure(ex) =>
+            logger.error(ex, "unexpected error")
+            complete(HttpResponse(InternalServerError, entity = ex.getMessage))
         }
       }
     }
@@ -117,8 +123,12 @@ trait CommandApi {
                 onComplete(metadataCoordinator ? GetLocations(db, namespace, metric)) {
                   case Success(response: LocationsGot) =>
                     complete(HttpEntity(ContentTypes.`application/json`, write(response)))
-                  case Success(_)  => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-                  case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
+                  case Success(wrongResponse) =>
+                    logger.error(s"received unexpected response $wrongResponse")
+                    complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+                  case Failure(ex) =>
+                    logger.error(ex, "unexpected error")
+                    complete(HttpResponse(InternalServerError, entity = ex.getMessage))
                 }
               }
             }
@@ -144,8 +154,12 @@ trait CommandApi {
         onComplete(readCoordinator ? GetDbs) {
           case Success(DbsGot(dbs)) =>
             complete(HttpEntity(ContentTypes.`application/json`, write(ShowDbsResponse(dbs))))
-          case Success(_)  => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-          case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
+          case Success(wrongResponse) =>
+            logger.error(s"received unexpected response $wrongResponse")
+            complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+          case Failure(ex) =>
+            logger.error(ex, "unexpected error")
+            complete(HttpResponse(InternalServerError, entity = ex.getMessage))
         }
       }
     }
@@ -172,8 +186,12 @@ trait CommandApi {
             onComplete(readCoordinator ? GetNamespaces(db)) {
               case Success(NamespacesGot(_, namespaces)) =>
                 complete(HttpEntity(ContentTypes.`application/json`, write(ShowNamespacesResponse(namespaces))))
-              case Success(_)  => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-              case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
+              case Success(wrongResponse) =>
+                logger.error(s"received unexpected response $wrongResponse")
+                complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+              case Failure(ex) =>
+                logger.error(ex, "unexpected error")
+                complete(HttpResponse(InternalServerError, entity = ex.getMessage))
             }
           }
         }
@@ -207,8 +225,12 @@ trait CommandApi {
             withNamespaceAuthorization(db, namespace, true, authorizationProvider) {
               onComplete(writeCoordinator ? DeleteNamespace(db, namespace)) {
                 case Success(NamespaceDeleted(_, _)) => complete("Ok")
-                case Success(_)                      => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-                case Failure(ex)                     => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
+                case Success(wrongResponse) =>
+                  logger.error(s"received unexpected response $wrongResponse")
+                  complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+                case Failure(ex) =>
+                  logger.error(ex, "unexpected error")
+                  complete(HttpResponse(InternalServerError, entity = ex.getMessage))
               }
             }
           }
@@ -246,8 +268,12 @@ trait CommandApi {
                 onComplete(readCoordinator ? GetMetrics(db, namespace)) {
                   case Success(MetricsGot(_, _, metrics)) =>
                     complete(HttpEntity(ContentTypes.`application/json`, write(ShowMetricsResponse(metrics))))
-                  case Success(_)  => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-                  case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
+                  case Success(wrongResponse) =>
+                    logger.error(s"received unexpected response $wrongResponse")
+                    complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+                  case Failure(ex) =>
+                    logger.error(ex, "unexpected error")
+                    complete(HttpResponse(InternalServerError, entity = ex.getMessage))
                 }
               }
             }
@@ -310,12 +336,12 @@ trait CommandApi {
                       write(
                         DescribeMetricResponse(
                           schemaOpt
-                            .map(s =>
-                              s.fieldsMap.map {
-                                case (_, field) =>
-                                  Field(name = field.name, `type` = field.indexType.getClass.getSimpleName)
-                              }.toSet)
-                            .getOrElse(Set.empty),
+                            .fold(Set.empty[Field])(s =>
+                              s.fieldsMap.foldLeft(Set.empty[Field]) {
+                                case (acc: Set[Field], (_, schemaField)) =>
+                                  acc + Field(name = schemaField.name,
+                                              `type` = schemaField.indexType.getClass.getSimpleName)
+                            }),
                           Some(metricInfo)
                         )
                       )
@@ -323,8 +349,12 @@ trait CommandApi {
                   )
                 case Success(SchemaGot(_, _, _, None) :: _ :: Nil) =>
                   complete(HttpResponse(NotFound))
-                case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
-                case _           => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+                case Success(wrongResponse) =>
+                  logger.error(s"received unexpected response $wrongResponse")
+                  complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+                case Failure(ex) =>
+                  logger.error(ex, "unexpected error")
+                  complete(HttpResponse(InternalServerError, entity = ex.getMessage))
               }
             }
           }
@@ -360,8 +390,12 @@ trait CommandApi {
             withMetricAuthorization(db, namespace, metric, true, authorizationProvider) {
               onComplete(writeCoordinator ? DropMetric(db, namespace, metric)) {
                 case Success(MetricDropped(_, _, _)) => complete("Ok")
-                case Success(_)                      => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-                case Failure(ex)                     => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
+                case Success(wrongResponse) =>
+                  logger.error(s"received unexpected response $wrongResponse")
+                  complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+                case Failure(ex) =>
+                  logger.error(ex, "unexpected error")
+                  complete(HttpResponse(InternalServerError, entity = ex.getMessage))
               }
             }
           }

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
@@ -108,24 +108,24 @@ trait CommandApi {
       new ApiResponse(code = 500, message = "Internal server error")
     ))
   def locationsApi: Route = {
-      pathPrefix("locations") {
-        pathPrefix(Segment) { db =>
-          pathPrefix(Segment) { namespace =>
-            pathPrefix(Segment) { metric =>
-              (pathEnd & get) {
-                withMetricAuthorization(db, namespace, metric, false, authorizationProvider) {
-                  onComplete(metadataCoordinator ? GetLocations(db, namespace, metric)) {
-                    case Success(response: LocationsGot) =>
-                      complete(HttpEntity(ContentTypes.`application/json`, write(response)))
-                    case Success(_)  => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-                    case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
-                  }
+    pathPrefix("locations") {
+      pathPrefix(Segment) { db =>
+        pathPrefix(Segment) { namespace =>
+          pathPrefix(Segment) { metric =>
+            (pathEnd & get) {
+              withMetricAuthorization(db, namespace, metric, false, authorizationProvider) {
+                onComplete(metadataCoordinator ? GetLocations(db, namespace, metric)) {
+                  case Success(response: LocationsGot) =>
+                    complete(HttpEntity(ContentTypes.`application/json`, write(response)))
+                  case Success(_)  => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+                  case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
                 }
               }
             }
           }
         }
       }
+    }
   }
 
   @Api(value = "/dbs", produces = "application/json")
@@ -139,16 +139,16 @@ trait CommandApi {
       new ApiResponse(code = 500, message = "Internal server error")
     ))
   def showDbs: Route =
-      path("dbs") {
-        (pathEnd & get) {
-          onComplete(readCoordinator ? GetDbs) {
-            case Success(DbsGot(dbs)) =>
-              complete(HttpEntity(ContentTypes.`application/json`, write(ShowDbsResponse(dbs))))
-            case Success(_)  => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-            case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
-          }
+    path("dbs") {
+      (pathEnd & get) {
+        onComplete(readCoordinator ? GetDbs) {
+          case Success(DbsGot(dbs)) =>
+            complete(HttpEntity(ContentTypes.`application/json`, write(ShowDbsResponse(dbs))))
+          case Success(_)  => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+          case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
         }
       }
+    }
 
   @Api(value = "/{db}/namespaces", produces = "application/json")
   @Path("/{db}/namespaces")
@@ -165,19 +165,19 @@ trait CommandApi {
       new ApiResponse(code = 500, message = "Internal server error")
     ))
   def showNamespaces: Route =
-      pathPrefix(Segment) { db =>
-        path("namespaces") {
-          (pathEnd & get) {
-            withDbAuthorization(db, false, authorizationProvider) {
-              onComplete(readCoordinator ? GetNamespaces(db)) {
-                case Success(NamespacesGot(_, namespaces)) =>
-                  complete(HttpEntity(ContentTypes.`application/json`, write(ShowNamespacesResponse(namespaces))))
-                case Success(_)  => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-                case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
-              }
+    pathPrefix(Segment) { db =>
+      path("namespaces") {
+        (pathEnd & get) {
+          withDbAuthorization(db, false, authorizationProvider) {
+            onComplete(readCoordinator ? GetNamespaces(db)) {
+              case Success(NamespacesGot(_, namespaces)) =>
+                complete(HttpEntity(ContentTypes.`application/json`, write(ShowNamespacesResponse(namespaces))))
+              case Success(_)  => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+              case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
             }
           }
         }
+      }
     }
 
   @Api(value = "/{db}/{namespace}", produces = "application/json")
@@ -200,18 +200,18 @@ trait CommandApi {
       new ApiResponse(code = 500, message = "Internal server error")
     ))
   def dropNamespace: Route = {
-      pathPrefix(Segment) { db =>
-        pathPrefix(Segment) { namespace =>
-          pathEnd {
-            delete {
-              withNamespaceAuthorization(db, namespace, true, authorizationProvider) {
-                onComplete(writeCoordinator ? DeleteNamespace(db, namespace)) {
-                  case Success(NamespaceDeleted(_, _)) => complete("Ok")
-                  case Success(_)                      => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-                  case Failure(ex)                     => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
-                }
+    pathPrefix(Segment) { db =>
+      pathPrefix(Segment) { namespace =>
+        pathEnd {
+          delete {
+            withNamespaceAuthorization(db, namespace, true, authorizationProvider) {
+              onComplete(writeCoordinator ? DeleteNamespace(db, namespace)) {
+                case Success(NamespaceDeleted(_, _)) => complete("Ok")
+                case Success(_)                      => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+                case Failure(ex)                     => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
               }
             }
+          }
         }
       }
     }
@@ -237,22 +237,22 @@ trait CommandApi {
       new ApiResponse(code = 500, message = "Internal server error")
     ))
   def showMetrics: Route =
-      pathPrefix(Segment) { db =>
-        pathPrefix(Segment) { namespace =>
-          path("metrics") {
-            pathEnd {
-              get {
-                withNamespaceAuthorization(db, namespace, false, authorizationProvider) {
-                  onComplete(readCoordinator ? GetMetrics(db, namespace)) {
-                    case Success(MetricsGot(_, _, metrics)) =>
-                      complete(HttpEntity(ContentTypes.`application/json`, write(ShowMetricsResponse(metrics))))
-                    case Success(_)  => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-                    case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
-                  }
+    pathPrefix(Segment) { db =>
+      pathPrefix(Segment) { namespace =>
+        path("metrics") {
+          pathEnd {
+            get {
+              withNamespaceAuthorization(db, namespace, false, authorizationProvider) {
+                onComplete(readCoordinator ? GetMetrics(db, namespace)) {
+                  case Success(MetricsGot(_, _, metrics)) =>
+                    complete(HttpEntity(ContentTypes.`application/json`, write(ShowMetricsResponse(metrics))))
+                  case Success(_)  => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+                  case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
                 }
               }
             }
           }
+        }
       }
     }
 
@@ -278,57 +278,57 @@ trait CommandApi {
       new ApiResponse(code = 500, message = "Internal server error")
     ))
   def describeMetric: Route =
-      pathPrefix(Segment) { db =>
-        pathPrefix(Segment) { namespace =>
-          pathPrefix(Segment) { metric =>
-            (pathEnd & get) {
-              withMetricAuthorization(db, namespace, metric, false, authorizationProvider) {
-                onComplete(
-                  Future.sequence(
-                    Seq((readCoordinator ? GetSchema(db, namespace, metric)).mapTo[SchemaGot],
-                        (metadataCoordinator ? GetMetricInfo(db, namespace, metric)).mapTo[MetricInfoGot])
-                  )) {
-                  case Success(SchemaGot(_, _, _, Some(schema)) :: MetricInfoGot(_, _, _, metricInfo) :: Nil) =>
-                    complete(
-                      HttpEntity(
-                        ContentTypes.`application/json`,
-                        write(
-                          DescribeMetricResponse(
-                            schema.fieldsMap.map {
-                              case (_, field) =>
-                                Field(name = field.name, `type` = field.indexType.getClass.getSimpleName)
-                            }.toSet,
-                            metricInfo
-                          )
+    pathPrefix(Segment) { db =>
+      pathPrefix(Segment) { namespace =>
+        pathPrefix(Segment) { metric =>
+          (pathEnd & get) {
+            withMetricAuthorization(db, namespace, metric, false, authorizationProvider) {
+              onComplete(
+                Future.sequence(
+                  Seq((readCoordinator ? GetSchema(db, namespace, metric)).mapTo[SchemaGot],
+                      (metadataCoordinator ? GetMetricInfo(db, namespace, metric)).mapTo[MetricInfoGot])
+                )) {
+                case Success(SchemaGot(_, _, _, Some(schema)) :: MetricInfoGot(_, _, _, metricInfo) :: Nil) =>
+                  complete(
+                    HttpEntity(
+                      ContentTypes.`application/json`,
+                      write(
+                        DescribeMetricResponse(
+                          schema.fieldsMap.map {
+                            case (_, field) =>
+                              Field(name = field.name, `type` = field.indexType.getClass.getSimpleName)
+                          }.toSet,
+                          metricInfo
                         )
                       )
                     )
-                  case Success(SchemaGot(_, _, _, schemaOpt) :: MetricInfoGot(_, _, _, Some(metricInfo)) :: Nil) =>
-                    complete(
-                      HttpEntity(
-                        ContentTypes.`application/json`,
-                        write(
-                          DescribeMetricResponse(
-                            schemaOpt
-                              .map(s =>
-                                s.fieldsMap.map {
-                                  case (_, field) =>
-                                    Field(name = field.name, `type` = field.indexType.getClass.getSimpleName)
-                                }.toSet)
-                              .getOrElse(Set.empty),
-                            Some(metricInfo)
-                          )
+                  )
+                case Success(SchemaGot(_, _, _, schemaOpt) :: MetricInfoGot(_, _, _, Some(metricInfo)) :: Nil) =>
+                  complete(
+                    HttpEntity(
+                      ContentTypes.`application/json`,
+                      write(
+                        DescribeMetricResponse(
+                          schemaOpt
+                            .map(s =>
+                              s.fieldsMap.map {
+                                case (_, field) =>
+                                  Field(name = field.name, `type` = field.indexType.getClass.getSimpleName)
+                              }.toSet)
+                            .getOrElse(Set.empty),
+                          Some(metricInfo)
                         )
                       )
                     )
-                  case Success(SchemaGot(_, _, _, None) :: _ :: Nil) =>
-                    complete(HttpResponse(NotFound))
-                  case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
-                  case _           => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-                }
+                  )
+                case Success(SchemaGot(_, _, _, None) :: _ :: Nil) =>
+                  complete(HttpResponse(NotFound))
+                case Failure(ex) => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
+                case _           => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
               }
             }
           }
+        }
       }
     }
 
@@ -353,25 +353,25 @@ trait CommandApi {
       new ApiResponse(code = 500, message = "Internal server error")
     ))
   def dropMetric: Route =
-      pathPrefix(Segment) { db =>
-        pathPrefix(Segment) { namespace =>
-          pathPrefix(Segment) { metric =>
-            delete {
-              withMetricAuthorization(db, namespace, metric, true, authorizationProvider) {
-                onComplete(writeCoordinator ? DropMetric(db, namespace, metric)) {
-                  case Success(MetricDropped(_, _, _)) => complete("Ok")
-                  case Success(_)                      => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
-                  case Failure(ex)                     => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
-                }
+    pathPrefix(Segment) { db =>
+      pathPrefix(Segment) { namespace =>
+        pathPrefix(Segment) { metric =>
+          delete {
+            withMetricAuthorization(db, namespace, metric, true, authorizationProvider) {
+              onComplete(writeCoordinator ? DropMetric(db, namespace, metric)) {
+                case Success(MetricDropped(_, _, _)) => complete("Ok")
+                case Success(_)                      => complete(HttpResponse(InternalServerError, entity = "Unknown reason"))
+                case Failure(ex)                     => complete(HttpResponse(InternalServerError, entity = ex.getMessage))
               }
             }
           }
         }
+      }
     }
 
   def commandsApi: Route =
     pathPrefix("commands") {
       topologyApi ~ locationsApi ~ showDbs ~ showNamespaces ~ showMetrics ~ dropNamespace ~ describeMetric ~ dropMetric
-  }
+    }
 
 }

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiSpec.scala
@@ -17,6 +17,7 @@
 package io.radicalbit.nsdb.web
 
 import akka.actor.{Actor, ActorRef, Props}
+import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.Route
@@ -78,6 +79,8 @@ class CommandApiSpec extends NSDbFlatSpec with ScalatestRouteTest with CommandAp
 
   override implicit val formats: DefaultFormats = DefaultFormats
   override implicit val timeout: Timeout        = 5 seconds
+
+  override implicit val logger: LoggingAdapter = system.log
 
   val testSecuredRoutes = Route.seal(
     commandsApi

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiSpec.scala
@@ -24,6 +24,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.util.Timeout
 import io.radicalbit.nsdb.actor.FakeReadCoordinator
 import io.radicalbit.nsdb.common.model.MetricInfo
+import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.test.NSDbFlatSpec
@@ -35,7 +36,7 @@ import org.json4s.jackson.Serialization.write
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-object CommandApiTest {
+object CommandApiSpec {
 
   class FakeWriteCoordinator extends Actor {
     override def receive: Receive = {
@@ -46,6 +47,10 @@ object CommandApiTest {
 
   class FakeMetadataCoordinator extends Actor {
     override def receive: Receive = {
+      case GetTopology =>
+        sender() ! TopologyGot(Set(NSDbNode("address", "id")))
+      case GetLocations(db, namespace, metric) =>
+        sender() ! LocationsGot(db, namespace, metric, Seq(Location.empty))
       case GetMetricInfo(db, namespace, "metricWithoutInfo") =>
         sender() ! MetricInfoGot(db, namespace, "metricWithoutInfo", None)
       case GetMetricInfo(db, namespace, "nonExistingMetric") =>
@@ -56,10 +61,10 @@ object CommandApiTest {
   }
 }
 
-class CommandApiTest extends NSDbFlatSpec with ScalatestRouteTest with CommandApi {
+class CommandApiSpec extends NSDbFlatSpec with ScalatestRouteTest with CommandApi {
 
   import FakeReadCoordinator.Data._
-  import io.radicalbit.nsdb.web.CommandApiTest._
+  import io.radicalbit.nsdb.web.CommandApiSpec._
 
   override def readCoordinator: ActorRef = system.actorOf(Props[FakeReadCoordinator])
 
@@ -78,7 +83,23 @@ class CommandApiTest extends NSDbFlatSpec with ScalatestRouteTest with CommandAp
     commandsApi
   )
 
-  "CommandsApi show dbs" should "return dbs" in {
+  "CommandApi" should "get cluster topology" in {
+    Get("/commands/topology").withHeaders(RawHeader("testHeader", "testHeader")) ~> testSecuredRoutes ~> check {
+      status shouldBe OK
+      val entity = entityAs[String]
+      entity shouldBe write(TopologyGot(Set(NSDbNode("address", "id"))))
+    }
+  }
+
+  "CommandApi" should "get locations for a metric" in {
+    Get("/commands/locations/db/namespace/metric").withHeaders(RawHeader("testHeader", "testHeader")) ~> testSecuredRoutes ~> check {
+      status shouldBe OK
+      val entity = entityAs[String]
+      entity shouldBe write(LocationsGot("db", "namespace", "metric", Seq(Location.empty)))
+    }
+  }
+
+  "CommandsApi" should "show dbs" in {
     Get("/commands/dbs").withHeaders(RawHeader("testHeader", "testHeader")) ~> testSecuredRoutes ~> check {
       status shouldBe OK
       val entity = entityAs[String]
@@ -86,7 +107,7 @@ class CommandApiTest extends NSDbFlatSpec with ScalatestRouteTest with CommandAp
     }
   }
 
-  "CommandsApi show namespaces" should "return namespaces" in {
+  "CommandsApi" should "show namespaces" in {
     Get("/commands/db1/namespaces").withHeaders(RawHeader("testHeader", "testHeader")) ~> testSecuredRoutes ~> check {
       status shouldBe OK
       val entity = entityAs[String]
@@ -94,7 +115,7 @@ class CommandApiTest extends NSDbFlatSpec with ScalatestRouteTest with CommandAp
     }
   }
 
-  "CommandsApi show metrics" should "return namespaces" in {
+  "CommandsApi" should "show metrics" in {
     Get("/commands/db1/namespace1/metrics").withHeaders(RawHeader("testHeader", "testHeader")) ~> testSecuredRoutes ~> check {
       status shouldBe OK
       val entity = entityAs[String]
@@ -102,7 +123,7 @@ class CommandApiTest extends NSDbFlatSpec with ScalatestRouteTest with CommandAp
     }
   }
 
-  "CommandsApi describe existing metric " should "return description" in {
+  "CommandsApi" should "describe existing metric" in {
     Get("/commands/db1/namespace1/metricWithoutInfo").withHeaders(RawHeader("testHeader", "testHeader")) ~> testSecuredRoutes ~> check {
       status shouldBe OK
       val entity = entityAs[String]
@@ -128,7 +149,7 @@ class CommandApiTest extends NSDbFlatSpec with ScalatestRouteTest with CommandAp
     }
   }
 
-  "CommandsApi describe metric initialized but without schema " should "return description" in {
+  "CommandsApi" should "describe initialized metric but without schema" in {
     Get("/commands/db1/namespace1/metricWithoutSchema").withHeaders(RawHeader("testHeader", "testHeader")) ~> testSecuredRoutes ~> check {
       status shouldBe OK
       val entity = entityAs[String]
@@ -140,19 +161,19 @@ class CommandApiTest extends NSDbFlatSpec with ScalatestRouteTest with CommandAp
     }
   }
 
-  "CommandsApi describe not existing metric " should "return NotFound" in {
+  "CommandsApi" should "return NotFound for a non existing metric" in {
     Get("/commands/db1/namespace1/nonExistingMetric").withHeaders(RawHeader("testHeader", "testHeader")) ~> testSecuredRoutes ~> check {
       status shouldBe NotFound
     }
   }
 
-  "CommandsApi drop namespace" should " drop" in {
+  "CommandsApi" should "drop a namespace" in {
     Delete("/commands/db1/namespace1").withHeaders(RawHeader("testHeader", "testHeader")) ~> testSecuredRoutes ~> check {
       status shouldBe OK
     }
   }
 
-  "CommandsApi drop metric" should " drop" in {
+  "CommandsApi" should "drop metric" in {
     Delete("/commands/db1/namespace1/metric1").withHeaders(RawHeader("testHeader", "testHeader")) ~> testSecuredRoutes ~> check {
       status shouldBe OK
     }


### PR DESCRIPTION
This PR aims at introducing 2 apis:

* get cluster topology api: returns all cluster members with the Akka address and the NSDb unique identifier
* get locations api: given a coordinate triplet all the locations and replicas are returned.

A little bug fix and log improvements are provided as well.