### PR TITLE
Custom supervision strategy

### DIFF
--- a/nsdb-cluster/src/multi-jvm/resources/application.conf
+++ b/nsdb-cluster/src/multi-jvm/resources/application.conf
@@ -1,5 +1,9 @@
 
-akka.loglevel = ERROR
+akka{
+    loglevel = ERROR
+    log-dead-letters = 1
+    log-dead-letters-during-shutdown = off
+}
 akka.actor {
   provider = "cluster"
 
@@ -11,7 +15,6 @@ akka.actor {
     mailbox-type = "akka.dispatch.UnboundedControlAwareMailbox"
   }
 }
-akka.log-dead-letters-during-shutdown = off
 nsdb {
 
   retry-policy {
@@ -54,7 +57,7 @@ nsdb {
   }
 
   write {
-    retry-attempts = 10
+    retry-attempts = 3
   }
 
   storage {

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/NodeActorGuardianForTest.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/NodeActorGuardianForTest.scala
@@ -1,9 +1,11 @@
 package io.radicalbit.nsdb.cluster.actor
-import akka.actor.ActorRef
+import akka.actor.{ActorContext, ActorRef}
 
 class NodeActorGuardianForTest extends NodeActorsGuardian {
 
   override protected lazy val nodeId: String = selfNodeName
+
+  override def shutdownBehaviour(context: ActorContext, child: ActorRef) : Unit = context.stop(child)
 
   override def createClusterListener: ActorRef = context.actorOf(ClusterListenerTestActor.props(), name = "clusterListener")
 

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/SupervisionSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/SupervisionSpec.scala
@@ -1,0 +1,169 @@
+package io.radicalbit.nsdb.cluster.actor
+
+import akka.actor.{Actor, ActorRef, Props}
+import akka.cluster.{Member, MemberStatus}
+import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec}
+import akka.testkit.{ImplicitSender, TestProbe}
+import com.typesafe.config.ConfigFactory
+import io.radicalbit.nsdb.STMultiNodeSpec
+import io.radicalbit.nsdb.cluster.extension.NSDbClusterSnapshot
+import io.radicalbit.nsdb.common.statement.{AllFields, SelectSQLStatement}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Commands.ExecuteStatement
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.SelectStatementExecuted
+
+import java.util.UUID
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class SupervisionSpecMultiJvmNode1 extends SupervisionSpec
+class SupervisionSpecMultiJvmNode2 extends SupervisionSpec
+class SupervisionSpecMultiJvmNode3 extends SupervisionSpec
+
+object SupervisionSpecConfig extends MultiNodeConfig {
+  val node1 = role("node-1")
+  val node2 = role("node-2")
+  val node3 = role("node-3")
+
+  commonConfig(ConfigFactory.parseResources("application.conf"))
+
+  nodeConfig(node1)(ConfigFactory.parseString(
+    """
+       |akka.remote.artery.canonical.port = 25520
+    """.stripMargin))
+
+  nodeConfig(node2)(ConfigFactory.parseString(
+    """
+      |akka.remote.artery.canonical.port = 25530
+    """.stripMargin))
+
+  nodeConfig(node3)(ConfigFactory.parseString(
+    """
+      |akka.remote.artery.canonical.port = 25540
+    """.stripMargin))
+
+
+}
+
+class NodeActorGuardianForTestWithFailingCoordinator(probe: ActorRef) extends NodeActorGuardianForTest {
+
+  class FailingReadCoordinator(probe: ActorRef) extends Actor {
+
+    val volatileDb = UUID.randomUUID().toString
+
+    override def preStart(): Unit =
+      log.error(s"failing read coordinator started at path ${self.path}")
+
+    override def receive: Receive = {
+      case "GetVolatileId" => sender() ! volatileDb
+      case ExecuteStatement(statement, _) if statement.db == "failingDb" =>
+        probe ! "Failure"
+        throw new RuntimeException("it's failing")
+      case ExecuteStatement(statement, _)  =>
+        sender ! SelectStatementExecuted(statement, Seq.empty, null)
+    }
+  }
+
+  override protected lazy val readCoordinator: ActorRef =
+    context.actorOf(Props( new FailingReadCoordinator(probe)), s"read-coordinator_$actorNameSuffix")
+
+}
+
+class SupervisionSpec extends MultiNodeSpec(SupervisionSpecConfig) with STMultiNodeSpec with ImplicitSender {
+
+  import SupervisionSpecConfig._
+
+  def initialParticipants: Int = roles.size
+
+  val selfMember: Member = cluster.selfMember
+  val nodeName   = s"${selfMember.address.host.getOrElse("noHost")}_${selfMember.address.port.getOrElse(2552)}"
+
+  val probe = TestProbe()
+
+  private def readCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/read-coordinator_${nodeName}_$nodeName"
+
+  val correctStatement = ExecuteStatement(SelectSQLStatement(
+    db = "db",
+    namespace = "namespace",
+    metric = "metric",
+    distinct = false,
+    fields = AllFields(),
+    None
+  ))
+
+  val errorStatement = ExecuteStatement(SelectSQLStatement(
+    db = "failingDb",
+    namespace = "namespace",
+    metric = "metric",
+    distinct = false,
+    fields = AllFields(),
+    None
+  ))
+
+  "ClusterListener" must {
+    "successfully set up a cluster with a potentially failing node" in {
+
+      runOn(node1, node2, node3) {
+        system.actorOf(Props(new NodeActorGuardianForTestWithFailingCoordinator(probe.ref)), name = s"guardian_${nodeName}_$nodeName")
+      }
+
+      cluster.join(node(node1).address)
+      cluster.join(node(node1).address)
+      cluster.join(node(node1).address)
+
+      awaitAssert {
+        cluster.state.members.count(_.status == MemberStatus.Up) shouldBe 3
+        NSDbClusterSnapshot(system).nodes.size shouldBe 3
+      }
+      enterBarrier(5 seconds, "nodes joined")
+    }
+
+    "handle errors and properly resume child actor" in {
+      val readCoordinator = system.actorSelection(readCoordinatorPath(nodeName))
+
+      readCoordinator ! correctStatement
+
+      expectMsgType[SelectStatementExecuted]
+
+      readCoordinator ! "GetVolatileId"
+
+      val volatileId = expectMsgType[String]
+
+      readCoordinator ! errorStatement
+
+      probe.expectMsg("Failure")
+      probe.expectNoMessage(5 seconds)
+
+
+      expectNoMessage(5 seconds)
+
+      readCoordinator ! correctStatement
+
+      expectMsgType[SelectStatementExecuted]
+
+      readCoordinator ! "GetVolatileId"
+
+      expectMsgType[String] shouldBe volatileId
+    }
+
+    "handle errors and terminate child actor when resumes exceeds the limits" in {
+        system.actorSelection(readCoordinatorPath(nodeName)).resolveOne(1 seconds).onComplete {
+          case Success(readCoordinator) =>
+            readCoordinator ! errorStatement
+            readCoordinator ! errorStatement
+            readCoordinator ! errorStatement
+
+            probe.expectMsg("Failure")
+            probe.expectMsg("Failure")
+            probe.expectMsg("Failure")
+
+            val terminationPrrobe = TestProbe()
+            terminationPrrobe.watch(readCoordinator)
+            terminationPrrobe.expectTerminated(readCoordinator)
+          case Failure(ex) => fail(ex)
+        }
+    }
+
+  }
+
+}

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricPerformerActor.scala
@@ -135,9 +135,10 @@ class MetricPerformerActor(val basePath: String,
           facetsIndexWriter.close()
       }
 
+      val persistedBits = performedBitOperations.toSeq
       context.parent ! Refresh(opBufferMap.keys.toSeq, groupedByKey.keys.toSeq)
-      (localCommitLogCoordinator ? PersistedBits(performedBitOperations)).recover {
-        case _ => localCommitLogCoordinator ! PersistedBits(performedBitOperations)
+      (localCommitLogCoordinator ? PersistedBits(persistedBits)).recover {
+        case _ => localCommitLogCoordinator ! PersistedBits(persistedBits)
       }
 
       if (toRetryOperations.nonEmpty)

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/supervision/OneForOneWithRetriesStrategy.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/supervision/OneForOneWithRetriesStrategy.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.actors.supervision
+
+import akka.actor.SupervisorStrategy.{Escalate, Restart, Resume, Stop}
+import akka.actor.{ActorContext, ActorRef, ChildRestartStats, SupervisorStrategy}
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.concurrent.duration.Duration
+
+/**
+  * Applies the fault handling `Directive` (Resume, Restart, Stop) specified in the `Decider`
+  * to the child actor that failed, as opposed to [[akka.actor.AllForOneStrategy]] that applies
+  * it to all children.
+  *
+  * @param maxNrOfRetries the number of times a child actor is allowed to be restarted or resumed, negative value means no limit
+  *  if the duration is infinite. If the limit is exceeded the child actor is stopped
+  * @param withinTimeRange duration of the time window for maxNrOfRetries, Duration.Inf means no window
+  * @param loggingEnabled the strategy logs the failure if this is enabled (true), by default it is enabled
+  * @param decider mapping from Throwable to [[akka.actor.SupervisorStrategy.Directive]], you can also use a
+  *   [[scala.collection.immutable.Seq]] of Throwables which maps the given Throwables to restarts, otherwise escalates.
+  * @param shutdownBehaviour behavoiur to be executed when the number or restart or retry attempts is reached.
+  */
+case class OneForOneWithRetriesStrategy(maxNrOfRetries: Int = -1,
+                                        withinTimeRange: Duration = Duration.Inf,
+                                        override val loggingEnabled: Boolean = true)(
+    val decider: SupervisorStrategy.Decider)(val shutdownBehaviour: (ActorContext, ActorRef) => Unit)
+    extends SupervisorStrategy {
+
+  private val childrenResumes = new ConcurrentHashMap[String, Int]()
+
+  def withinTimeRangeOption(withinTimeRange: Duration): Option[Duration] =
+    if (withinTimeRange.isFinite && withinTimeRange >= Duration.Zero) Some(withinTimeRange) else None
+
+  def maxNrOfRetriesOption(maxNrOfRetries: Int): Option[Int] =
+    if (maxNrOfRetries < 0) None else Some(maxNrOfRetries)
+
+  private val retriesWindow =
+    (maxNrOfRetriesOption(maxNrOfRetries), withinTimeRangeOption(withinTimeRange).map(_.toMillis.toInt))
+
+  def handleChildTerminated(context: ActorContext, child: ActorRef, children: Iterable[ActorRef]): Unit = ()
+
+  override def processFailure(context: ActorContext,
+                              restart: Boolean,
+                              child: ActorRef,
+                              cause: Throwable,
+                              stats: ChildRestartStats,
+                              children: Iterable[ChildRestartStats]): Unit =
+    if (restart && stats.requestRestartPermission(retriesWindow))
+      restartChild(child, cause, suspendFirst = false)
+    else
+      shutdownBehaviour(context, child)
+
+  override def handleFailure(context: ActorContext,
+                             child: ActorRef,
+                             cause: Throwable,
+                             stats: ChildRestartStats,
+                             children: Iterable[ChildRestartStats]): Boolean = {
+    val directive: SupervisorStrategy.Directive = decider.applyOrElse(cause, (_: Any) => Escalate)
+    directive match {
+      case Resume =>
+        logFailure(context, child, cause, directive)
+        if (maxNrOfRetries > -1)
+          if (Option(childrenResumes.get(child.path.toSerializationFormat)).forall { _ < maxNrOfRetries }) {
+            childrenResumes.put(child.path.toSerializationFormat,
+                                Option(childrenResumes.get(child.path.toSerializationFormat)).map(_ + 1).getOrElse(1))
+            resumeChild(child, cause)
+          } else
+            shutdownBehaviour(context, child)
+        else
+          resumeChild(child, cause)
+        true
+      case Restart =>
+        logFailure(context, child, cause, directive)
+        processFailure(context, true, child, cause, stats, children)
+        true
+      case Stop =>
+        logFailure(context, child, cause, directive)
+        processFailure(context, false, child, cause, stats, children)
+        true
+      case Escalate =>
+        logFailure(context, child, cause, directive)
+        false
+    }
+  }
+
+}

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/supervision/OneForOneWithRetriesStrategySpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/supervision/OneForOneWithRetriesStrategySpec.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018-2020 Radicalbit S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.radicalbit.nsdb.actors.supervision
+
+import akka.actor.SupervisorStrategy.{Restart, Resume, Stop}
+import akka.actor.{Actor, ActorLogging, ActorSystem, Props, SupervisorStrategy}
+import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
+import io.radicalbit.nsdb.test.NSDbSpecLike
+import org.scalatest.{BeforeAndAfter, OneInstancePerTest}
+
+import java.util.UUID
+import scala.concurrent.duration._
+
+class OneForOneWithRetriesStrategySpec
+    extends TestKit(ActorSystem("OneForOneWithRetriesStrategySpec"))
+    with ImplicitSender
+    with NSDbSpecLike
+    with OneInstancePerTest
+    with BeforeAndAfter {
+
+  class TestSupervisorActor() extends Actor with ActorLogging {
+
+    override val supervisorStrategy: SupervisorStrategy = OneForOneWithRetriesStrategy(maxNrOfRetries = 1) {
+      case _: IllegalArgumentException =>
+        Resume
+      case _: IllegalStateException =>
+        Restart
+      case _ =>
+        Stop
+    } { (context, child) =>
+      context.stop(child)
+    }
+
+    override def receive: Receive = {
+      case msg => sender() ! msg
+    }
+  }
+
+  class FailingActor extends Actor {
+
+    val volatileId: String = UUID.randomUUID().toString
+
+    override def receive: Receive = {
+      case "ResumeMessage" =>
+        throw new IllegalArgumentException()
+      case "RestartMessage" =>
+        throw new IllegalStateException()
+      case _ =>
+        throw new RuntimeException()
+    }
+
+    override def postStop(): Unit = {
+      println("aaaaaa")
+    }
+  }
+
+  val testSupervisor: TestActorRef[TestSupervisorActor] =
+    TestActorRef[TestSupervisorActor](Props(new TestSupervisorActor()))
+
+  "OneForOneWithRetriesStrategy" when {
+    "An actor throws an exception if maxNrOfRetries is not reached" should {
+      "resume it properly" in {
+        val failingActor = TestActorRef[FailingActor](Props(new FailingActor()), testSupervisor)
+
+        val volatileId = failingActor.underlyingActor.volatileId
+
+        failingActor ! "ResumeMessage"
+
+        expectNoMessage(1 seconds)
+
+        failingActor.underlyingActor.volatileId shouldBe volatileId
+      }
+
+      "restart it properly" in {
+        val failingActor = TestActorRef[FailingActor](Props(new FailingActor()), testSupervisor)
+
+        val volatileId = failingActor.underlyingActor.volatileId
+
+        failingActor ! "RestartMessage"
+
+        expectNoMessage(1 seconds)
+
+        failingActor.underlyingActor.volatileId shouldNot be(volatileId)
+      }
+    }
+
+    "An actor throws an exception if maxNrOfRetries is reached" should {
+      "resume it properly" in {
+
+        val failingActor = TestActorRef[FailingActor](Props(new FailingActor()), testSupervisor)
+
+        val probe = TestProbe()
+        probe.watch(failingActor)
+
+        failingActor ! "ResumeMessage"
+        failingActor ! "ResumeMessage"
+
+        probe.expectTerminated(failingActor)
+      }
+
+      "restart it properly" in {
+
+        val failingActor = TestActorRef[FailingActor](Props(new FailingActor()), testSupervisor)
+
+        val probe = TestProbe()
+        probe.watch(failingActor)
+
+        failingActor ! "RestartMessage"
+        failingActor ! "RestartMessage"
+
+        probe.expectTerminated(failingActor)
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
This PR Introduces a new supervision strategy class 

`OneForOneWithRetriesStrategy.scala`

The idea behind this new strategy is that in case of a resume Directive,  the `maxNrOfRetries` approach can be applied as it is for the restart directive.
For many scenarios, NSDb actors must be supervised with the resume approach, in order to preserve actor's statuses.
After a configurable number of attempts, a fatal behaviour must be applied.

Inside `NodeActorGuardian` a custom supervision approach has been implemented.
Except for `InvalidLocationsInNode` that is a custom exception thrown my `MetricAccumulator` after a separated retry mechanism, only a Resume directive is applied, with a configurable retry attempts
