### PR TITLE
Top Level Actors Hierarchy

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
@@ -16,17 +16,16 @@
 
 package io.radicalbit.nsdb.cluster
 
-import java.util.concurrent.TimeUnit
 import akka.actor._
 import akka.cluster.Cluster
-import akka.cluster.ddata.DistributedData
 import akka.cluster.singleton._
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
-import akka.remote.RemoteScope
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.actor._
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.globalTimeout
+
+import java.util.concurrent.TimeUnit
 
 /**
   * Creates top level actors.
@@ -38,11 +37,8 @@ trait NSDbActors {
   implicit lazy val timeout: Timeout =
     Timeout(system.settings.config.getDuration(globalTimeout, TimeUnit.SECONDS), TimeUnit.SECONDS)
 
-  private def createNodeActorGuardianName(nodeId: String, nodeName: String): String =
-    s"guardian_${nodeId}_${nodeName}"
-
-  private def createNodeActorGuardianPath(nodeId: String, nodeName: String): String =
-    s"/user/${createNodeActorGuardianName(nodeId, nodeName)}"
+  private def createNodeActorGuardianName(nodeName: String): String =
+    s"guardian_${nodeName}"
 
   def initTopLevelActors(): Unit = {
     AkkaManagement(system).start()
@@ -61,11 +57,6 @@ trait NSDbActors {
       name = "databaseActorGuardianProxy"
     )
 
-//    DistributedData(system).replicator
-
-//    system
-
-    system.actorOf(Props[NodeActorsGuardian])
-//    system.actorOf(Props[ClusterListener], name = s"cluster-listener_${createNodeName(Cluster(system).selfMember)}")
+    system.actorOf(Props[NodeActorsGuardian], createNodeActorGuardianName(createNodeName(Cluster(system).selfMember)))
   }
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/NSDbActors.scala
@@ -23,6 +23,7 @@ import akka.cluster.ddata.DistributedData
 import akka.cluster.singleton._
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
+import akka.remote.RemoteScope
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.actor._
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel.globalTimeout
@@ -36,6 +37,12 @@ trait NSDbActors {
 
   implicit lazy val timeout: Timeout =
     Timeout(system.settings.config.getDuration(globalTimeout, TimeUnit.SECONDS), TimeUnit.SECONDS)
+
+  private def createNodeActorGuardianName(nodeId: String, nodeName: String): String =
+    s"guardian_${nodeId}_${nodeName}"
+
+  private def createNodeActorGuardianPath(nodeId: String, nodeName: String): String =
+    s"/user/${createNodeActorGuardianName(nodeId, nodeName)}"
 
   def initTopLevelActors(): Unit = {
     AkkaManagement(system).start()
@@ -54,8 +61,11 @@ trait NSDbActors {
       name = "databaseActorGuardianProxy"
     )
 
-    DistributedData(system).replicator
+//    DistributedData(system).replicator
 
-    system.actorOf(Props[ClusterListener], name = s"cluster-listener_${createNodeName(Cluster(system).selfMember)}")
+//    system
+
+    system.actorOf(Props[NodeActorsGuardian])
+//    system.actorOf(Props[ClusterListener], name = s"cluster-listener_${createNodeName(Cluster(system).selfMember)}")
   }
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
@@ -16,9 +16,6 @@
 
 package io.radicalbit.nsdb.cluster.actor
 
-import java.nio.file.{Files, NoSuchFileException, Paths}
-import java.util.concurrent.TimeUnit
-
 import akka.actor._
 import akka.cluster.ClusterEvent._
 import akka.cluster.metrics.{ClusterMetricsChanged, ClusterMetricsExtension, Metric, NodeMetrics}
@@ -27,7 +24,6 @@ import akka.cluster.pubsub.DistributedPubSubMediator.{Publish, Subscribe}
 import akka.cluster.{Cluster, Member}
 import akka.event.LoggingAdapter
 import akka.pattern.ask
-import akka.remote.RemoteScope
 import akka.util.Timeout
 import io.radicalbit.nsdb.cluster.PubSubTopics._
 import io.radicalbit.nsdb.cluster._
@@ -51,6 +47,8 @@ import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{
 }
 import io.radicalbit.nsdb.util.{ErrorManagementUtils, FileUtils, FutureRetryUtility}
 
+import java.nio.file.{Files, NoSuchFileException, Paths}
+import java.util.concurrent.TimeUnit
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -112,13 +110,6 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
 
   private def createNodeActorGuardianPath(nodeId: String, nodeName: String): String =
     s"/user/${createNodeActorGuardianName(nodeId, nodeName)}"
-
-//  protected def createNodeActorsGuardian(): ActorRef = {
-//    context.system.actorOf(
-//      NodeActorsGuardian.props(self, nodeId).withDeploy(Deploy(scope = RemoteScope(cluster.selfMember.address))),
-//      name = createNodeActorGuardianName(nodeId, selfNodeName)
-//    )
-//  }
 
   protected def retrieveLocationsToAdd: List[LocationWithCoordinates] =
     FileUtils.getLocationsFromFilesystem(indexPath, nodeId)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
@@ -155,7 +155,7 @@ abstract class AbstractClusterListener extends Actor with ActorLogging with Futu
     case MemberUp(member) if member == cluster.selfMember =>
       log.info(s"Member with nodeId $nodeId and address ${member.address} is Up")
 
-      val nodeActorsGuardian = context.parent // createNodeActorsGuardian()
+      val nodeActorsGuardian = context.parent
 
       (for {
         children @ NodeChildActorsGot(metadataCoordinator, _, _, _) <- (nodeActorsGuardian ? GetNodeChildActors)

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/MetadataRestoreSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/MetadataRestoreSpec.scala
@@ -7,7 +7,7 @@ import akka.testkit.ImplicitSender
 import com.typesafe.config.ConfigFactory
 import io.radicalbit.nsdb.STMultiNodeSpec
 import io.radicalbit.nsdb.cluster.actor.MetadataSpec.{node1, node2}
-import io.radicalbit.nsdb.cluster.actor.{ClusterListenerTestActor, DatabaseActorsGuardian}
+import io.radicalbit.nsdb.cluster.actor.{ClusterListenerTestActor, DatabaseActorsGuardian, NodeActorGuardianForTest}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.ExecuteRestoreMetadata
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.MetadataRestored
 import io.radicalbit.nsdb.common.model.MetricInfo
@@ -39,9 +39,12 @@ class MetadataRestoreSpec extends MultiNodeSpec(MetadataRestoreSpec) with STMult
   private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/metadata-coordinator_${nodeName}_$nodeName"
   private def schemaCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/schema-coordinator_${nodeName}_$nodeName"
 
- system.actorOf(Props[DatabaseActorsGuardian], "guardian")
+  system.actorOf(Props[DatabaseActorsGuardian], "guardian")
 
-  system.actorOf(ClusterListenerTestActor.props(), name = "clusterListener")
+  val selfMember = cluster.selfMember
+  val nodeName   = s"${selfMember.address.host.getOrElse("noHost")}_${selfMember.address.port.getOrElse(2552)}"
+  val nodeActorGuardian = system.actorOf(Props[NodeActorGuardianForTest], name = s"guardian_${nodeName}_$nodeName")
+//  system.actorOf(ClusterListenerTestActor.props(), name = "clusterListener")
 
   "Metadata system" must {
 

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/MetadataRestoreSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/MetadataRestoreSpec.scala
@@ -1,13 +1,13 @@
 package io.radicalbit.nsdb.cluster
 
-import akka.actor.{ActorSelection, Props}
-import akka.cluster.MemberStatus
+import akka.actor.{ActorRef, ActorSelection, Props}
+import akka.cluster.{Member, MemberStatus}
 import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec}
 import akka.testkit.ImplicitSender
 import com.typesafe.config.ConfigFactory
 import io.radicalbit.nsdb.STMultiNodeSpec
 import io.radicalbit.nsdb.cluster.actor.MetadataSpec.{node1, node2}
-import io.radicalbit.nsdb.cluster.actor.{ClusterListenerTestActor, DatabaseActorsGuardian, NodeActorGuardianForTest}
+import io.radicalbit.nsdb.cluster.actor.{DatabaseActorsGuardian, NodeActorGuardianForTest}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands.ExecuteRestoreMetadata
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events.MetadataRestored
 import io.radicalbit.nsdb.common.model.MetricInfo
@@ -41,10 +41,9 @@ class MetadataRestoreSpec extends MultiNodeSpec(MetadataRestoreSpec) with STMult
 
   system.actorOf(Props[DatabaseActorsGuardian], "guardian")
 
-  val selfMember = cluster.selfMember
+  val selfMember: Member = cluster.selfMember
   val nodeName   = s"${selfMember.address.host.getOrElse("noHost")}_${selfMember.address.port.getOrElse(2552)}"
-  val nodeActorGuardian = system.actorOf(Props[NodeActorGuardianForTest], name = s"guardian_${nodeName}_$nodeName")
-//  system.actorOf(ClusterListenerTestActor.props(), name = "clusterListener")
+  val nodeActorGuardian: ActorRef = system.actorOf(Props[NodeActorGuardianForTest], name = s"guardian_${nodeName}_$nodeName")
 
   "Metadata system" must {
 

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
@@ -62,11 +62,6 @@ class NodeActorsGuardianForTest(val resultActor: ActorRef, val testType: TestTyp
 }
 
 class ClusterListenerWithMockedChildren(override val resultActor: ActorRef, override val testType: TestType) extends ClusterListenerTestActor {
-//  val nodeActorsGuardianForTest =
-//          context.actorOf(Props(new NodeActorsGuardianForTest), name = s"guardian_${selfNodeName}")
-
-//          override def createNodeActorsGuardian(): ActorRef = nodeActorsGuardianForTest
-
   override def onSuccessBehaviour(readCoordinator: ActorRef,
                                   writeCoordinator: ActorRef,
                                   metadataCoordinator: ActorRef,

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
@@ -108,7 +108,6 @@ class ClusterListenerSpec extends MultiNodeSpec(ClusterListenerSpecConfig) with 
     "successfully create a NsdbNodeEndpoint when a new member in the cluster is Up" in {
       val resultActor = TestProbe("resultActor")
       cluster.system.actorOf(Props(new NodeActorsGuardianForTest(resultActor.testActor, SuccessTest)))
-//      cluster.system.actorOf(Props(new ClusterListenerWithMockedChildren(resultActor.testActor, SuccessTest)))
       cluster.join(node(node1).address)
       cluster.join(node(node2).address)
       enterBarrier(5 seconds, "nodes joined")
@@ -118,7 +117,6 @@ class ClusterListenerSpec extends MultiNodeSpec(ClusterListenerSpecConfig) with 
     "return a failure and leave the cluster" in {
       val resultActor = TestProbe("resultActor")
       cluster.system.actorOf(Props(new NodeActorsGuardianForTest(resultActor.testActor, FailureTest)))
-//      cluster.system.actorOf(Props(new ClusterListenerWithMockedChildren(resultActor.testActor, FailureTest)))
       cluster.join(node(node1).address)
       cluster.join(node(node2).address)
       enterBarrier(5 seconds, "nodes joined")
@@ -129,8 +127,6 @@ class ClusterListenerSpec extends MultiNodeSpec(ClusterListenerSpecConfig) with 
       val resultActor = TestProbe("resultActor")
       val clusterListener =
         cluster.system.actorOf(Props(new NodeActorsGuardianForTest(resultActor.testActor, FailureTest)))
-//        cluster.system.actorOf(Props(new ClusterListenerWithMockedChildren(resultActor.testActor, FailureTest)),
-//                               name = "clusterListener")
       clusterListener ! UnreachableMember(cluster.selfMember)
       awaitAssert(resultActor.expectMsg("Failure"))
     }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerSpec.scala
@@ -47,7 +47,10 @@ class WriteCoordinatorForTest extends Actor with ActorLogging {
   }
 }
 
-class NodeActorsGuardianForTest extends Actor with ActorLogging {
+class NodeActorsGuardianForTest(val resultActor: ActorRef, val testType: TestType) extends Actor with ActorLogging {
+
+  context.actorOf(Props(new ClusterListenerWithMockedChildren(resultActor, testType)))
+
   private lazy val metaDataCoordinator = context.actorOf(Props(new MetaDataCoordinatorForTest))
   private lazy val writeCoordinator    = context.actorOf(Props(new WriteCoordinatorForTest))
   private lazy val readCoordinator     = context.actorOf(Props(new ReadCoordinatorForTest))
@@ -59,10 +62,10 @@ class NodeActorsGuardianForTest extends Actor with ActorLogging {
 }
 
 class ClusterListenerWithMockedChildren(override val resultActor: ActorRef, override val testType: TestType) extends ClusterListenerTestActor {
-  val nodeActorsGuardianForTest =
-          context.actorOf(Props(new NodeActorsGuardianForTest), name = s"guardian_${selfNodeName}")
+//  val nodeActorsGuardianForTest =
+//          context.actorOf(Props(new NodeActorsGuardianForTest), name = s"guardian_${selfNodeName}")
 
-          override def createNodeActorsGuardian(): ActorRef = nodeActorsGuardianForTest
+//          override def createNodeActorsGuardian(): ActorRef = nodeActorsGuardianForTest
 
   override def onSuccessBehaviour(readCoordinator: ActorRef,
                                   writeCoordinator: ActorRef,
@@ -88,6 +91,7 @@ object ClusterListenerSpecConfig extends MultiNodeConfig {
                                            |    delay = 1 second
                                            |    n-retries = 2
                                            |  }
+                                           |  heartbeat.interval = 10 seconds
                                            |  global.timeout = 30 seconds
                                            |}
                                            |""".stripMargin))
@@ -103,7 +107,8 @@ class ClusterListenerSpec extends MultiNodeSpec(ClusterListenerSpecConfig) with 
   "ClusterListener" must {
     "successfully create a NsdbNodeEndpoint when a new member in the cluster is Up" in {
       val resultActor = TestProbe("resultActor")
-      cluster.system.actorOf(Props(new ClusterListenerWithMockedChildren(resultActor.testActor, SuccessTest)))
+      cluster.system.actorOf(Props(new NodeActorsGuardianForTest(resultActor.testActor, SuccessTest)))
+//      cluster.system.actorOf(Props(new ClusterListenerWithMockedChildren(resultActor.testActor, SuccessTest)))
       cluster.join(node(node1).address)
       cluster.join(node(node2).address)
       enterBarrier(5 seconds, "nodes joined")
@@ -112,7 +117,8 @@ class ClusterListenerSpec extends MultiNodeSpec(ClusterListenerSpecConfig) with 
 
     "return a failure and leave the cluster" in {
       val resultActor = TestProbe("resultActor")
-      cluster.system.actorOf(Props(new ClusterListenerWithMockedChildren(resultActor.testActor, FailureTest)))
+      cluster.system.actorOf(Props(new NodeActorsGuardianForTest(resultActor.testActor, FailureTest)))
+//      cluster.system.actorOf(Props(new ClusterListenerWithMockedChildren(resultActor.testActor, FailureTest)))
       cluster.join(node(node1).address)
       cluster.join(node(node2).address)
       enterBarrier(5 seconds, "nodes joined")
@@ -122,8 +128,9 @@ class ClusterListenerSpec extends MultiNodeSpec(ClusterListenerSpecConfig) with 
     "correctly handle 'UnreachableMember' msg" in {
       val resultActor = TestProbe("resultActor")
       val clusterListener =
-        cluster.system.actorOf(Props(new ClusterListenerWithMockedChildren(resultActor.testActor, FailureTest)),
-                               name = "clusterListener")
+        cluster.system.actorOf(Props(new NodeActorsGuardianForTest(resultActor.testActor, FailureTest)))
+//        cluster.system.actorOf(Props(new ClusterListenerWithMockedChildren(resultActor.testActor, FailureTest)),
+//                               name = "clusterListener")
       clusterListener ! UnreachableMember(cluster.selfMember)
       awaitAssert(resultActor.expectMsg("Failure"))
     }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -13,6 +13,7 @@ import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.extension.NSDbClusterSnapshot
 import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.model.{Location, LocationWithCoordinates}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.{GetNodeChildActors, NodeChildActorsGot}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -47,7 +48,9 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
 
   implicit val timeout: Timeout = Timeout(5.seconds)
 
-  system.actorOf(ClusterListenerTestActor.props(), name = "clusterListener")
+  val selfMember = cluster.selfMember
+  val nodeName   = s"${selfMember.address.host.getOrElse("noHost")}_${selfMember.address.port.getOrElse(2552)}"
+  val nodeActorGuardian = system.actorOf(Props[NodeActorGuardianForTest], name = s"guardian_${nodeName}_$nodeName")
 
   private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/metadata-coordinator_${nodeName}_$nodeName"
 
@@ -59,6 +62,8 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
       awaitAssert {
         cluster.state.members.count(_.status == MemberStatus.Up) shouldBe 2
         NSDbClusterSnapshot(system).nodes.size shouldBe 2
+        nodeActorGuardian ! GetNodeChildActors
+        expectMsgType[NodeChildActorsGot]
       }
 
       enterBarrier("joined")

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -1,7 +1,7 @@
 package io.radicalbit.nsdb.cluster.actor
 
-import akka.actor.Props
-import akka.cluster.MemberStatus
+import akka.actor.{ActorRef, Props}
+import akka.cluster.{Member, MemberStatus}
 import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec}
 import akka.testkit.ImplicitSender
 import akka.util.Timeout
@@ -44,13 +44,13 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
 
   override def initialParticipants = roles.size
 
-  val guardian = system.actorOf(Props[DatabaseActorsGuardian], "guardian")
+  val guardian: ActorRef = system.actorOf(Props[DatabaseActorsGuardian], "guardian")
 
   implicit val timeout: Timeout = Timeout(5.seconds)
 
-  val selfMember = cluster.selfMember
+  val selfMember: Member = cluster.selfMember
   val nodeName   = s"${selfMember.address.host.getOrElse("noHost")}_${selfMember.address.port.getOrElse(2552)}"
-  val nodeActorGuardian = system.actorOf(Props[NodeActorGuardianForTest], name = s"guardian_${nodeName}_$nodeName")
+  val nodeActorGuardian: ActorRef = system.actorOf(Props[NodeActorGuardianForTest], name = s"guardian_${nodeName}_$nodeName")
 
   private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/metadata-coordinator_${nodeName}_$nodeName"
 

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/NodeActorGuardianForTest.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/NodeActorGuardianForTest.scala
@@ -1,0 +1,10 @@
+package io.radicalbit.nsdb.cluster.actor
+import akka.actor.ActorRef
+
+class NodeActorGuardianForTest extends NodeActorsGuardian {
+
+  override protected lazy val nodeId: String = selfNodeName
+
+  override def createClusterListener: ActorRef = context.actorOf(ClusterListenerTestActor.props(), name = "clusterListener")
+
+}


### PR DESCRIPTION
This PR is for improving the top levl actor creation and hierarchy.

In particular, `ClusterListenerActor` has been transformed into a child of `DatabaseActorGuardian` which is a new top level actor. All the coordinator are its siblings.

Basically the new hierarchy might be summarized as follows:

* NodeActorGuardian
  *  ClusterListener
  * [*]Coordinator
  * [*]DataActor

NodeActorGuardian will have (in future developments) the responsibility to provide a tailored supervision strategy to all the coordinators, data and listener actors.