### PR TITLE
Live locations

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -1,0 +1,103 @@
+#
+#   Copyright 2018-2020 Radicalbit S.r.l.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#  
+name: Development Continous Integration
+on:
+  push:
+    branches: [ '**' ]
+jobs:
+  code-style:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: "adopt@1.8"
+      - name: Coursier cache
+        uses: coursier/cache-action@v5
+      - name: Code Style Check
+        run: sbt fixCheck scalafmtCheck test:scalafmtCheck multi-jvm:scalafmtCheck
+  cross-scala-compilation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: "adopt@1.8"
+      - name: Coursier cache
+        uses: coursier/cache-action@v5
+      - name: Cross Compilation
+        run: sbt +compile
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: "adopt@1.8"
+      - name: Coursier cache
+        uses: coursier/cache-action@v5
+      - name: Build and Test
+        run: sbt test
+  multi-jvm-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: "adopt@1.8"
+      - name: Coursier cache
+        uses: coursier/cache-action@v5
+      - name: Build and Test
+        run: sbt multi-jvm:test
+  it-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: "adopt@1.8"
+      - name: Coursier cache
+        uses: coursier/cache-action@v5
+      - name: Build and Test
+        run: sbt it:test
+  publish-test:
+    needs:
+      - code-style
+      - cross-scala-compilation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: "adopt@1.8"
+      - name: Coursier cache
+        uses: coursier/cache-action@v5
+      - name: Test Publish Artifacts
+        run: sbt +publishLocal
+      - name: Test Publish Docker image
+        run: sbt ";project nsdb-cluster; docker:publishLocal"

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
@@ -111,10 +111,10 @@ class NodeActorsGuardian extends Actor with ActorLogging {
 
   private lazy val metadataCache = context.actorOf(
     Props[ReplicatedMetadataCache].withDeploy(Deploy(scope = RemoteScope(selfMember.address))),
-    s"metadata-cache-$actorNameSuffix")
+    s"metadata-cache_$actorNameSuffix")
   private lazy val schemaCache = context.actorOf(
     Props[ReplicatedSchemaCache].withDeploy(Deploy(scope = RemoteScope(selfMember.address))),
-    s"schema-cache-$actorNameSuffix")
+    s"schema-cache_$actorNameSuffix")
 
   protected lazy val schemaCoordinator: ActorRef = context.actorOf(
     SchemaCoordinator

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
@@ -71,7 +71,6 @@ class NodeActorsGuardian extends Actor with ActorLogging {
 
   private lazy val writeNodesSelectionLogic = new CapacityWriteNodesSelectionLogic(
     CapacityWriteNodesSelectionLogic.fromConfigValue(config.getString("nsdb.cluster.metrics-selector")))
-  private lazy val readNodesSelection = new LocalityReadNodesSelection(nodeFsId)
 
   private lazy val maxAttempts = context.system.settings.config.getInt("nsdb.write.retry-attempts")
 
@@ -132,7 +131,7 @@ class NodeActorsGuardian extends Actor with ActorLogging {
   protected lazy val readCoordinator: ActorRef =
     context.actorOf(
       ReadCoordinator
-        .props(metadataCoordinator, schemaCoordinator, mediator, readNodesSelection)
+        .props(metadataCoordinator, schemaCoordinator, mediator, new LocalityReadNodesSelection(node.uniqueNodeId))
         .withDispatcher("akka.actor.control-aware-dispatcher")
         .withDeploy(Deploy(scope = RemoteScope(selfMember.address))),
       s"read-coordinator_$actorNameSuffix"

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/NodeActorsGuardian.scala
@@ -109,8 +109,12 @@ class NodeActorsGuardian extends Actor with ActorLogging {
 
   private val clusterListener: ActorRef = createClusterListener
 
-  private lazy val metadataCache = context.actorOf(Props[ReplicatedMetadataCache], s"metadata-cache-$actorNameSuffix")
-  private lazy val schemaCache   = context.actorOf(Props[ReplicatedSchemaCache], s"schema-cache-$actorNameSuffix")
+  private lazy val metadataCache = context.actorOf(
+    Props[ReplicatedMetadataCache].withDeploy(Deploy(scope = RemoteScope(selfMember.address))),
+    s"metadata-cache-$actorNameSuffix")
+  private lazy val schemaCache = context.actorOf(
+    Props[ReplicatedSchemaCache].withDeploy(Deploy(scope = RemoteScope(selfMember.address))),
+    s"schema-cache-$actorNameSuffix")
 
   protected lazy val schemaCoordinator: ActorRef = context.actorOf(
     SchemaCoordinator

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
@@ -157,11 +157,11 @@ object ReplicatedMetadataCache {
   final case class NodeToBlackListAdded(node: NSDbNode)                     extends AddNodeToBlackListResponse
   final case class AddNodeToBlackListFailed(node: NSDbNode, reason: String) extends AddNodeToBlackListResponse
 
-  final case class NSDbNodeWithTtl(node: NSDbNode, createdAt: Long) extends NSDbSerializable
-  final case object GetNodesBlackListFromCache                               extends NSDbSerializable
-  sealed trait GetNodesBlackListFromCacheResponse                            extends NSDbSerializable
-  final case class NodesBlackListFromCacheGot(blacklist: Set[NSDbNode])      extends GetNodesBlackListFromCacheResponse
-  final case class GetNodesBlackListFromCacheFailed(reason: String)          extends GetNodesBlackListFromCacheResponse
+  final case class NSDbNodeWithTtl(node: NSDbNode, createdAt: Long)     extends NSDbSerializable
+  final case object GetNodesBlackListFromCache                          extends NSDbSerializable
+  sealed trait GetNodesBlackListFromCacheResponse                       extends NSDbSerializable
+  final case class NodesBlackListFromCacheGot(blacklist: Set[NSDbNode]) extends GetNodesBlackListFromCacheResponse
+  final case class GetNodesBlackListFromCacheFailed(reason: String)     extends GetNodesBlackListFromCacheResponse
 
   final case object CheckBlackListTtl                                               extends NSDbSerializable
   final case class RemoveNodesFromBlacklist(nodesToBeRemoved: Set[NSDbNodeWithTtl]) extends NSDbSerializable

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCache.scala
@@ -158,10 +158,10 @@ object ReplicatedMetadataCache {
   final case class AddNodeToBlackListFailed(node: NSDbNode, reason: String) extends AddNodeToBlackListResponse
 
   final case class NSDbNodeWithTtl(node: NSDbNode, createdAt: Long) extends NSDbSerializable
-  final case object GetNodesBlackList                               extends NSDbSerializable
-  sealed trait GetNodesBlackListResponse                            extends NSDbSerializable
-  final case class NodesBlackListGot(blacklist: Set[NSDbNode])      extends GetNodesBlackListResponse
-  final case class GetNodesBlackListFailed(reason: String)          extends GetNodesBlackListResponse
+  final case object GetNodesBlackListFromCache                               extends NSDbSerializable
+  sealed trait GetNodesBlackListFromCacheResponse                            extends NSDbSerializable
+  final case class NodesBlackListFromCacheGot(blacklist: Set[NSDbNode])      extends GetNodesBlackListFromCacheResponse
+  final case class GetNodesBlackListFromCacheFailed(reason: String)          extends GetNodesBlackListFromCacheResponse
 
   final case object CheckBlackListTtl                                               extends NSDbSerializable
   final case class RemoveNodesFromBlacklist(nodesToBeRemoved: Set[NSDbNodeWithTtl]) extends NSDbSerializable
@@ -413,7 +413,7 @@ class ReplicatedMetadataCache extends Actor with ActorLogging with WriteConfig {
     case GetMetricsFromCache(db, namespace) =>
       log.debug("searching for key {} in cache", coordinatesKey)
       replicator ! Get(coordinatesKey, ReadLocal, request = Some(MetricRequest(db, namespace, sender())))
-    case GetNodesBlackList =>
+    case GetNodesBlackListFromCache =>
       log.debug("searching for nodes blacklist")
       replicator ! Get(nodesBlacklistKey, ReadLocal, Some(NodesBlackListRequest(sender())))
     case DropMetricFromCache(db, namespace, metric) =>
@@ -544,7 +544,7 @@ class ReplicatedMetadataCache extends Actor with ActorLogging with WriteConfig {
       replyTo ! MetricsFromCacheGot(db, namespace, elements)
     case g @ GetSuccess(_, Some(NodesBlackListRequest(replyTo))) =>
       val elements = g.dataValue.asInstanceOf[ORSet[NSDbNodeWithTtl]].elements
-      replyTo ! NodesBlackListGot(elements.map(_.node))
+      replyTo ! NodesBlackListFromCacheGot(elements.map(_.node))
     case g @ GetSuccess(_, Some(NodesBlackListInternalRequest)) =>
       val elements = g.dataValue.asInstanceOf[ORSet[NSDbNodeWithTtl]].elements
       self ! RemoveNodesFromBlacklist(elements.filter(e => System.currentTimeMillis > e.createdAt + blackListTtl))
@@ -555,7 +555,7 @@ class ReplicatedMetadataCache extends Actor with ActorLogging with WriteConfig {
     case NotFound(_, Some(OutdatedLocationsRequest(replyTo))) =>
       replyTo ! OutdatedLocationsFromCacheGot(Set.empty)
     case NotFound(_, Some(NodesBlackListRequest(replyTo))) =>
-      replyTo ! NodesBlackListGot(Set.empty)
+      replyTo ! NodesBlackListFromCacheGot(Set.empty)
     case NotFound(_, Some(NodesBlackListInternalRequest)) => //do nothing
     case NotFound(_, Some(MetricInfoRequest(key, replyTo))) =>
       replyTo ! MetricInfoCached(key.db, key.namespace, key.metric, None)

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -591,14 +591,18 @@ class MetadataCoordinator(clusterListener: ActorRef,
         }
         .pipeTo(sender())
     case GetNodesBlackList =>
-      (metadataCache ? GetNodesBlackListFromCache).mapTo[GetNodesBlackListFromCacheResponse].map{
-        case NodesBlackListFromCacheGot(blackList) => NodesBlackListGot(blackList)
-        case   GetNodesBlackListFromCacheFailed(reason) => GetNodesBlackListFailed(reason)
-      }.recover {
-        case t =>
-          log.error(t,"Unexpected error while retrieving Nodes Blacklist")
-          GetNodesBlackListFailed(t.getMessage)
-      }.pipeTo(sender())
+      (metadataCache ? GetNodesBlackListFromCache)
+        .mapTo[GetNodesBlackListFromCacheResponse]
+        .map {
+          case NodesBlackListFromCacheGot(blackList)    => NodesBlackListGot(blackList)
+          case GetNodesBlackListFromCacheFailed(reason) => GetNodesBlackListFailed(reason)
+        }
+        .recover {
+          case t =>
+            log.error(t, "Unexpected error while retrieving Nodes Blacklist")
+            GetNodesBlackListFailed(t.getMessage)
+        }
+        .pipeTo(sender())
   }
 
 }
@@ -720,9 +724,9 @@ object MetadataCoordinator {
     case class MetadataRestored(path: String)                      extends RestoreMetadataResponse
     case class RestoreMetadataFailed(path: String, reason: String) extends RestoreMetadataResponse
 
-    trait GetNodesBlackListResponse                                  extends NSDbSerializable
-    case class NodesBlackListGot(blackList: Set[NSDbNode])                      extends RestoreMetadataResponse
-    case class GetNodesBlackListFailed(reason: String) extends RestoreMetadataResponse
+    trait GetNodesBlackListResponse                        extends NSDbSerializable
+    case class NodesBlackListGot(blackList: Set[NSDbNode]) extends RestoreMetadataResponse
+    case class GetNodesBlackListFailed(reason: String)     extends RestoreMetadataResponse
   }
 
   def props(clusterListener: ActorRef,

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinator.scala
@@ -470,11 +470,6 @@ class MetadataCoordinator(clusterListener: ActorRef,
           NamespaceDeleted(db, namespace)
         }
         .pipeTo(sender())
-//    case GetLocations(db, namespace, metric) =>
-//      (metadataCache ? GetLocationsFromCache(db, namespace, metric))
-//        .mapTo[LocationsCached]
-//        .map(l => LocationsGot(db, namespace, metric, l.locations))
-//        .pipeTo(sender())
     case GetLiveLocations(db, namespace, metric) =>
       getLiveLocation(db, namespace, metric).pipeTo(sender())
     case GetWriteLocations(db, namespace, metric, timestamp) =>

--- a/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelection.scala
+++ b/nsdb-cluster/src/main/scala/io/radicalbit/nsdb/cluster/logic/LocalityReadNodesSelection.scala
@@ -22,15 +22,15 @@ import io.radicalbit.nsdb.model.Location
   * ReadNodesSelection strategy that privileges local locations.
   * @param localNode the local node.
   */
-class LocalityReadNodesSelection(localNode: String) extends ReadNodesSelection {
+class LocalityReadNodesSelection(localNodeUniqueId: String) extends ReadNodesSelection {
 
   override def getDistinctLocationsByNode(locationsWithReplicas: Seq[Location]): Map[String, Seq[Location]] = {
-    assert(localNode != null)
+    assert(localNodeUniqueId != null)
     locationsWithReplicas
       .groupBy(l => (l.from, l.to))
       .map {
         case ((_, _), locations) if locations.size > 1 =>
-          locations.find(_.node.uniqueNodeId == localNode).getOrElse(locations.head)
+          locations.find(_.node.uniqueNodeId == localNodeUniqueId).getOrElse(locations.head)
         case ((_, _), locations) => locations.minBy(_.node.uniqueNodeId)
       }
       .toSeq

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/STMultiNodeSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/STMultiNodeSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.BeforeAndAfterAll
   */
 trait STMultiNodeSpec extends MultiNodeSpecCallbacks with NSDbSpecLike with BeforeAndAfterAll { this: MultiNodeSpec =>
 
-  protected lazy val cluster: Cluster = Cluster(system)
+  protected implicit lazy val cluster: Cluster = Cluster(system)
 
   def join(from: RoleName, to: RoleName): Unit = {
     runOn(from) {

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/STMultiNodeSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/STMultiNodeSpec.scala
@@ -1,5 +1,6 @@
 package io.radicalbit.nsdb
 
+import akka.actor.ActorSelection
 import akka.cluster.Cluster
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.{MultiNodeSpec, MultiNodeSpecCallbacks}
@@ -19,6 +20,12 @@ trait STMultiNodeSpec extends MultiNodeSpecCallbacks with NSDbSpecLike with Befo
       cluster join node(to).address
     }
     enterBarrier(from.name + "-joined")
+  }
+
+  def getActorPath(pathFunction: String => String)(implicit cluster: Cluster): ActorSelection = {
+    val selfMember = cluster.selfMember
+    val nodeName   = s"${selfMember.address.host.getOrElse("noHost")}_${selfMember.address.port.getOrElse(2552)}"
+    cluster.system.actorSelection(pathFunction(nodeName))
   }
 
   override def beforeAll() = multiNodeSpecBeforeAll()

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -51,11 +51,11 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
   val nodeName   = s"${selfMember.address.host.getOrElse("noHost")}_${selfMember.address.port.getOrElse(2552)}"
   val nodeActorGuardian: ActorRef = system.actorOf(NodeActorGuardianForTest.props(nodeName), name = s"guardian_${nodeName}_$nodeName")
 
-
   val nsdbNode1 = NSDbNode("localhost_2552", "node1", "volatile1")
   val nsdbNode2 = NSDbNode("localhost_2553", "node2", "volatile2")
 
   private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/metadata-coordinator_${nodeName}_${nodeName}_$nodeName"
+  private def metadataCache(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/metadata-cache_${nodeName}_${nodeName}_$nodeName"
 
   "Metadata system" must {
 
@@ -201,5 +201,6 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
 
       enterBarrier("after-GetWriteLocationsFailed-test")
     }
+
   }
 }

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/MetadataSpec.scala
@@ -1,7 +1,7 @@
 package io.radicalbit.nsdb.cluster.actor
 
-import akka.actor.{ActorRef, ActorSelection}
-import akka.cluster.{Cluster, Member, MemberStatus}
+import akka.actor.ActorRef
+import akka.cluster.{Member, MemberStatus}
 import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec}
 import akka.testkit.ImplicitSender
 import akka.util.Timeout
@@ -54,12 +54,6 @@ class MetadataSpec extends MultiNodeSpec(MetadataSpec) with STMultiNodeSpec with
 
   val nsdbNode1 = NSDbNode("localhost_2552", "node1", "volatile1")
   val nsdbNode2 = NSDbNode("localhost_2553", "node2", "volatile2")
-
-  private def getActorPath(pathFunction: String => String)(implicit cluster: Cluster): ActorSelection = {
-    val selfMember = cluster.selfMember
-    val nodeName   = s"${selfMember.address.host.getOrElse("noHost")}_${selfMember.address.port.getOrElse(2552)}"
-    system.actorSelection(pathFunction(nodeName))
-  }
 
   private def metadataCoordinatorPath(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/metadata-coordinator_${nodeName}_${nodeName}_$nodeName"
   private def metadataCache(nodeName: String) = s"user/guardian_${nodeName}_$nodeName/metadata-cache_${nodeName}_${nodeName}_$nodeName"

--- a/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
+++ b/nsdb-cluster/src/multi-jvm/scala/io/radicalbit/nsdb/cluster/actor/ReplicatedMetadataCacheSpec.scala
@@ -514,10 +514,10 @@ class ReplicatedMetadataCacheSpec
 
     "manage nodes blacklist" in {
 
-      replicatedCache ! GetNodesBlackList
+      replicatedCache ! GetNodesBlackListFromCache
 
       awaitAssert {
-        expectMsgType[NodesBlackListGot].blacklist.size shouldBe 0
+        expectMsgType[NodesBlackListFromCacheGot].blacklist.size shouldBe 0
       }
 
       enterBarrier("no-nodes-blacklist")
@@ -540,23 +540,23 @@ class ReplicatedMetadataCacheSpec
       enterBarrier("after-add-nodes-in-blacklist")
 
       awaitAssert {
-        replicatedCache ! GetNodesBlackList
-        val outdatedLocationsFromCacheGot = expectMsgType[NodesBlackListGot]
+        replicatedCache ! GetNodesBlackListFromCache
+        val outdatedLocationsFromCacheGot = expectMsgType[NodesBlackListFromCacheGot]
         outdatedLocationsFromCacheGot.blacklist shouldBe Set(node1, node2)
       }
     }
 
     "ensure that a blacklisted node is removed from the list after the configured ttl" in {
       awaitAssert {
-        replicatedCache ! GetNodesBlackList
-        val outdatedLocationsFromCacheGot = expectMsgType[NodesBlackListGot]
+        replicatedCache ! GetNodesBlackListFromCache
+        val outdatedLocationsFromCacheGot = expectMsgType[NodesBlackListFromCacheGot]
         outdatedLocationsFromCacheGot.blacklist.size shouldBe 2
       }
 
       awaitAssert {
         replicatedCache ! CheckBlackListTtl
-        replicatedCache ! GetNodesBlackList
-        val outdatedLocationsFromCacheGot = expectMsgType[NodesBlackListGot]
+        replicatedCache ! GetNodesBlackListFromCache
+        val outdatedLocationsFromCacheGot = expectMsgType[NodesBlackListFromCacheGot]
         outdatedLocationsFromCacheGot.blacklist shouldBe Set()
       }
     }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -17,11 +17,11 @@
 package io.radicalbit.nsdb.cluster.coordinator
 
 import akka.actor.{ActorSystem, Props}
-import akka.pattern._
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import io.radicalbit.nsdb.cluster.actor.MetricsDataActor.ExecuteDeleteStatementInternalInLocations
+import io.radicalbit.nsdb.cluster.actor.ReplicatedMetadataCache.{AddNodeToBlackList, NodeToBlackListAdded}
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.commands._
 import io.radicalbit.nsdb.cluster.coordinator.MetadataCoordinator.events._
 import io.radicalbit.nsdb.cluster.coordinator.mockedActors.{
@@ -35,12 +35,10 @@ import io.radicalbit.nsdb.common.model.MetricInfo
 import io.radicalbit.nsdb.common.protocol.{Bit, NSDbNode}
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
-import io.radicalbit.nsdb.protocol.MessageProtocol.Events.MetricInfoGot
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events._
 import io.radicalbit.nsdb.test.NSDbSpecLike
-import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{LocationsGot, MetricInfoGot}
 import org.scalatest._
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class MetadataCoordinatorSpec
@@ -79,27 +77,41 @@ class MetadataCoordinatorSpec
   val namespace = "testNamespace"
   val metric    = "testMetric"
 
-  implicit val timeout = Timeout(10 seconds)
-
   val node1 = NSDbNode("localhost_2552", "node_01", "volatile1")
   val node2 = NSDbNode("localhost_2553", "node_02", "volatile2")
+
+  val loc11 = Location(metric, node1, 0L, 30000L)
+  val loc21 = Location(metric, node2, 0L, 30000L)
+  val loc12 = Location(metric, node1, 30000L, 60000L)
+  val loc22 = Location(metric, node2, 30000L, 60000L)
+
+  implicit val timeout = Timeout(5 seconds)
 
   override def beforeAll = {
     NSDbClusterSnapshot(system).addNode(node1)
     NSDbClusterSnapshot(system).addNode(node2)
 
-    Await.result(metadataCoordinator ? SubscribeCommitLogCoordinator(commitLogCoordinator, node1.uniqueNodeId),
-                 10 seconds)
-    Await.result(metadataCoordinator ? SubscribeMetricsDataActor(metricsDataActorProbe.ref, node1.uniqueNodeId),
-                 10 seconds)
+    metadataCoordinator ! SubscribeCommitLogCoordinator(commitLogCoordinator, node1.uniqueNodeId)
+    awaitAssert {
+      expectMsgType[CommitLogCoordinatorSubscribed]
+    }
+    metadataCoordinator ! SubscribeMetricsDataActor(metricsDataActorProbe.ref, node1.uniqueNodeId)
+    awaitAssert {
+      expectMsgType[MetricsDataActorSubscribed]
+    }
 
     val nameRecord = Bit(0, 1, Map("name" -> "name"), Map("city" -> "milano"))
-    Await.result(schemaCoordinator ? UpdateSchemaFromRecord(db, namespace, metric, nameRecord), 10 seconds)
+    schemaCoordinator ! UpdateSchemaFromRecord(db, namespace, metric, nameRecord)
+    awaitAssert {
+      expectMsgType[SchemaUpdated]
+    }
   }
 
   override def beforeEach: Unit = {
-    implicit val timeout = Timeout(5 seconds)
-    Await.result(metadataCache ? DeleteAll, 5 seconds)
+    metadataCache ! DeleteAll
+    awaitAssert {
+      expectMsgType[DeleteDone.type]
+    }
   }
 
   "MetadataCoordinator" should {
@@ -118,9 +130,9 @@ class MetadataCoordinatorSpec
       locationAdded.namespace shouldBe namespace
       locationAdded.locations.sortBy(_.to) shouldBe locations
 
-      probe.send(metadataCoordinator, GetLocations(db, namespace, metric))
+      probe.send(metadataCoordinator, GetLiveLocations(db, namespace, metric))
       awaitAssert {
-        probe.expectMsgType[LocationsGot].locations.sortBy(_.to) shouldBe locations
+        probe.expectMsgType[LiveLocationsGot].locations.sortBy(_.to) shouldBe locations
       }
     }
 
@@ -135,9 +147,9 @@ class MetadataCoordinatorSpec
         probe.expectMsgType[LocationsAdded]
       }
 
-      probe.send(metadataCoordinator, GetLocations(db, namespace, metric))
+      probe.send(metadataCoordinator, GetLiveLocations(db, namespace, metric))
       val retrievedLocations = awaitAssert {
-        probe.expectMsgType[LocationsGot]
+        probe.expectMsgType[LiveLocationsGot]
       }
 
       retrievedLocations.locations.size shouldBe 2
@@ -155,11 +167,6 @@ class MetadataCoordinatorSpec
     }
 
     "retrieve Locations for a metric" in {
-
-      val loc11 = Location(metric, node1, 0L, 30000L)
-      val loc21 = Location(metric, node2, 0L, 30000L)
-      val loc12 = Location(metric, node1, 30000L, 60000L)
-      val loc22 = Location(metric, node2, 30000L, 60000L)
 
       probe.send(metadataCoordinator, AddLocations(db, namespace, Seq(loc11)))
       awaitAssert {
@@ -181,9 +188,9 @@ class MetadataCoordinatorSpec
         probe.expectMsgType[LocationsAdded]
       }
 
-      probe.send(metadataCoordinator, GetLocations(db, namespace, metric))
+      probe.send(metadataCoordinator, GetLiveLocations(db, namespace, metric))
       val retrievedLocations = awaitAssert {
-        probe.expectMsgType[LocationsGot]
+        probe.expectMsgType[LiveLocationsGot]
       }
 
       retrievedLocations.locations.size shouldBe 4
@@ -289,7 +296,7 @@ class MetadataCoordinatorSpec
       locationGot_3.locations.head.to shouldBe 300L
     }
 
-    "retrieve metric infos" in {
+    "retrieve metric info" in {
 
       val metricInfo = MetricInfo(db, namespace, metric, 100)
 
@@ -353,14 +360,14 @@ class MetadataCoordinatorSpec
       }
 
       awaitAssert {
-        probe.send(metadataCoordinator, GetLocations(db, namespace, metric))
-        val locationsGot = probe.expectMsgType[LocationsGot]
+        probe.send(metadataCoordinator, GetLiveLocations(db, namespace, metric))
+        val locationsGot = probe.expectMsgType[LiveLocationsGot]
         locationsGot.locations.sortBy(_.from) shouldBe locations
       }
 
       awaitAssert {
-        probe.send(metadataCoordinator, GetLocations(db, namespace, metric))
-        val locationsGot = probe.expectMsgType[LocationsGot]
+        probe.send(metadataCoordinator, GetLiveLocations(db, namespace, metric))
+        val locationsGot = probe.expectMsgType[LiveLocationsGot]
         locationsGot.locations.sortBy(_.from) shouldBe locations.takeRight(2)
       }
 
@@ -370,8 +377,8 @@ class MetadataCoordinatorSpec
       }
 
       awaitAssert {
-        probe.send(metadataCoordinator, GetLocations(db, namespace, metric))
-        val locationsGot = probe.expectMsgType[LocationsGot]
+        probe.send(metadataCoordinator, GetLiveLocations(db, namespace, metric))
+        val locationsGot = probe.expectMsgType[LiveLocationsGot]
         locationsGot.locations.sortBy(_.from) shouldBe locations.takeRight(1)
 
         val deleteCommand = metricsDataActorProbe.expectMsgType[ExecuteDeleteStatementInternalInLocations]
@@ -379,6 +386,32 @@ class MetadataCoordinatorSpec
       }
     }
 
+    "exclude blacklisted nodes from location" in {
+
+      metadataCoordinator ! AddLocations(db, namespace, Seq(loc11, loc12, loc21, loc22))
+      awaitAssert {
+        expectMsgType[LocationsAdded]
+      }
+
+      metadataCache ! AddNodeToBlackList(node1)
+      awaitAssert {
+        expectMsgType[NodeToBlackListAdded].node shouldBe node1
+      }
+
+      awaitAssert {
+        metadataCoordinator ! GetLiveLocations(db, namespace, metric)
+        val locations = expectMsgType[LiveLocationsGot].locations
+        locations.size shouldBe 4
+      }
+
+      awaitAssert {
+        metadataCoordinator ! GetLiveLocations(db, namespace, metric)
+        val locations = expectMsgType[LiveLocationsGot].locations
+        locations.size shouldBe 2
+        locations should contain(loc21)
+        locations should contain(loc22)
+      }
+    }
   }
 
 }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/MetadataCoordinatorSpec.scala
@@ -212,8 +212,8 @@ class MetadataCoordinatorSpec
         locationGot.metric shouldBe metric
 
         locationGot.locations.size shouldBe 1
-        locationGot.locations.head.from shouldBe 0L
-        locationGot.locations.head.to shouldBe 60000L
+        locationGot.locations.foreach(_.from shouldBe 0L)
+        locationGot.locations.foreach(_.to shouldBe 60000L)
       }
 
       awaitAssert {
@@ -224,8 +224,8 @@ class MetadataCoordinatorSpec
         locationGot_2.metric shouldBe metric
 
         locationGot_2.locations.size shouldBe 1
-        locationGot_2.locations.head.from shouldBe 60000L
-        locationGot_2.locations.head.to shouldBe 120000L
+        locationGot_2.locations.foreach(_.from shouldBe 60000L)
+        locationGot_2.locations.foreach(_.to shouldBe 120000L)
       }
 
       awaitAssert {
@@ -236,8 +236,8 @@ class MetadataCoordinatorSpec
         locationGot_3.metric shouldBe metric
 
         locationGot_3.locations.size shouldBe 1
-        locationGot_3.locations.head.from shouldBe 60000L
-        locationGot_3.locations.head.to shouldBe 120000L
+        locationGot_3.locations.foreach(_.from shouldBe 60000L)
+        locationGot_3.locations.foreach(_.to shouldBe 120000L)
       }
 
     }
@@ -266,8 +266,8 @@ class MetadataCoordinatorSpec
       locationGot.metric shouldBe metric
       locationGot.locations.size shouldBe 1
 
-      locationGot.locations.head.from shouldBe 0L
-      locationGot.locations.head.to shouldBe 100L
+      locationGot.locations.foreach(_.from shouldBe 0L)
+      locationGot.locations.foreach(_.to shouldBe 100L)
 
       probe.send(metadataCoordinator, GetWriteLocations(db, namespace, metric, 101))
       val locationGot_2 = awaitAssert {
@@ -279,8 +279,8 @@ class MetadataCoordinatorSpec
       locationGot_2.metric shouldBe metric
 
       locationGot_2.locations.size shouldBe 1
-      locationGot_2.locations.head.from shouldBe 100L
-      locationGot_2.locations.head.to shouldBe 200L
+      locationGot_2.locations.foreach(_.from shouldBe 100L)
+      locationGot_2.locations.foreach(_.to shouldBe 200L)
 
       probe.send(metadataCoordinator, GetWriteLocations(db, namespace, metric, 202))
       val locationGot_3 = awaitAssert {
@@ -292,8 +292,8 @@ class MetadataCoordinatorSpec
       locationGot_3.metric shouldBe metric
 
       locationGot_3.locations.size shouldBe 1
-      locationGot_3.locations.head.from shouldBe 200L
-      locationGot_3.locations.head.to shouldBe 300L
+      locationGot_3.locations.foreach(_.from shouldBe 200L)
+      locationGot_3.locations.foreach(_.to shouldBe 300L)
     }
 
     "retrieve metric info" in {
@@ -393,15 +393,15 @@ class MetadataCoordinatorSpec
         expectMsgType[LocationsAdded]
       }
 
-      metadataCache ! AddNodeToBlackList(node1)
-      awaitAssert {
-        expectMsgType[NodeToBlackListAdded].node shouldBe node1
-      }
-
       awaitAssert {
         metadataCoordinator ! GetLiveLocations(db, namespace, metric)
         val locations = expectMsgType[LiveLocationsGot].locations
         locations.size shouldBe 4
+      }
+
+      metadataCache ! AddNodeToBlackList(node1)
+      awaitAssert {
+        expectMsgType[NodeToBlackListAdded].node shouldBe node1
       }
 
       awaitAssert {

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorBehaviour.scala
@@ -242,8 +242,8 @@ trait WriteCoordinatorBehaviour { this: TestKit with NSDbSpecLike =>
       probe.send(schemaCoordinator, GetSchema(db, namespace, "testMetric"))
       probe.expectMsgType[SchemaGot].schema.isDefined shouldBe true
 
-      probe.send(metadataCoordinator, GetLocations(db, namespace, "testMetric"))
-      val locations = probe.expectMsgType[LocationsGot].locations
+      probe.send(metadataCoordinator, GetLiveLocations(db, namespace, "testMetric"))
+      val locations = probe.expectMsgType[LiveLocationsGot].locations
 
       probe.send(metricsDataActor, GetCountWithLocations(db, namespace, "testMetric", locations))
 
@@ -256,8 +256,8 @@ trait WriteCoordinatorBehaviour { this: TestKit with NSDbSpecLike =>
 
       expectNoMessage(interval)
 
-      probe.send(metadataCoordinator, GetLocations(db, namespace, "testMetric"))
-      val locationsAfterDrop = probe.expectMsgType[LocationsGot].locations
+      probe.send(metadataCoordinator, GetLiveLocations(db, namespace, "testMetric"))
+      val locationsAfterDrop = probe.expectMsgType[LiveLocationsGot].locations
       locationsAfterDrop.size shouldBe 0
 
       probe.send(metricsDataActor, GetCountWithLocations(db, namespace, "testMetric", locationsAfterDrop))

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/WriteCoordinatorErrorsSpec.scala
@@ -31,7 +31,7 @@ import io.radicalbit.nsdb.commit_log.CommitLogWriterActor.{RejectedEntryAction, 
 import io.radicalbit.nsdb.common.protocol.{Bit, NSDbNode}
 import io.radicalbit.nsdb.model.Location
 import io.radicalbit.nsdb.protocol.MessageProtocol.Commands._
-import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{LocationsGot, RecordRejected}
+import io.radicalbit.nsdb.protocol.MessageProtocol.Events.{LiveLocationsGot, RecordRejected}
 import io.radicalbit.nsdb.test.NSDbSpecLike
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
@@ -47,8 +47,8 @@ class MockedMetadataCoordinator extends Actor with ActorLogging {
   val locations: mutable.Map[(String, String), Seq[Location]] = mutable.Map.empty
 
   override def receive: Receive = {
-    case GetLocations(db, namespace, metric) =>
-      sender() ! LocationsGot(db, namespace, metric, locations.getOrElse((namespace, metric), Seq.empty))
+    case GetLiveLocations(db, namespace, metric) =>
+      sender() ! LiveLocationsGot(db, namespace, metric, locations.getOrElse((namespace, metric), Seq.empty))
     case GetWriteLocations(db, namespace, metric, timestamp) =>
       val locationNode1 = Location(metric, node1, timestamp, timestamp + shardingInterval.toMillis)
       val locationNode2 = Location(metric, node2, timestamp, timestamp + shardingInterval.toMillis)

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
@@ -71,11 +71,6 @@ class LocalMetadataCoordinator(cache: ActorRef) extends Actor {
         .mapTo[NamespaceFromCacheDropped]
         .map(_ => NamespaceDeleted(db, namespace))
         .pipeTo(sender())
-    case GetLocations(db, namespace, metric) =>
-      (cache ? GetLocationsFromCache(db, namespace, metric))
-        .mapTo[LocationsCached]
-        .map(l => LocationsGot(db, namespace, metric, l.locations))
-        .pipeTo(sender())
     case GetWriteLocations(db, namespace, metric, timestamp) =>
       val start = getShardStartIstant(timestamp, defaultShardingInterval)
       val end   = getShardEndIstant(start, defaultShardingInterval)
@@ -129,7 +124,7 @@ class LocalMetadataCoordinator(cache: ActorRef) extends Actor {
     case GetLiveLocations(db, namespace, metric) =>
       (cache ? GetLocationsFromCache(db, namespace, metric))
         .mapTo[LocationsCached]
-        .map(l => LocationsGot(db, namespace, metric, l.locations))
+        .map(l => LiveLocationsGot(db, namespace, metric, l.locations))
         .pipeTo(sender())
   }
 }

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
@@ -126,6 +126,8 @@ class LocalMetadataCoordinator(cache: ActorRef) extends Actor {
           case e => MetricInfoFailed(metricInfo, s"Unknown response from cache $e")
         }
         .pipeTo(sender)
+    case GetNodesBlackList =>
+      sender() ! NodesBlackListGot(Set.empty)
   }
 }
 

--- a/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
+++ b/nsdb-cluster/src/test/scala/io/radicalbit/nsdb/cluster/coordinator/mockedActors/LocalMetadataCoordinator.scala
@@ -126,8 +126,11 @@ class LocalMetadataCoordinator(cache: ActorRef) extends Actor {
           case e => MetricInfoFailed(metricInfo, s"Unknown response from cache $e")
         }
         .pipeTo(sender)
-    case GetNodesBlackList =>
-      sender() ! NodesBlackListGot(Set.empty)
+    case GetLiveLocations(db, namespace, metric) =>
+      (cache ? GetLocationsFromCache(db, namespace, metric))
+        .mapTo[LocationsCached]
+        .map(l => LocationsGot(db, namespace, metric, l.locations))
+        .pipeTo(sender())
   }
 }
 

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -33,8 +33,8 @@ object MessageProtocol {
     * commands executed among NSDb actors.
     */
   object Commands {
-    case object GetTopology                                                    extends NSDbSerializable
-    case class GetLocations(db: String, namespace: String, metric: String)     extends NSDbSerializable
+    case object GetTopology extends NSDbSerializable
+//    case class GetLocations(db: String, namespace: String, metric: String)     extends NSDbSerializable
     case class GetLiveLocations(db: String, namespace: String, metric: String) extends NSDbSerializable
     case object GetDbs                                                         extends ControlMessage with NSDbSerializable
     case class GetNamespaces(db: String)                                       extends ControlMessage with NSDbSerializable
@@ -116,9 +116,6 @@ object MessageProtocol {
     * events received from nsdb actors.
     */
   object Events {
-
-    case class LocationsGot(db: String, namespace: String, metric: String, locations: Seq[Location])
-        extends NSDbSerializable
 
     sealed trait GetLiveLocationsResponse extends NSDbSerializable
     case class LiveLocationsGot(db: String, namespace: String, metric: String, locations: Seq[Location])

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -33,8 +33,7 @@ object MessageProtocol {
     * commands executed among NSDb actors.
     */
   object Commands {
-    case object GetTopology extends NSDbSerializable
-//    case class GetLocations(db: String, namespace: String, metric: String)     extends NSDbSerializable
+    case object GetTopology                                                    extends NSDbSerializable
     case class GetLiveLocations(db: String, namespace: String, metric: String) extends NSDbSerializable
     case object GetDbs                                                         extends ControlMessage with NSDbSerializable
     case class GetNamespaces(db: String)                                       extends ControlMessage with NSDbSerializable

--- a/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
+++ b/nsdb-core/src/main/scala/io/radicalbit/nsdb/protocol/MessageProtocol.scala
@@ -33,12 +33,13 @@ object MessageProtocol {
     * commands executed among NSDb actors.
     */
   object Commands {
-    case object GetTopology                                                extends NSDbSerializable
-    case class GetLocations(db: String, namespace: String, metric: String) extends NSDbSerializable
-    case object GetDbs                                                     extends ControlMessage with NSDbSerializable
-    case class GetNamespaces(db: String)                                   extends ControlMessage with NSDbSerializable
-    case class GetMetrics(db: String, namespace: String)                   extends ControlMessage with NSDbSerializable
-    case class GetSchema(db: String, namespace: String, metric: String)    extends NSDbSerializable
+    case object GetTopology                                                    extends NSDbSerializable
+    case class GetLocations(db: String, namespace: String, metric: String)     extends NSDbSerializable
+    case class GetLiveLocations(db: String, namespace: String, metric: String) extends NSDbSerializable
+    case object GetDbs                                                         extends ControlMessage with NSDbSerializable
+    case class GetNamespaces(db: String)                                       extends ControlMessage with NSDbSerializable
+    case class GetMetrics(db: String, namespace: String)                       extends ControlMessage with NSDbSerializable
+    case class GetSchema(db: String, namespace: String, metric: String)        extends NSDbSerializable
 
     case class GetMetricInfo(db: String, namespace: String, metric: String) extends NSDbSerializable
 
@@ -118,6 +119,12 @@ object MessageProtocol {
 
     case class LocationsGot(db: String, namespace: String, metric: String, locations: Seq[Location])
         extends NSDbSerializable
+
+    sealed trait GetLiveLocationsResponse extends NSDbSerializable
+    case class LiveLocationsGot(db: String, namespace: String, metric: String, locations: Seq[Location])
+        extends GetLiveLocationsResponse
+    case class GetLiveLocationError(db: String, namespace: String, metric: String, error: String)
+        extends GetLiveLocationsResponse
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
     @JsonSubTypes(

--- a/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
+++ b/nsdb-http/src/main/scala/io/radicalbit/nsdb/web/routes/CommandApi.scala
@@ -120,8 +120,8 @@ trait CommandApi {
           pathPrefix(Segment) { metric =>
             (pathEnd & get) {
               withMetricAuthorization(db, namespace, metric, false, authorizationProvider) {
-                onComplete(metadataCoordinator ? GetLocations(db, namespace, metric)) {
-                  case Success(response: LocationsGot) =>
+                onComplete(metadataCoordinator ? GetLiveLocations(db, namespace, metric)) {
+                  case Success(response: LiveLocationsGot) =>
                     complete(HttpEntity(ContentTypes.`application/json`, write(response)))
                   case Success(wrongResponse) =>
                     logger.error(s"received unexpected response $wrongResponse")

--- a/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiSpec.scala
+++ b/nsdb-http/src/test/scala/io/radicalbit/nsdb/web/CommandApiSpec.scala
@@ -51,8 +51,8 @@ object CommandApiSpec {
     override def receive: Receive = {
       case GetTopology =>
         sender() ! TopologyGot(Set(NSDbNode("address", "fs", "volatile")))
-      case GetLocations(db, namespace, metric) =>
-        sender() ! LocationsGot(db, namespace, metric, Seq(Location.empty))
+      case GetLiveLocations(db, namespace, metric) =>
+        sender() ! LiveLocationsGot(db, namespace, metric, Seq(Location.empty))
       case GetMetricInfo(db, namespace, "metricWithoutInfo") =>
         sender() ! MetricInfoGot(db, namespace, "metricWithoutInfo", None)
       case GetMetricInfo(db, namespace, "nonExistingMetric") =>
@@ -99,7 +99,7 @@ class CommandApiSpec extends NSDbFlatSpec with ScalatestRouteTest with CommandAp
     Get("/commands/locations/db/namespace/metric").withHeaders(RawHeader("testHeader", "testHeader")) ~> testSecuredRoutes ~> check {
       status shouldBe OK
       val entity = entityAs[String]
-      entity shouldBe write(LocationsGot("db", "namespace", "metric", Seq(Location.empty)))
+      entity shouldBe write(LiveLocationsGot("db", "namespace", "metric", Seq(Location.empty)))
     }
   }
 


### PR DESCRIPTION
This PR aims at introducing the concept of `LiveLocation`.

A live location is a location that is not blacklisted, therefore and can be safely used to fetch data from.

The `MetadataCoordinator` behaviour has been updated. In particular the old `GetLocations` command has been replaced by `GetLiveLocations` that filters out all the location metadata that are blacklisted.

The LiveLocations are used in `ReadCoordinator` and `WriteCoordinator` for the read and write operations.

Also, a new dev pipeline has been added. The purpose of that pipeline is to provide a subset of the PRs and main branch CI in order to perform preliminary checks during the development of new features