### PR TITLE
Unique Node Name

### DIFF
--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/AbstractClusterListener.scala
@@ -47,7 +47,6 @@ import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{
   MetricsDataActorUnSubscribed,
   PublisherUnSubscribed
 }
-import io.radicalbit.nsdb.util.FileUtils.NODE_FS_ID_LENGTH
 import io.radicalbit.nsdb.util.{ErrorManagementUtils, FileUtils, FutureRetryUtility}
 import org.apache.commons.lang3.RandomStringUtils
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ClusterListener.scala
@@ -27,7 +27,8 @@ final class ClusterListener extends AbstractClusterListener {
                                    writeCoordinator: ActorRef,
                                    metadataCoordinator: ActorRef,
                                    publisherActor: ActorRef): Unit =
-    new NsdbNodeEndpoint(nodeFsId, readCoordinator, writeCoordinator, metadataCoordinator, publisherActor)(context.system)
+    new NsdbNodeEndpoint(nodeFsId, readCoordinator, writeCoordinator, metadataCoordinator, publisherActor)(
+      context.system)
 
   protected def onFailureBehaviour(member: Member, error: Any): Unit = {
     log.error("received wrong response {}", error)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
@@ -25,12 +25,13 @@ import akka.remote.RemoteScope
 import io.radicalbit.nsdb.actors.PublisherActor
 import io.radicalbit.nsdb.actors.supervision.OneForOneWithRetriesStrategy
 import io.radicalbit.nsdb.cluster.PubSubTopics._
+import io.radicalbit.nsdb.cluster.actor.NodeActorsGuardian.{UpdateVolatileId, VolatileIdUpdated}
 import io.radicalbit.nsdb.cluster.coordinator._
 import io.radicalbit.nsdb.cluster.createNodeAddress
 import io.radicalbit.nsdb.cluster.extension.NSDbClusterSnapshot
 import io.radicalbit.nsdb.cluster.logic.{CapacityWriteNodesSelectionLogic, LocalityReadNodesSelection}
 import io.radicalbit.nsdb.common.configuration.NSDbConfig.HighLevel._
-import io.radicalbit.nsdb.common.protocol.NSDbNode
+import io.radicalbit.nsdb.common.protocol.{NSDbNode, NSDbSerializable}
 import io.radicalbit.nsdb.exception.InvalidLocationsInNode
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
 import io.radicalbit.nsdb.util.FileUtils
@@ -47,21 +48,21 @@ class NodeActorsGuardian extends Actor with ActorLogging {
 
   private val mediator = DistributedPubSub(context.system).mediator
 
-  private val nodeAddress = createNodeAddress(selfMember)
+  protected val nodeAddress: String = createNodeAddress(selfMember)
 
   protected lazy val selfNodeName: String = createNodeAddress(selfMember)
-  protected lazy val nodeFsId: String       = FileUtils.getOrCreateNodeFsId(selfNodeName, config.getString(NSDBMetadataPath))
-
-  protected lazy val node: NSDbNode = NSDbNode(nodeAddress, nodeFsId)
+  protected lazy val nodeFsId: String     = FileUtils.getOrCreateNodeFsId(selfNodeName, config.getString(NSDBMetadataPath))
 
   private val config = context.system.settings.config
 
   private val indexBasePath = config.getString(StorageIndexPath)
 
+  protected var node: NSDbNode = _
+
   if (config.hasPath(StorageTmpPath))
     System.setProperty("java.io.tmpdir", config.getString(StorageTmpPath))
 
-  protected def actorNameSuffix: String = NSDbNode(nodeAddress, nodeFsId).uniqueNodeId
+  protected def actorNameSuffix: String = node.uniqueNodeId
 
   private lazy val writeNodesSelectionLogic = new CapacityWriteNodesSelectionLogic(
     CapacityWriteNodesSelectionLogic.fromConfigValue(config.getString("nsdb.cluster.metrics-selector")))
@@ -157,19 +158,22 @@ class NodeActorsGuardian extends Actor with ActorLogging {
       context.system.settings.config.getDuration("nsdb.heartbeat.interval", TimeUnit.SECONDS),
       TimeUnit.SECONDS)
 
-    import context.dispatcher
+//    import context.dispatcher
 
-    /**
-      * scheduler that disseminate gossip message to all the cluster listener actors
-      */
-    context.system.scheduler.schedule(interval, interval) {
-      mediator ! Publish(NSDB_LISTENERS_TOPIC, NodeAlive(NSDbNode(nodeAddress, nodeFsId)))
-    }
+//    /**
+//      * scheduler that disseminate gossip message to all the cluster listener actors
+//      */
+//    context.system.scheduler.schedule(interval, interval) {
+//      mediator ! Publish(NSDB_LISTENERS_TOPIC, NodeAlive(NSDbNode(nodeAddress, nodeFsId)))
+//    }
 
     log.info(s"NodeActorGuardian is ready at ${self.path.name}")
   }
 
   def receive: Receive = {
+    case UpdateVolatileId(volatileId) =>
+      node = NSDbNode(nodeAddress, nodeFsId, volatileId)
+      sender() ! VolatileIdUpdated(node)
     case GetNodeChildActors =>
       sender ! NodeChildActorsGot(metadataCoordinator, writeCoordinator, readCoordinator, publisherActor)
     case GetMetricsDataActors =>
@@ -182,4 +186,9 @@ class NodeActorsGuardian extends Actor with ActorLogging {
       log.debug(s"gossiping publishers for node ${node.uniqueNodeId}")
       mediator ! Publish(COORDINATORS_TOPIC, SubscribePublisher(publisherActor, node.uniqueNodeId))
   }
+}
+
+object NodeActorsGuardian {
+  case class UpdateVolatileId(volatileId: String) extends NSDbSerializable
+  case class VolatileIdUpdated(node: NSDbNode)    extends NSDbSerializable
 }

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/extension/NSDbClusterSnapshot.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/extension/NSDbClusterSnapshot.scala
@@ -22,8 +22,8 @@ import io.radicalbit.nsdb.common.protocol.NSDbNode
 import scala.collection.JavaConverters._
 
 /**
-  * Extension that is inspired by the akka [[Cluster]] extension with the purpose to store the current snapshot for a NSDb cluster.
-  * Besides the (already provided by akka) [[Member]] information, the unique node identifier is snapshot
+  * Extension that is inspired by the akka [[akka.cluster.Cluster]] extension with the purpose to store the current snapshot for a NSDb cluster.
+  * Besides the (already provided by akka) [[akka.cluster.Member]] information, the unique node identifier is snapshot
   * and associated to an address, which may vary.
   */
 class NSDbClusterSnapshotExtension(system: ExtendedActorSystem) extends Extension {
@@ -36,10 +36,11 @@ class NSDbClusterSnapshotExtension(system: ExtendedActorSystem) extends Extensio
     * Adds a node and associate it to the a unique identifier
     * @param address the actual address of the node.
     * @param nodeId the node unique identifier.
+    * @param volatileId the node volatile id
     */
-  def addNode(address: String, nodeId: String): NSDbNode = {
+  def addNode(address: String, nodeId: String, volatileId: String): NSDbNode = {
     system.log.debug(s"adding node with address $address and $nodeId to $threadSafeMap")
-    threadSafeMap.put(address, NSDbNode(address, nodeId))
+    threadSafeMap.put(address, NSDbNode(address, nodeId, volatileId))
   }
 
   def addNode(node: NSDbNode): NSDbNode = {

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/package.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/package.scala
@@ -44,4 +44,6 @@ package object cluster {
     final val NSDB_METRICS_TOPIC   = "nsdb-metrics"
     final val NSDB_LISTENERS_TOPIC = "nsdb-listeners"
   }
+
+  final val VOLATILE_ID_LENGTH: Int = 10
 }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/MetadataRestoreSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/MetadataRestoreSpec.scala
@@ -36,14 +36,14 @@ class MetadataRestoreSpecMultiJvmNode2 extends MetadataRestoreSpec {}
 class MetadataRestoreSpec extends MultiNodeSpec(MetadataRestoreSpec) with STMultiNodeSpec with ImplicitSender {
   override def initialParticipants: Int = roles.size
 
-  private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/metadata-coordinator_${nodeName}_$nodeName"
-  private def schemaCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/schema-coordinator_${nodeName}_$nodeName"
+  private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/metadata-coordinator_${nodeName}_${nodeName}_$nodeName"
+  private def schemaCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/schema-coordinator_${nodeName}_${nodeName}_$nodeName"
 
   system.actorOf(Props[DatabaseActorsGuardian], "guardian")
 
   val selfMember: Member = cluster.selfMember
   val nodeName   = s"${selfMember.address.host.getOrElse("noHost")}_${selfMember.address.port.getOrElse(2552)}"
-  val nodeActorGuardian: ActorRef = system.actorOf(Props[NodeActorGuardianForTest], name = s"guardian_${nodeName}_$nodeName")
+  val nodeActorGuardian: ActorRef = system.actorOf(NodeActorGuardianForTest.props(nodeName), name = s"guardian_${nodeName}_$nodeName")
 
   "Metadata system" must {
 

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ClusterListenerTestActor.scala
@@ -19,7 +19,7 @@ abstract class ClusterListenerTestActor
 
   override protected lazy val nodeFsId: String = selfNodeName
 
-  val node = NSDbNode("nodeAddress", nodeFsId)
+  val node = NSDbNode(selfNodeName, nodeFsId, "volatile")
 
   override def receive: Receive = super.receive orElse {
     case SubscribeAck(subscribe) => log.info("subscribe {}", subscribe)

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -45,18 +45,18 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
 
   override def initialParticipants = roles.size
 
-  val guardian: ActorRef = system.actorOf(Props[DatabaseActorsGuardian], "guardian")
-
   implicit val timeout: Timeout = Timeout(5.seconds)
 
   val selfMember: Member = cluster.selfMember
   val nodeName   = s"${selfMember.address.host.getOrElse("noHost")}_${selfMember.address.port.getOrElse(2552)}"
-  val nodeActorGuardian: ActorRef = system.actorOf(Props[NodeActorGuardianForTest], name = s"guardian_${nodeName}_$nodeName")
+  val nodeActorGuardian: ActorRef = system.actorOf(NodeActorGuardianForTest.props(nodeName), name = s"guardian_${nodeName}_$nodeName")
 
-  val nsdbNode1 = NSDbNode("localhost_2552", "node1")
-  val nsdbNode2 = NSDbNode("localhost_2553", "node2")
 
-  private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/metadata-coordinator_${nodeName}_$nodeName"
+
+  val nsdbNode1 = NSDbNode("localhost_2552", "node1", "volatile1")
+  val nsdbNode2 = NSDbNode("localhost_2553", "node2", "volatile2")
+
+  private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/metadata-coordinator_${nodeName}_${nodeName}_$nodeName"
 
   "Metadata system" must {
 

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/NodeActorGuardianForTest.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/NodeActorGuardianForTest.scala
@@ -1,7 +1,10 @@
 package io.radicalbit.nsdb.cluster.actor
-import akka.actor.{ActorContext, ActorRef}
+import akka.actor.{ActorContext, ActorRef, Props}
+import io.radicalbit.nsdb.cluster.VOLATILE_ID_LENGTH
+import io.radicalbit.nsdb.common.protocol.NSDbNode
+import org.apache.commons.lang3.RandomStringUtils
 
-class NodeActorGuardianForTest extends NodeActorsGuardian {
+class NodeActorGuardianForTest(val volatileId: String) extends NodeActorsGuardian{
 
   override protected lazy val nodeFsId: String = selfNodeName
 
@@ -9,4 +12,11 @@ class NodeActorGuardianForTest extends NodeActorsGuardian {
 
   override def createClusterListener: ActorRef = context.actorOf(ClusterListenerTestActor.props(), name = "clusterListener")
 
+  node = NSDbNode(nodeAddress, nodeFsId, volatileId)
+}
+
+object NodeActorGuardianForTest {
+  def props: Props = Props(new NodeActorGuardianForTest(RandomStringUtils.randomAlphabetic(VOLATILE_ID_LENGTH)))
+
+  def props(volatileId: String): Props = Props(new NodeActorGuardianForTest(volatileId))
 }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -72,8 +72,8 @@ class ReplicatedMetadataCacheSpec
 
   private val replicatedCache = system.actorOf(Props[ReplicatedMetadataCache])
 
-  val nsdbNode1 = NSDbNode("localhost_2552", "node1")
-  val nsdbNode2 = NSDbNode("localhost_2553", "node2")
+  val nsdbNode1 = NSDbNode("localhost_2552", "node1", "volatile1")
+  val nsdbNode2 = NSDbNode("localhost_2553", "node2", "volatile2")
 
   "ReplicatedMetadataCache" must {
 
@@ -449,8 +449,8 @@ class ReplicatedMetadataCacheSpec
       val namespace = "namespace2"
       val metric   = "metric2"
 
-      val nsdbNode10 = NSDbNode("localhost_2552", "node10")
-      val nsdbNode20 = NSDbNode("localhost_2552", "node20")
+      val nsdbNode10 = NSDbNode("localhost_2552", "node10", "volatile10")
+      val nsdbNode20 = NSDbNode("localhost_2552", "node20", "volatile20")
 
       runOn(node1) {
         for (i ← 10 to 20) {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/AbstractReadCoordinatorSpec.scala
@@ -56,7 +56,7 @@ abstract class AbstractReadCoordinatorSpec
   val db        = "db"
   val namespace = "registry"
 
-  val node               = NSDbNode("localhost", "node1")
+  val node               = NSDbNode("localhost", "node1", "volatile")
   val readNodesSelection = new LocalityReadNodesSelection("notImportant")
 
   val schemaCoordinator =

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -81,8 +81,8 @@ class MetadataCoordinatorSpec
 
   implicit val timeout = Timeout(10 seconds)
 
-  val node1 = NSDbNode("localhost_2552", "node_01")
-  val node2 = NSDbNode("localhost_2553", "node_02")
+  val node1 = NSDbNode("localhost_2552", "node_01", "volatile1")
+  val node2 = NSDbNode("localhost_2553", "node_02", "volatile2")
 
   override def beforeAll = {
     NSDbClusterSnapshot(system).addNode(node1)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/RetentionSpec.scala
@@ -124,7 +124,7 @@ class RetentionSpec
   )
 
   override def beforeAll = {
-    val node = NSDbNode("localhost", "nodeId")
+    val node = NSDbNode("localhost", "nodeId", "volatile")
     NSDbClusterSnapshot(system).addNode(node)
 
     awaitAssert {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -64,7 +64,7 @@ trait WriteCoordinatorBehaviour { this: TestKit with NSDbSpecLike =>
 
   def namespace: String
 
-  val node: NSDbNode = NSDbNode("localhost", "nodeId")
+  val node: NSDbNode = NSDbNode("localhost", "nodeId", "volatile")
 
   val interval = FiniteDuration(system.settings.config.getDuration("nsdb.write.scheduler.interval", TimeUnit.SECONDS),
                                 TimeUnit.SECONDS) + 1.second
@@ -97,7 +97,7 @@ trait WriteCoordinatorBehaviour { this: TestKit with NSDbSpecLike =>
   val record2 =
     Bit(System.currentTimeMillis, 2, Map("content" -> s"content", "content2" -> s"content2"), Map.empty)
 
-  NSDbClusterSnapshot(system).addNode("localhost", "nodeId")
+  NSDbClusterSnapshot(system).addNode(node)
 
   def defaultBehaviour {
     "write records" in {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
@@ -58,8 +58,8 @@ class MockedMetadataCoordinator extends Actor with ActorLogging {
 }
 
 object MockedMetadataCoordinator {
-  val node1 = NSDbNode("localhost_2552", "node1")
-  val node2 = NSDbNode("localhost_2553", "node2")
+  val node1 = NSDbNode("localhost_2552", "node1", "volatile1")
+  val node2 = NSDbNode("localhost_2553", "node2", "volatile2")
 }
 
 class WriteCoordinatorErrorsSpec

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelectionSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelectionSpec.scala
@@ -26,9 +26,9 @@ class LocalityReadNodesSelectionSpec extends NSDbSpec {
     Location("metric", node, i, i + 1)
   }
 
-  val thisNode  = NSDbNode("thisNode", "thisNode")
-  val thatNode  = NSDbNode("thatNode", "thatNode")
-  val thatNode2 = NSDbNode("thatNode2", "thatNode2")
+  val thisNode  = NSDbNode("thisNode", "thisNode", "thisVolatile")
+  val thatNode  = NSDbNode("thatNode", "thatNode", "thatVolatile")
+  val thatNode2 = NSDbNode("thatNode2", "thatNode2", "thatVolatile2")
 
   val localityReadNodesSelection = new LocalityReadNodesSelection(thisNode.uniqueNodeId)
 

--- a/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/NSDbNode.scala
+++ b/nsdb-common/src/main/scala/io/radicalbit/nsdb/common/protocol/NSDbNode.scala
@@ -21,17 +21,18 @@ package io.radicalbit.nsdb.common.protocol
   * and an identifier associated to the file system, i.e. the concrete volume in which shards are stored.
   * @param nodeAddress the akka cluster node address.
   * @param nodeFsId the file system identifier.
+  * @param volatileNodeUuid needed to be able to distinguish different incarnations of a node with same nodeAddress and nodeFsId.
   */
-case class NSDbNode(nodeAddress: String, nodeFsId: String) extends NSDbSerializable {
-  def uniqueNodeId: String = s"${nodeAddress}_$nodeFsId"
+case class NSDbNode(nodeAddress: String, nodeFsId: String, volatileNodeUuid: String) extends NSDbSerializable {
+  def uniqueNodeId: String = s"${nodeAddress}_${nodeFsId}_$volatileNodeUuid"
 }
 
 object NSDbNode {
 
   def fromUniqueId(uniqueIdentifier: String): NSDbNode = {
     val components = uniqueIdentifier.split('_')
-    NSDbNode(components(0), components(1))
+    NSDbNode(components(0), components(1), components(2))
   }
 
-  def empty: NSDbNode = NSDbNode("", "")
+  def empty: NSDbNode = NSDbNode("", "", "")
 }

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/actors/MetricReaderActor.scala
@@ -91,9 +91,9 @@ class MetricReaderActor(val basePath: String, node: NSDbNode, val db: String, va
     s"shard_reader-${location.node.nodeAddress}-${location.node.nodeFsId}-${location.metric}-${location.from}-${location.to}"
 
   private def location(actorName: String): Option[Location] =
-    actorName.split("-").takeRight(5) match {
-      case Array(nodeAddress, nodeFsId, metric, from, to) =>
-        Some(Location(metric, NSDbNode(nodeAddress, nodeFsId), from.toLong, to.toLong))
+    actorName.split("-").takeRight(6) match {
+      case Array(nodeAddress, nodeFsId, volatileNodeId, metric, from, to) =>
+        Some(Location(metric, NSDbNode(nodeAddress, nodeFsId, volatileNodeId), from.toLong, to.toLong))
       case _ => None
     }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/FileUtils.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/util/FileUtils.scala
@@ -33,10 +33,10 @@ import scala.collection.JavaConverters._
   */
 object FileUtils {
 
-  final val NODE_ID_EXTENSION = "name"
-  final val NODE_ID_LENGTH    = 10
-  final val BUFFER_SIZE       = 4096
-  final val buffer            = new Array[Byte](BUFFER_SIZE)
+  final val NODE_FS_ID_EXTENSION = "name"
+  final val NODE_FS_ID_LENGTH    = 10
+  final val BUFFER_SIZE          = 4096
+  final val buffer               = new Array[Byte](BUFFER_SIZE)
 
   private class DirectoryFilter extends FileFilter {
     override def accept(pathname: File): Boolean = pathname.isDirectory
@@ -49,7 +49,7 @@ object FileUtils {
 
   private class NodeIdFilter extends FileFilter {
     override def accept(pathname: File): Boolean =
-      !pathname.isDirectory && pathname.getName.endsWith(NODE_ID_EXTENSION)
+      !pathname.isDirectory && pathname.getName.endsWith(NODE_FS_ID_EXTENSION)
   }
 
   /**
@@ -137,9 +137,9 @@ object FileUtils {
   def getOrCreateNodeFsId(address: String, basePath: String): String = {
     Option(Paths.get(basePath).toFile.listFiles(new NodeIdFilter)).getOrElse(Array.empty) match {
       case Array() =>
-        val newName = RandomStringUtils.randomAlphabetic(NODE_ID_LENGTH)
+        val newName = RandomStringUtils.randomAlphabetic(NODE_FS_ID_LENGTH)
         new File(basePath).mkdirs()
-        new File(basePath, s"$newName.$NODE_ID_EXTENSION").createNewFile()
+        new File(basePath, s"$newName.$NODE_FS_ID_EXTENSION").createNewFile()
         newName
       case Array(singleFile) => FilenameUtils.removeExtension(singleFile.getName)
       case _                 => throw new InvalidNodeIdException(address)

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricAccumulatorActorSpec.scala
@@ -50,7 +50,7 @@ class MetricAccumulatorActorSpec()
   val namespace = "namespace"
   val metric    = "shardActorMetric"
   val nodeName  = "node1"
-  val node      = NSDbNode(nodeName, nodeName)
+  val node      = NSDbNode.empty
 
   val metricsReaderActor =
     system.actorOf(RoundRobinPool(1, None).props(MetricReaderActor.props(basePath, node, db, namespace)))

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricPerformerActorSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/actors/MetricPerformerActorSpec.scala
@@ -77,7 +77,7 @@ class MetricPerformerActorSpec
 
   indexerPerformerActor.underlyingActor.supervisorStrategy
 
-  val node = NSDbNode("node1", "node1")
+  val node = NSDbNode.empty
 
   val errorLocation               = Location("IndexerPerformerActorMetric", node, 1, 1)
   val unstableRecoverableLocation = Location("IndexerPerformerActorMetric", node, 2, 2)

--- a/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/AllFacetIndexSpec.scala
+++ b/nsdb-core/src/test/scala/io/radicalbit/nsdb/index/AllFacetIndexSpec.scala
@@ -35,7 +35,7 @@ class AllFacetIndexSpec extends NSDbSpec with OneInstancePerTest {
     "Combine Results for temporal average calculation" in {
       val basePath = s"target/test_index/${UUID.randomUUID}"
 
-      val location = Location("metric", NSDbNode("node", "node"), 0, 100)
+      val location = Location("metric", NSDbNode.empty, 0, 100)
       val directory =
         new MMapDirectory(Paths.get(basePath, "db", "namespace", "shards", s"${location.shardName}"))
 

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiSpec.scala
@@ -50,7 +50,7 @@ object CommandApiSpec {
   class FakeMetadataCoordinator extends Actor {
     override def receive: Receive = {
       case GetTopology =>
-        sender() ! TopologyGot(Set(NSDbNode("address", "fs")))
+        sender() ! TopologyGot(Set(NSDbNode("address", "fs", "volatile")))
       case GetLocations(db, namespace, metric) =>
         sender() ! LocationsGot(db, namespace, metric, Seq(Location.empty))
       case GetMetricInfo(db, namespace, "metricWithoutInfo") =>
@@ -91,7 +91,7 @@ class CommandApiSpec extends NSDbFlatSpec with ScalatestRouteTest with CommandAp
     Get("/commands/topology").withHeaders(RawHeader("testHeader", "testHeader")) ~> testSecuredRoutes ~> check {
       status shouldBe OK
       val entity = entityAs[String]
-      entity shouldBe write(TopologyGot(Set(NSDbNode("address", "fs"))))
+      entity shouldBe write(TopologyGot(Set(NSDbNode("address", "fs", "volatile"))))
     }
   }
 


### PR DESCRIPTION
This PR is for introducing a new component to identify an NSDb node.

That component is called: `volatileId`

the `volatileId` is generated at the time of node joining, and it's essential di distinguish different node incarnation that might have the same address and the same file system identifier

Now a NSDd node identifier, that is modeled by the `NSDbNode` class can be considered unanmigous