### PR TITLE
Nodes blacklist

### DIFF
--- a/nsdb-cluster/src/main/resources/nsdb.conf
+++ b/nsdb-cluster/src/main/resources/nsdb.conf
@@ -145,6 +145,11 @@ nsdb {
   retention.check.interval = 30 seconds
   retention.check.interval = ${?RETENTION_CHECK_INTERVAL}
 
+  blacklist.check.interval = 30 seconds
+  blacklist.check.interval = ${?BLACKLIST_CHECK_INTERVAL}
+  blacklist.ttl = 60 seconds
+  blacklist.ttl = ${?BLACKLIST_TTL}
+
   heartbeat.interval = 10 seconds
   heartbeat.interval = ${?HEARTBEAT_INTERVAL}
 

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
@@ -75,9 +75,6 @@ class NodeActorsGuardian extends Actor with ActorLogging {
 
   private lazy val maxAttempts = context.system.settings.config.getInt("nsdb.write.retry-attempts")
 
-  private val metadataCache = context.actorOf(Props[ReplicatedMetadataCache], s"metadata-cache-$nodeFsId-$nodeAddress")
-  private val schemaCache   = context.actorOf(Props[ReplicatedSchemaCache], s"schema-cache-$nodeFsId-$nodeAddress")
-
   def shutdownBehaviour(context: ActorContext, child: ActorRef): Unit =
     context.system.terminate()
 
@@ -112,6 +109,9 @@ class NodeActorsGuardian extends Actor with ActorLogging {
   }
 
   private val clusterListener: ActorRef = createClusterListener
+
+  private lazy val metadataCache = context.actorOf(Props[ReplicatedMetadataCache], s"metadata-cache-$actorNameSuffix")
+  private lazy val schemaCache   = context.actorOf(Props[ReplicatedSchemaCache], s"schema-cache-$actorNameSuffix")
 
   protected lazy val schemaCoordinator: ActorRef = context.actorOf(
     SchemaCoordinator

--- a/nsdb-cluster/src/multi-jvm/resources/application.conf
+++ b/nsdb-cluster/src/multi-jvm/resources/application.conf
@@ -37,6 +37,9 @@ nsdb {
   write.scheduler.interval = 15 seconds
   retention.check.interval = 1 seconds
 
+  blacklist.check.interval = 30 seconds
+  blacklist.ttl = 60 seconds
+
   cluster {
     metrics-selector = disk
     metadata-write-consistency = "all"

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -18,43 +18,7 @@ object ReplicatedMetadataCacheSpec extends MultiNodeConfig {
   val node1 = role("node-1")
   val node2 = role("node-2")
 
-  commonConfig(ConfigFactory.parseString("""
-    |akka.loglevel = ERROR
-    |akka.actor {
-    | provider = "cluster"
-    |
-    | serialization-bindings {
-    |   "io.radicalbit.nsdb.common.protocol.NSDbSerializable" = jackson-json
-    | }
-    |
-    | control-aware-dispatcher {
-    |     mailbox-type = "akka.dispatch.UnboundedControlAwareMailbox"
-    |   }
-    |}
-    |akka.log-dead-letters-during-shutdown = off
-    |nsdb {
-    |
-    |  global.timeout = 30 seconds
-    |  read-coordinator.timeout = 10 seconds
-    |  namespace-schema.timeout = 10 seconds
-    |  namespace-data.timeout = 10 seconds
-    |  publisher.timeout = 10 seconds
-    |  publisher.scheduler.interval = 5 seconds
-    |  write.scheduler.interval = 15 seconds
-    |
-    |  cluster.metadata-write-consistency = "all"
-    |
-    |  write-coordinator.timeout = 5 seconds
-    |  metadata-coordinator.timeout = 5 seconds
-    |  commit-log {
-    |    serializer = "io.radicalbit.nsdb.commit_log.StandardCommitLogSerializer"
-    |    writer = "io.radicalbit.nsdb.commit_log.RollingCommitLogFileWriter"
-    |    directory = "target/commitLog"
-    |    max-size = 50000
-    |    passivate-after = 5s
-    |  }
-    |}
-    """.stripMargin))
+  commonConfig(ConfigFactory.parseResources("application.conf"))
 }
 
 class ReplicatedMetadataCacheSpecMultiJvmNode1 extends ReplicatedMetadataCacheSpec
@@ -406,7 +370,7 @@ class ReplicatedMetadataCacheSpec
         }
 
         replicatedCache ! EvictLocation("db", "namespace", Location(metric, nsdbNode1, 0, 1))
-        expectMsg(Right(LocationEvicted("db", "namespace", Location(metric, nsdbNode1, 0, 1))))
+        expectMsg(LocationEvicted("db", "namespace", Location(metric, nsdbNode1, 0, 1)))
       }
 
       runOn(node1) {
@@ -484,7 +448,7 @@ class ReplicatedMetadataCacheSpec
 
       runOn(node2) {
           replicatedCache ! EvictLocationsInNode(nsdbNode10.uniqueNodeId)
-          expectMsg(Right(LocationsInNodeEvicted(nsdbNode10.uniqueNodeId)))
+          expectMsg(LocationsInNodeEvicted(nsdbNode10.uniqueNodeId))
       }
 
       awaitAssert {
@@ -494,7 +458,7 @@ class ReplicatedMetadataCacheSpec
 
       runOn(node1) {
           replicatedCache ! EvictLocationsInNode(nsdbNode20.uniqueNodeId)
-          expectMsg(Right(LocationsInNodeEvicted(nsdbNode20.uniqueNodeId)))
+          expectMsg(LocationsInNodeEvicted(nsdbNode20.uniqueNodeId))
       }
 
       awaitAssert {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCache.scala
@@ -84,7 +84,7 @@ class LocalMetadataCache extends Actor {
       val key              = MetricLocationsCacheKey(db, namespace, location.metric)
       val previousLocation = locations.getOrElse(key, Set.empty)
       locations.put(key, previousLocation - location)
-      sender ! Right(LocationEvicted(db, namespace, location))
+      sender ! LocationEvicted(db, namespace, location)
     case GetMetricInfoFromCache(db, namespace, metric) =>
       val key = MetricInfoCacheKey(db, namespace, metric)
       sender ! MetricInfoCached(db, namespace, metric, Option(metricInfo.get(key)))

--- a/nsdb-minicluster/src/main/resources/nsdb-minicluster.conf
+++ b/nsdb-minicluster/src/main/resources/nsdb-minicluster.conf
@@ -124,6 +124,9 @@ nsdb {
 
   retention.check.interval = 30 seconds
 
+  blacklist.check.interval = 30 seconds
+  blacklist.ttl = 60 seconds
+
   heartbeat.interval = 1 seconds
 
   stream.timeout = 30 seconds


### PR DESCRIPTION
A node Blacklist is a new metadata that aims at tracking the nodes that are marked as unstable by Akka cluster or that are downed.

Since the actions that are executed in case of a downed or unstable node (e.g. location metadata removal) might take a considerably amount of time and are eventual consistent, the first operation that will be performed (In future developments), is to add it to the blacklist, which is consulted for filtering out purposes during the write and read operations.